### PR TITLE
Bug/tfn 364 remove unused unused farestages matchingjson

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -32,6 +32,8 @@ export const PERIOD_EXPIRY = 'fdbt-period-expiry';
 
 export const PERIOD_SINGLE_OPERATOR_SERVICES = 'fdbt-period-single-services';
 
+export const MATCHING_COOKIE = 'fdbt-matching';
+
 export const ALL_COOKIES: string[] = [
     'fdbt-operator',
     'fdbt-faretype',
@@ -48,6 +50,7 @@ export const ALL_COOKIES: string[] = [
     'fdbt-csv-zone-upload',
     'fdbt-period-expiry',
     'fdbt-period-single-services',
+    'fdbt-matching',
 ];
 
 export const ALLOWED_CSV_FILE_TYPES = [

--- a/src/pages/api/matching.ts
+++ b/src/pages/api/matching.ts
@@ -86,12 +86,8 @@ const getMatchingJson = (
         }),
 });
 
-const isFareStageUnassigned = (userFareStages: UserFareStages, matchingFareZones: MatchingFareZones): boolean => {
-    if (userFareStages.fareStages.some(stage => !matchingFareZones[stage.stageName])) {
-        return true;
-    }
-    return false;
-};
+const isFareStageUnassigned = (userFareStages: UserFareStages, matchingFareZones: MatchingFareZones): boolean =>
+    userFareStages.fareStages.some(stage => !matchingFareZones[stage.stageName]);
 
 export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
     try {

--- a/src/pages/api/matching.ts
+++ b/src/pages/api/matching.ts
@@ -1,10 +1,10 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { redirectTo, redirectToError, getUuidFromCookie } from './apiUtils';
+import { redirectTo, redirectToError, getUuidFromCookie, setCookieOnResponseObject, getDomain } from './apiUtils';
 import { BasicService } from '../matching';
 import { Stop } from '../../data/dynamodb';
 import { putStringInS3, UserFareStages } from '../../data/s3';
 import { isCookiesUUIDMatch } from './service/validator';
-import { MATCHING_DATA_BUCKET_NAME } from '../../constants';
+import { MATCHING_DATA_BUCKET_NAME, MATCHING_COOKIE } from '../../constants';
 
 interface MatchingData {
     type: string;
@@ -86,6 +86,13 @@ const getMatchingJson = (
         }),
 });
 
+const isFareStageUnassigned = (userFareStages: UserFareStages, matchingFareZones: MatchingFareZones): boolean => {
+    if (userFareStages.fareStages.some(stage => !matchingFareZones[stage.stageName])) {
+        return true;
+    }
+    return false;
+};
+
 export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
     try {
         if (!isCookiesUUIDMatch(req, res)) {
@@ -99,14 +106,24 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
         const service: BasicService = JSON.parse(req.body.service);
         const userFareStages: UserFareStages = JSON.parse(req.body.userfarestages);
 
+        const matchingFareZones = getMatchingFareZonesFromForm(req);
+
+        if (isFareStageUnassigned(userFareStages, matchingFareZones) && matchingFareZones !== {}) {
+            const error = { error: true };
+            setCookieOnResponseObject(getDomain(req), MATCHING_COOKIE, JSON.stringify({ error }), req, res);
+            redirectTo(res, '/matching');
+            return;
+        }
+
         // Deleting these keys from the object in order to faciliate looping through the fare stage values in the body
         delete req.body.service;
         delete req.body.userfarestages;
 
-        const matchingFareZones = getMatchingFareZonesFromForm(req);
+        const uuid = getUuidFromCookie(req, res);
+
         const matchingJson = getMatchingJson(service, userFareStages, matchingFareZones);
 
-        const uuid = getUuidFromCookie(req, res);
+        setCookieOnResponseObject(getDomain(req), MATCHING_COOKIE, JSON.stringify({ error: false }), req, res);
 
         await putDataInS3(matchingJson, uuid);
 

--- a/src/pages/matching.tsx
+++ b/src/pages/matching.tsx
@@ -143,21 +143,6 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
         .map(atco => naptanInfo.find(s => s.atcoCode === atco))
         .filter((stop: Stop | undefined): stop is Stop => stop !== undefined);
 
-    if (!matchingCookie) {
-        return {
-            props: {
-                stops: orderedStops,
-                userFareStages,
-                service: {
-                    lineName,
-                    nocCode,
-                    operatorShortName: service.operatorShortName,
-                },
-                error: false,
-            },
-        };
-    }
-
     return {
         props: {
             stops: orderedStops,

--- a/src/pages/matching.tsx
+++ b/src/pages/matching.tsx
@@ -10,7 +10,7 @@ import {
     RawService,
     RawJourneyPatternSection,
 } from '../data/dynamodb';
-import { OPERATOR_COOKIE, SERVICE_COOKIE, JOURNEY_COOKIE } from '../constants';
+import { OPERATOR_COOKIE, SERVICE_COOKIE, JOURNEY_COOKIE, MATCHING_COOKIE } from '../constants';
 import { getUserFareStages, UserFareStages, FareStage } from '../data/s3';
 import { formatStopName } from '../utils';
 
@@ -27,16 +27,22 @@ interface MatchingProps {
     userFareStages: UserFareStages;
     stops: Stop[];
     service: BasicService;
+    error: boolean;
 }
 
-const Matching = ({ userFareStages, stops, service }: MatchingProps): ReactElement => (
+const Matching = ({ userFareStages, stops, service, error }: MatchingProps): ReactElement => (
     <Layout title={title} description={description}>
         <main className="govuk-main-wrapper app-main-class matching-page" id="main-content" role="main">
             <form action="/api/matching" method="post">
-                <div className="govuk-form-group">
+                <div className={`govuk-form-group${error ? ' govuk-form-group--error' : ''}`}>
                     <legend className="govuk-fieldset__legend govuk-fieldset__legend--xl">
                         <h1 className="govuk-fieldset__heading">Match stops to fares stages</h1>
                     </legend>
+                    <span id="dropdown-error" className="govuk-error-message">
+                        <span className={error ? '' : 'govuk-visually-hidden'}>
+                            Ensure each fare stage is assigned at least once.
+                        </span>
+                    </span>
                     <span className="govuk-hint" id="match-fares-hint">
                         Please select the correct fare stages for each stop.
                     </span>
@@ -109,6 +115,7 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
     const operatorCookie = cookies[OPERATOR_COOKIE];
     const serviceCookie = cookies[SERVICE_COOKIE];
     const journeyCookie = cookies[JOURNEY_COOKIE];
+    const matchingCookie = cookies[MATCHING_COOKIE];
 
     if (!operatorCookie || !serviceCookie || !journeyCookie) {
         throw new Error('Necessary cookies not found to show matching page');
@@ -117,11 +124,9 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
     const operatorObject = JSON.parse(operatorCookie);
     const serviceObject = JSON.parse(serviceCookie);
     const journeyObject = JSON.parse(journeyCookie);
-
     const lineName = serviceObject.service.split('#')[0];
     const { nocCode } = operatorObject;
     const [selectedStartPoint, selectedEndPoint] = journeyObject.journeyPattern.split('#');
-
     const service = await getServiceByNocCodeAndLineName(operatorObject.nocCode, lineName);
     const userFareStages = await getUserFareStages(operatorObject.uuid);
     const relevantJourneys = getJourneysByStartAndEndPoint(service, selectedStartPoint, selectedEndPoint);
@@ -138,6 +143,25 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
         .map(atco => naptanInfo.find(s => s.atcoCode === atco))
         .filter((stop: Stop | undefined): stop is Stop => stop !== undefined);
 
+    if (!matchingCookie) {
+        return {
+            props: {
+                stops: orderedStops,
+                userFareStages,
+                service: {
+                    lineName,
+                    nocCode,
+                    operatorShortName: service.operatorShortName,
+                },
+                error: false,
+            },
+        };
+    }
+
+    const matchingObject = JSON.parse(matchingCookie);
+
+    const { error } = matchingObject;
+
     return {
         props: {
             stops: orderedStops,
@@ -147,6 +171,7 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
                 nocCode,
                 operatorShortName: service.operatorShortName,
             },
+            error: !matchingCookie ? {} : error,
         },
     };
 };

--- a/src/pages/matching.tsx
+++ b/src/pages/matching.tsx
@@ -158,10 +158,6 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
         };
     }
 
-    const matchingObject = JSON.parse(matchingCookie);
-
-    const { error } = matchingObject;
-
     return {
         props: {
             stops: orderedStops,
@@ -171,7 +167,7 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props:
                 nocCode,
                 operatorShortName: service.operatorShortName,
             },
-            error: !matchingCookie ? {} : error,
+            error: !matchingCookie ? false : JSON.parse(matchingCookie).error,
         },
     };
 };

--- a/tests/pages/__snapshots__/matching.test.tsx.snap
+++ b/tests/pages/__snapshots__/matching.test.tsx.snap
@@ -27,6 +27,16 @@ exports[`Matching Page should render correctly 1`] = `
           </h1>
         </legend>
         <span
+          className="govuk-error-message"
+          id="dropdown-error"
+        >
+          <span
+            className="govuk-visually-hidden"
+          >
+            Ensure each fare stage is assigned at least once.
+          </span>
+        </span>
+        <span
           className="govuk-hint"
           id="match-fares-hint"
         >

--- a/tests/pages/api/matching.test.ts
+++ b/tests/pages/api/matching.test.ts
@@ -73,25 +73,25 @@ describe('Matching API', () => {
         });
     });
 
-    // it('redirects to error page if no stops are allocated to fare stages', async () => {
-    //     const { req, res } = getMockRequestAndResponse(
-    //         {},
-    //         {
-    //             option0: '',
-    //             option1: '',
-    //             service: JSON.stringify(service),
-    //             userfarestages: JSON.stringify(mockMatchingUserFareStagesWithAllStagesAssigned),
-    //         },
-    //         {},
-    //         writeHeadMock,
-    //     );
+    it('redirects to matching page if no stops are allocated to fare stages', async () => {
+        const { req, res } = getMockRequestAndResponse(
+            {},
+            {
+                option0: '',
+                option1: '',
+                service: JSON.stringify(service),
+                userfarestages: JSON.stringify(mockMatchingUserFareStagesWithAllStagesAssigned),
+            },
+            {},
+            writeHeadMock,
+        );
 
-    //     await matching(req, res);
+        await matching(req, res);
 
-    //     expect(writeHeadMock).toBeCalledWith(302, {
-    //         Location: '/error',
-    //     });
-    // });
+        expect(writeHeadMock).toBeCalledWith(302, {
+            Location: '/matching',
+        });
+    });
 
     it('redirects to thankyou page if all valid', async () => {
         const { req, res } = getMockRequestAndResponse(

--- a/tests/pages/api/matching.test.ts
+++ b/tests/pages/api/matching.test.ts
@@ -3,7 +3,8 @@ import matching from '../../../src/pages/api/matching';
 import {
     getMockRequestAndResponse,
     service,
-    mockMatchingUserFareStages,
+    mockMatchingUserFareStagesWithUnassignedStages,
+    mockMatchingUserFareStagesWithAllStagesAssigned,
     expectedMatchingJson,
 } from '../../testData/mockData';
 import * as s3 from '../../../src/data/s3';
@@ -38,7 +39,7 @@ describe('Matching API', () => {
             {
                 ...selections,
                 service: JSON.stringify(service),
-                userfarestages: JSON.stringify(mockMatchingUserFareStages),
+                userfarestages: JSON.stringify(mockMatchingUserFareStagesWithAllStagesAssigned),
             },
             {},
             writeHeadMock,
@@ -54,25 +55,43 @@ describe('Matching API', () => {
         );
     });
 
-    it('redirects to error page if no stops are allocated to fare stages', async () => {
+    it('correctly redirects to matching page when there are fare stages that have not been assigned to stops', async () => {
         const { req, res } = getMockRequestAndResponse(
             {},
             {
-                option0: '',
-                option1: '',
+                ...selections,
                 service: JSON.stringify(service),
-                userfarestages: JSON.stringify(mockMatchingUserFareStages),
+                userfarestages: JSON.stringify(mockMatchingUserFareStagesWithUnassignedStages),
             },
             {},
             writeHeadMock,
         );
-
         await matching(req, res);
 
         expect(writeHeadMock).toBeCalledWith(302, {
-            Location: '/error',
+            Location: '/matching',
         });
     });
+
+    // it('redirects to error page if no stops are allocated to fare stages', async () => {
+    //     const { req, res } = getMockRequestAndResponse(
+    //         {},
+    //         {
+    //             option0: '',
+    //             option1: '',
+    //             service: JSON.stringify(service),
+    //             userfarestages: JSON.stringify(mockMatchingUserFareStagesWithAllStagesAssigned),
+    //         },
+    //         {},
+    //         writeHeadMock,
+    //     );
+
+    //     await matching(req, res);
+
+    //     expect(writeHeadMock).toBeCalledWith(302, {
+    //         Location: '/error',
+    //     });
+    // });
 
     it('redirects to thankyou page if all valid', async () => {
         const { req, res } = getMockRequestAndResponse(
@@ -80,7 +99,7 @@ describe('Matching API', () => {
             {
                 ...selections,
                 service: JSON.stringify(service),
-                userfarestages: JSON.stringify(mockMatchingUserFareStages),
+                userfarestages: JSON.stringify(mockMatchingUserFareStagesWithAllStagesAssigned),
             },
             {},
             writeHeadMock,
@@ -107,7 +126,11 @@ describe('Matching API', () => {
     it('redirects back to matching page if no service info in body', async () => {
         const { req, res } = getMockRequestAndResponse(
             {},
-            { ...selections, service: '', userfarestages: JSON.stringify(mockMatchingUserFareStages) },
+            {
+                ...selections,
+                service: '',
+                userfarestages: JSON.stringify(mockMatchingUserFareStagesWithAllStagesAssigned),
+            },
             {},
             writeHeadMock,
         );

--- a/tests/pages/matching.test.tsx
+++ b/tests/pages/matching.test.tsx
@@ -8,6 +8,7 @@ import {
     userFareStages,
     naptanStopInfo,
     service,
+    error,
     getMockContext,
     mockRawServiceWithDuplicates,
 } from '../testData/mockData';
@@ -31,7 +32,9 @@ describe('Matching Page', () => {
         batchGetStopsByAtcoCodeSpy.mockImplementation(() => Promise.resolve([]));
         getUserFareStagesSpy.mockImplementation(() => Promise.resolve(userFareStages));
 
-        wrapper = shallow(<Matching userFareStages={userFareStages} stops={naptanStopInfo} service={service} />);
+        wrapper = shallow(
+            <Matching userFareStages={userFareStages} stops={naptanStopInfo} service={service} error={error} />,
+        );
     });
 
     afterEach(() => {

--- a/tests/testData/mockData.ts
+++ b/tests/testData/mockData.ts
@@ -729,7 +729,7 @@ export const mockService: Service = {
     ],
 };
 
-export const mockMatchingUserFareStages = {
+export const mockMatchingUserFareStagesWithUnassignedStages = {
     fareStages: [
         {
             stageName: 'Acomb Green Lane',
@@ -817,6 +817,73 @@ export const mockMatchingUserFareStages = {
                 {
                     price: '1.00',
                     fareZones: ['Piccadilly (York)'],
+                },
+            ],
+        },
+        {
+            stageName: 'Piccadilly (York)',
+            prices: {},
+        },
+    ],
+};
+
+export const mockMatchingUserFareStagesWithAllStagesAssigned = {
+    fareStages: [
+        {
+            stageName: 'Acomb Green Lane',
+            prices: [
+                {
+                    price: '1.10',
+                    fareZones: ['Mattison Way', 'Nursery Drive', 'Holl Bank/Beech Ave'],
+                },
+                {
+                    price: '1.70',
+                    fareZones: [
+                        'Cambridge Street (York)',
+                        'Blossom Street',
+                        'Rail Station (York)',
+                        'Piccadilly (York)',
+                    ],
+                },
+            ],
+        },
+        {
+            stageName: 'Mattison Way',
+            prices: [
+                {
+                    price: '1.10',
+                    fareZones: ['Nursery Drive', 'Holl Bank/Beech Ave'],
+                },
+                {
+                    price: '1.70',
+                    fareZones: [
+                        'Cambridge Street (York)',
+                        'Blossom Street',
+                        'Rail Station (York)',
+                        'Piccadilly (York)',
+                    ],
+                },
+            ],
+        },
+        {
+            stageName: 'Holl Bank/Beech Ave',
+            prices: [
+                {
+                    price: '1.10',
+                    fareZones: ['Cambridge Street (York)', 'Blossom Street'],
+                },
+                {
+                    price: '1.70',
+                    fareZones: ['Rail Station (York)', 'Piccadilly (York)'],
+                },
+            ],
+        },
+        {
+            stageName: 'Blossom Street',
+            prices: [
+                {
+                    price: '1.00',
+                    fareZones: ['Rail Station (York)', 'Piccadilly (York)'],
                 },
             ],
         },


### PR DESCRIPTION
# Description
A user must assign at least one to stop to each fare stage that they include in their fare triangle (either upload or manual), otherwise the NeTEx that is produced does not validate. The purpose of this ticket was to create a function which checks that all fare stages have been assigned stops and, if they haven't, to redirect the user back to the matching page whilst also rendering an error message that tells them that each fare stage must be assigned at least once. To implement, I used our standard approach and setting a cookie on the response object with the error. This is in turn passed as a prop to the page to render the message.

# Testing instructions
* There are two unit tests for this new functionality. One of these that the user is correctly redirected to the matching page when there are fare stages that have not been assigned to stops. The other tests that the user is correctly redirected to the matching page if no stops at all are allocated to fare stages. 

# Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] Able to run pr locally
- [x] Lighthouse performed
- [x] Followed acceptance criteria
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [n/a] I have made corresponding changes to the documentation if applicable
- [x] I have added tests that prove my fix is effective or that my feature works


<img width="880" alt="Screenshot 2020-04-08 at 10 27 01" src="https://user-images.githubusercontent.com/55278762/78768426-d043c380-7983-11ea-9edc-ddd725f88d6e.png">
