### PR TITLE
[tfn-375] enable return single service faretype

### DIFF
--- a/src/pages/api/fareType.ts
+++ b/src/pages/api/fareType.ts
@@ -11,6 +11,14 @@ export default (req: NextApiRequest, res: NextApiResponse): void => {
         }
 
         if (req.body.fareType) {
+            const cookieValue = JSON.stringify({
+                errorMessage: '',
+                uuid: getUuidFromCookie(req, res),
+                fareType: req.body.fareType,
+            });
+
+            setCookieOnResponseObject(getDomain(req), FARETYPE_COOKIE, cookieValue, req, res);
+
             switch (req.body.fareType) {
                 case 'period':
                     redirectTo(res, '/periodType');

--- a/src/pages/api/fareType.ts
+++ b/src/pages/api/fareType.ts
@@ -18,8 +18,8 @@ export default (req: NextApiRequest, res: NextApiResponse): void => {
                 case 'single':
                     redirectTo(res, '/service');
                     return;
-                case 'return':
-                    // redirect to return page
+                case 'returnSingle':
+                    redirectTo(res, '/service');
                     return;
                 default:
                     throw new Error('Fare Type we expect was not received.');

--- a/src/pages/fareType.tsx
+++ b/src/pages/fareType.tsx
@@ -62,12 +62,10 @@ const FareType = ({ errors = [] }: FareTypeProps): ReactElement => {
                                             id="fareType-return"
                                             name="fareType"
                                             type="radio"
-                                            value="return"
-                                            disabled
-                                            aria-disabled="true"
+                                            value="returnSingle"
                                         />
                                         <label className="govuk-label govuk-radios__label" htmlFor="fareType-return">
-                                            Return
+                                            Return - Single Service
                                         </label>
                                     </div>
                                 </div>

--- a/tests/pages/__snapshots__/faretype.test.tsx.snap
+++ b/tests/pages/__snapshots__/faretype.test.tsx.snap
@@ -80,19 +80,17 @@ exports[`pages fareType should render correctly 1`] = `
                 className="govuk-radios__item"
               >
                 <input
-                  aria-disabled="true"
                   className="govuk-radios__input"
-                  disabled={true}
                   id="fareType-return"
                   name="fareType"
                   type="radio"
-                  value="return"
+                  value="returnSingle"
                 />
                 <label
                   className="govuk-label govuk-radios__label"
                   htmlFor="fareType-return"
                 >
-                  Return
+                  Return - Single Service
                 </label>
               </div>
             </div>

--- a/tests/pages/api/faretype.test.ts
+++ b/tests/pages/api/faretype.test.ts
@@ -18,6 +18,15 @@ describe('fareType', () => {
         });
     });
 
+    it('should return 302 redirect to /service when return single option is selected', () => {
+        const writeHeadMock = jest.fn();
+        const { req, res } = getMockRequestAndResponse({}, { fareType: 'returnSingle' }, {}, writeHeadMock);
+        fareType(req, res);
+        expect(writeHeadMock).toBeCalledWith(302, {
+            Location: '/service',
+        });
+    });
+
     it('should return 302 redirect to /fareType when session is valid but there is neither a service cookie nor has one been set', () => {
         const writeHeadMock = jest.fn();
         const { req, res } = getMockRequestAndResponse({ service: null }, null, {}, writeHeadMock);


### PR DESCRIPTION
# Description

Linked to ticket https://infinityworks.atlassian.net/browse/TFN-375

Minor changes where we are enabling return type and changing the title of it. Also links to the service page.

With the lighthouse testing i have noticed performance is low around 40 which is the same in dev. So potentially need to think about a later ticket to get this sorted

# Testing instructions
Run locally and go through the journey until you get to the faretype page.  The return -single operator option will be enabled and present.

The error messaging is already in place so no changes required here.

# Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

# Checklist:

-   [x] Able to run pr locally
-   [x] Lighthouse performed
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
