### PR TITLE
Feature/tfn 377 circular and non circular

### DIFF
--- a/src/pages/api/apiUtils/index.ts
+++ b/src/pages/api/apiUtils/index.ts
@@ -54,7 +54,14 @@ export const redirectTo = (res: NextApiResponse | ServerResponse, location: stri
     res.end();
 };
 
-export const redirectToError = (res: NextApiResponse | ServerResponse, message: string, error: Error): void => {
+export const redirectClientTo = (res: ServerResponse, location: string): void => {
+    res.writeHead(302, {
+        Location: location,
+    });
+    res.end();
+};
+
+export const redirectToError = (res: ServerResponse, message: string, error: Error): void => {
     console.error(message, error.stack);
     redirectTo(res, '/error');
 };

--- a/src/pages/api/apiUtils/index.ts
+++ b/src/pages/api/apiUtils/index.ts
@@ -54,13 +54,6 @@ export const redirectTo = (res: NextApiResponse | ServerResponse, location: stri
     res.end();
 };
 
-export const redirectClientTo = (res: ServerResponse, location: string): void => {
-    res.writeHead(302, {
-        Location: location,
-    });
-    res.end();
-};
-
 export const redirectToError = (res: ServerResponse, message: string, error: Error): void => {
     console.error(message, error.stack);
     redirectTo(res, '/error');

--- a/src/pages/api/apiUtils/index.ts
+++ b/src/pages/api/apiUtils/index.ts
@@ -54,7 +54,7 @@ export const redirectTo = (res: NextApiResponse | ServerResponse, location: stri
     res.end();
 };
 
-export const redirectToError = (res: ServerResponse, message: string, error: Error): void => {
+export const redirectToError = (res: NextApiResponse | ServerResponse, message: string, error: Error): void => {
     console.error(message, error.stack);
     redirectTo(res, '/error');
 };

--- a/src/pages/api/direction.ts
+++ b/src/pages/api/direction.ts
@@ -24,7 +24,7 @@ export default (req: NextApiRequest, res: NextApiResponse): void => {
 
         const cookieValue = JSON.stringify({ journeyPattern, uuid });
         setCookieOnResponseObject(getDomain(req), JOURNEY_COOKIE, cookieValue, req, res);
-        redirectTo(res, '/inputMethod');
+        redirectTo(res, '/selectJourney');
     } catch (error) {
         const message = 'There was a problem selecting the direction:';
         redirectToError(res, message, error);

--- a/src/pages/direction.tsx
+++ b/src/pages/direction.tsx
@@ -13,7 +13,7 @@ import {
     RawJourneyPattern,
     RawService,
 } from '../data/auroradb';
-import { redirectClientTo } from './api/apiUtils';
+import { redirectTo } from './api/apiUtils';
 
 const title = 'Select a Direction - Fares data build tool';
 const description = 'Direction selection page of the Fares data build tool';
@@ -146,7 +146,7 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{}> => {
             const uuid = getUuidFromCookies(ctx);
             const cookieValue = JSON.stringify({ journeyPattern: service.journeyPatterns, uuid });
             setCookieOnServerSide(ctx, JOURNEY_COOKIE, cookieValue);
-            redirectClientTo(ctx.res, '/inputMethod');
+            redirectTo(ctx.res, '/inputMethod');
         }
     }
 

--- a/src/pages/direction.tsx
+++ b/src/pages/direction.tsx
@@ -4,7 +4,7 @@ import { parseCookies } from 'nookies';
 import flatMap from 'array.prototype.flatmap';
 import Layout from '../layout/Layout';
 import { OPERATOR_COOKIE, SERVICE_COOKIE, JOURNEY_COOKIE } from '../constants';
-import { deleteCookieOnServerSide } from '../utils';
+import { deleteCookieOnServerSide, getUuidFromCookies, setCookieOnServerSide } from '../utils';
 import {
     getServiceByNocCodeAndLineName,
     Service,
@@ -13,6 +13,7 @@ import {
     RawJourneyPattern,
     RawService,
 } from '../data/auroradb';
+import { redirectClientTo } from './api/apiUtils';
 
 const title = 'Select a Direction - Fares data build tool';
 const description = 'Direction selection page of the Fares data build tool';
@@ -135,6 +136,15 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{}> => {
                 item => item.endPoint.Id === pattern.endPoint.Id && item.startPoint.Id === pattern.startPoint.Id,
             ) === index,
     );
+
+    if (service.journeyPatterns.length === 1) {
+        if (ctx.res) {
+            const uuid = getUuidFromCookies(ctx);
+            const cookieValue = JSON.stringify({ journeyPattern: service.journeyPatterns, uuid });
+            setCookieOnServerSide(ctx, JOURNEY_COOKIE, cookieValue);
+            redirectClientTo(ctx.res, '/inputMethod');
+        }
+    }
 
     return { props: { operator: operatorInfo.operator, lineName, service } };
 };

--- a/src/pages/direction.tsx
+++ b/src/pages/direction.tsx
@@ -140,7 +140,7 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{}> => {
             ) === index,
     );
 
-    // journey only valid for return single
+    // Redirect to inputMethod page if there is only one journeyPattern (i.e. circular journey)
     if (service.journeyPatterns.length === 1 && fareTypeInfo.fareType === 'returnSingle') {
         if (ctx.res) {
             const uuid = getUuidFromCookies(ctx);

--- a/src/pages/direction.tsx
+++ b/src/pages/direction.tsx
@@ -144,7 +144,8 @@ export const getServerSideProps = async (ctx: NextPageContext): Promise<{}> => {
     if (service.journeyPatterns.length === 1 && fareTypeInfo.fareType === 'returnSingle') {
         if (ctx.res) {
             const uuid = getUuidFromCookies(ctx);
-            const cookieValue = JSON.stringify({ journeyPattern: service.journeyPatterns, uuid });
+            const journeyPatternCookie = `${service.journeyPatterns[0].startPoint.Id}#${service.journeyPatterns[0].endPoint.Id}`;
+            const cookieValue = JSON.stringify({ journeyPattern: journeyPatternCookie, uuid });
             setCookieOnServerSide(ctx, JOURNEY_COOKIE, cookieValue);
             redirectTo(ctx.res, '/inputMethod');
         }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,6 +8,16 @@ import { ALL_COOKIES, OPERATOR_COOKIE } from '../constants/index';
 import { Stop } from '../data/auroradb';
 import { ErrorInfo } from '../types';
 
+export const setCookieOnServerSide = (ctx: NextPageContext, cookieName: string, cookieValue: string): void => {
+    if (ctx.req && ctx.res) {
+        const cookies = new Cookies(ctx.req, ctx.res);
+        const host = ctx?.req?.headers?.host;
+        const domain = host ? host.split(':')[0] : '';
+
+        cookies.set(cookieName, cookieValue, { domain, path: '/' });
+    }
+};
+
 export const deleteCookieOnServerSide = (ctx: NextPageContext, cookieName: string): void => {
     if (ctx.req && ctx.res) {
         const cookies = new Cookies(ctx.req, ctx.res);

--- a/tests/pages/api/direction.test.ts
+++ b/tests/pages/api/direction.test.ts
@@ -26,7 +26,7 @@ describe('direction', () => {
         (setCookieOnResponseObject as {}) = jest.fn();
         direction(req, res);
         expect(writeHeadMock).toBeCalledWith(302, {
-            Location: '/inputMethod',
+            Location: '/selectJourney',
         });
     });
 

--- a/tests/pages/direction.test.tsx
+++ b/tests/pages/direction.test.tsx
@@ -3,7 +3,13 @@ import { shallow } from 'enzyme';
 
 import Direction, { getServerSideProps } from '../../src/pages/direction';
 import { getServiceByNocCodeAndLineName, batchGetStopsByAtcoCode } from '../../src/data/auroradb';
-import { mockRawService, mockService, mockRawServiceWithDuplicates, getMockContext } from '../testData/mockData';
+import {
+    mockRawService,
+    mockService,
+    mockRawServiceWithDuplicates,
+    getMockContext,
+    mockSingleService,
+} from '../testData/mockData';
 
 jest.mock('../../src/data/auroradb.ts');
 
@@ -73,9 +79,30 @@ describe('pages', () => {
             });
         });
 
+        it('redirect to the inputMethod page when there is a circular journey', async () => {
+            (({ ...getServiceByNocCodeAndLineName } as jest.Mock).mockImplementation(() => mockSingleService));
+
+            const writeHeadMock = jest.fn();
+
+            const operator = 'HCTY';
+            const lineName = 'X6A';
+
+            const ctx = getMockContext(
+                { operator, serviceLineName: lineName, fareType: 'returnSingle' },
+                {},
+                '',
+                writeHeadMock,
+            );
+
+            await getServerSideProps(ctx);
+
+            expect(writeHeadMock).toBeCalledWith(302, {
+                Location: '/inputMethod',
+            });
+        });
+
         it('throws an error if no journey patterns can be found', async () => {
             (({ ...getServiceByNocCodeAndLineName } as jest.Mock).mockImplementation(() => Promise.resolve(null)));
-
             const ctx = getMockContext();
 
             await expect(getServerSideProps(ctx)).rejects.toThrow();

--- a/tests/testData/mockData.ts
+++ b/tests/testData/mockData.ts
@@ -130,6 +130,37 @@ export const getMockContext = (
     return ctx;
 };
 
+export const mockSingleService: RawService = {
+    serviceDescription: '\n\t\t\t\tInterchange Stand B,Seaham - Estate (Hail and Ride) N/B,Westlea\n\t\t\t',
+    operatorShortName: 'HCTY',
+    journeyPatterns: [
+        {
+            JourneyPattern: [
+                {
+                    OrderedStopPoints: [
+                        {
+                            StopPointRef: '13003921A',
+                            CommonName: 'Estate (Hail and Ride) N/B',
+                        },
+                        {
+                            StopPointRef: '13003612D',
+                            CommonName: 'New Strangford Road SE/B',
+                        },
+                        {
+                            StopPointRef: '13003611B',
+                            CommonName: 'New Tempest Road (York House) NE/B',
+                        },
+                        {
+                            StopPointRef: '13003655B',
+                            CommonName: 'Interchange Stand B',
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
 export const mockRawService: RawService = {
     serviceDescription: '\n\t\t\t\tInterchange Stand B,Seaham - Estate (Hail and Ride) N/B,Westlea\n\t\t\t',
     operatorShortName: 'HCTY',


### PR DESCRIPTION
# Description

Circular and non circular services when selecting the Return - Single Service radio button on the service page. If there is a circular service i.e. only one journey pattern then it will redirect to the inputMethod page without showing the directions page.

Otherwise if more than one then will continue to new page which is not yet implemented.

Not no lighthouse testing as its logic change for redirection.

JIRA ticket: https://infinityworks.atlassian.net/browse/TFN-377

# Testing instructions
**Test for circular**
- Run the web application
- Select 'Warrington' bus operator 
- Service page and select the 'Return - Single Service'.
- This should redirect to the /inputMethod as they only have a circular service, i.e. one service

**Testing for non-circular**
- Run web application
- Select durham operator
- Select any service and continue
- On directions page select one option from the dropdown and continue
- Will redirect to new page (NOT implemented) /journeySelection

# Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

# Checklist:

-   [x] Able to run pr locally
-   [n/a ] Lighthouse performed
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
