### PR TITLE
Altered periodValidity API to set the type of matching json according…

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,21 +1,24 @@
 # Description
-* Explain the purpose of this pr
+
+-   Explain the purpose of this pr
 
 # Testing instructions
-* Add testing instructions if required
+
+-   Add testing instructions if required
 
 # Type of change
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
+
+-   [ ] Bug fix (non-breaking change which fixes an issue)
+-   [ ] New feature (non-breaking change which adds functionality)
+-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+-   [ ] This change requires a documentation update
 
 # Checklist:
 
-- [ ] Able to run pr locally
-- [ ] Lighthouse performed
-- [ ] Followed acceptance criteria
-- [ ] My code follows the style guidelines of this project
-- [ ] I have performed a self-review of my own code
-- [ ] I have made corresponding changes to the documentation if applicable
-- [ ] I have added tests that prove my fix is effective or that my feature works
+-   [ ] Able to run pr locally
+-   [ ] Lighthouse performed
+-   [ ] Followed acceptance criteria
+-   [ ] My code follows the style guidelines of this project
+-   [ ] I have performed a self-review of my own code
+-   [ ] I have made corresponding changes to the documentation if applicable
+-   [ ] I have added tests that prove my fix is effective or that my feature works

--- a/src/pages/api/periodType.ts
+++ b/src/pages/api/periodType.ts
@@ -30,13 +30,18 @@ export default (req: NextApiRequest, res: NextApiResponse): void => {
 
         setCookieOnResponseObject(getDomain(req), PERIOD_TYPE, JSON.stringify(periodTypeObject), req, res);
 
-        if (periodType === 'geozone') {
+        if (periodType === 'periodGeoZone') {
             redirectTo(res, '/csvZoneUpload');
             return;
         }
 
-        if (periodType === 'singleOperator') {
+        if (periodType === 'periodMultipleServices') {
             redirectTo(res, '/singleOperator?selectAll=false');
+            return;
+        }
+
+        if (periodType === 'periodMultipleOperators') {
+            // redirect to page not made yet
             return;
         }
     } catch (error) {

--- a/src/pages/api/periodValidity.ts
+++ b/src/pages/api/periodValidity.ts
@@ -8,6 +8,7 @@ import {
     CSV_ZONE_UPLOAD_COOKIE,
     VALIDITY_COOKIE,
     PERIOD_SINGLE_OPERATOR_SERVICES,
+    PERIOD_TYPE,
 } from '../../constants';
 import { getDomain, setCookieOnResponseObject, redirectToError, redirectTo } from './apiUtils';
 import { batchGetStopsByAtcoCode, Stop } from '../../data/dynamodb';
@@ -42,14 +43,15 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
 
         const cookies = new Cookies(req, res);
 
-        const periodProduct = unescape(decodeURI(cookies.get(PERIOD_PRODUCT) || ''));
+        const periodProductCookie = unescape(decodeURI(cookies.get(PERIOD_PRODUCT) || ''));
         const daysValidCookie = unescape(decodeURI(cookies.get(VALIDITY_COOKIE) || ''));
         const operatorCookie = unescape(decodeURI(cookies.get(OPERATOR_COOKIE) || ''));
         const fareZoneCookie = unescape(decodeURI(cookies.get(CSV_ZONE_UPLOAD_COOKIE) || ''));
         const singleOperatorCookie = unescape(decodeURI(cookies.get(PERIOD_SINGLE_OPERATOR_SERVICES) || ''));
+        const periodTypeCookie = unescape(decodeURI(cookies.get(PERIOD_TYPE) || ''));
 
         if (
-            periodProduct === '' ||
+            periodProductCookie === '' ||
             daysValidCookie === '' ||
             (operatorCookie === '' && (fareZoneCookie === '' || singleOperatorCookie))
         ) {
@@ -57,9 +59,10 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
         }
 
         let props = {};
-        const { productName, productPrice } = JSON.parse(periodProduct);
+        const { productName, productPrice } = JSON.parse(periodProductCookie);
         const { daysValid } = JSON.parse(daysValidCookie);
         const { operator, uuid, nocCode } = JSON.parse(operatorCookie);
+        const { periodTypeName } = JSON.parse(periodTypeCookie);
 
         if (fareZoneCookie) {
             const { fareZoneName } = JSON.parse(fareZoneCookie);
@@ -89,7 +92,7 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
 
         const period: DecisionData = {
             operatorName: operator,
-            type: 'period',
+            type: periodTypeName,
             productName,
             productPrice,
             daysValid,

--- a/src/pages/periodType.tsx
+++ b/src/pages/periodType.tsx
@@ -35,7 +35,7 @@ const PeriodType = ({ error }: PeriodTypeInterface): ReactElement => {
                                         id="periodtype-geo-zone"
                                         name="periodType"
                                         type="radio"
-                                        value="geozone"
+                                        value="periodGeoZone"
                                     />
                                     <label className="govuk-label govuk-radios__label" htmlFor="periodtype-geo-zone">
                                         A ticket within a geographical zone
@@ -47,7 +47,7 @@ const PeriodType = ({ error }: PeriodTypeInterface): ReactElement => {
                                         id="periodtype-single-set-service"
                                         name="periodType"
                                         type="radio"
-                                        value="singleOperator"
+                                        value="periodMultipleServices"
                                     />
                                     <label
                                         className="govuk-label govuk-radios__label"
@@ -62,7 +62,7 @@ const PeriodType = ({ error }: PeriodTypeInterface): ReactElement => {
                                         id="periodtype-network"
                                         name="periodType"
                                         type="radio"
-                                        value="network"
+                                        value="periodMultipleOperators"
                                         disabled
                                         aria-disabled="true"
                                     />

--- a/tests/pages/__snapshots__/periodType.test.tsx.snap
+++ b/tests/pages/__snapshots__/periodType.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`pages periodtype should render correctly 1`] = `
                 id="periodtype-geo-zone"
                 name="periodType"
                 type="radio"
-                value="geozone"
+                value="periodGeoZone"
               />
               <label
                 className="govuk-label govuk-radios__label"
@@ -69,7 +69,7 @@ exports[`pages periodtype should render correctly 1`] = `
                 id="periodtype-single-set-service"
                 name="periodType"
                 type="radio"
-                value="singleOperator"
+                value="periodMultipleServices"
               />
               <label
                 className="govuk-label govuk-radios__label"
@@ -88,7 +88,7 @@ exports[`pages periodtype should render correctly 1`] = `
                 id="periodtype-network"
                 name="periodType"
                 type="radio"
-                value="network"
+                value="periodMultipleOperators"
               />
               <label
                 className="govuk-label govuk-radios__label"

--- a/tests/testData/mockData.ts
+++ b/tests/testData/mockData.ts
@@ -14,6 +14,7 @@ import {
     CSV_ZONE_UPLOAD_COOKIE,
     PERIOD_PRODUCT,
     VALIDITY_COOKIE,
+    PERIOD_TYPE,
 } from '../../src/constants';
 
 export const getMockRequestAndResponse = (
@@ -39,6 +40,7 @@ export const getMockRequestAndResponse = (
         productPrice = '1234',
         fareZoneName = 'fare zone 1',
         daysValid = '2',
+        periodTypeName = 'period',
     } = cookieValues;
 
     const {
@@ -83,6 +85,10 @@ export const getMockRequestAndResponse = (
         : '';
 
     cookieString += fareStages ? `${FARE_STAGES_COOKIE}=%7B%22fareStages%22%3A%22${fareStages}%22%7D;` : '';
+
+    cookieString += periodTypeName
+        ? `${PERIOD_TYPE}=%7B%22periodTypeName%22%3A%22${periodTypeName}%22%2C%22uuid%22%3A%22${operatorUuid}%22%2C%22nocCode%22%3A%22HCTY%22%7D;`
+        : '';
 
     const req = mockRequest({
         connection: {


### PR DESCRIPTION
… to the decision made by the user on the periodType page (set in a cookie), altered the snapshot as the values were changed, updated the test and the test helper method

# Description
* To fix the bug which was caused by hard-coding the periodType, meaning that the matching data submitted to S3 always had type=period.

# Testing instructions
* Unit test shows that the s3 put method uses the type set by the cookie.

# Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] Able to run pr locally
- [N/A] Lighthouse performed
- [x] Followed acceptance criteria
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation if applicable
- [Updated test] I have added tests that prove my fix is effective or that my feature works