### PR TITLE
Fix/tfn 411 remove unintended circular journey logic

### DIFF
--- a/src/pages/api/direction.ts
+++ b/src/pages/api/direction.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { getDomain, setCookieOnResponseObject, redirectTo, redirectToError, getUuidFromCookie } from './apiUtils/index';
-import { JOURNEY_COOKIE } from '../../constants/index';
+import { FARETYPE_COOKIE, JOURNEY_COOKIE } from '../../constants/index';
 import { isSessionValid } from './service/validator';
 
 export default (req: NextApiRequest, res: NextApiResponse): void => {
@@ -8,10 +8,10 @@ export default (req: NextApiRequest, res: NextApiResponse): void => {
         if (!isSessionValid(req, res)) {
             throw new Error('Session is invalid.');
         }
-
         const { journeyPattern } = req.body;
+        const fareTypeCookie = JSON.parse(req.cookies[FARETYPE_COOKIE]).fareType;
 
-        if (!journeyPattern) {
+        if (!journeyPattern || !fareTypeCookie) {
             redirectTo(res, '/direction');
             return;
         }
@@ -24,7 +24,12 @@ export default (req: NextApiRequest, res: NextApiResponse): void => {
 
         const cookieValue = JSON.stringify({ journeyPattern, uuid });
         setCookieOnResponseObject(getDomain(req), JOURNEY_COOKIE, cookieValue, req, res);
-        redirectTo(res, '/selectJourney');
+
+        if (fareTypeCookie === 'returnSingle') {
+            redirectTo(res, '/selectJourney');
+        }
+
+        redirectTo(res, '/inputMethod');
     } catch (error) {
         const message = 'There was a problem selecting the direction:';
         redirectToError(res, message, error);

--- a/tests/pages/api/direction.test.ts
+++ b/tests/pages/api/direction.test.ts
@@ -11,7 +11,8 @@ describe('direction', () => {
     });
 
     it('should return 302 redirect to /direction (i.e. itself) when the session is valid, but there is no request body', () => {
-        const { req, res } = getMockRequestAndResponse({}, null, {}, writeHeadMock);
+        const mockFareTypeCookie = { 'fdbt-fareType': '{"fareType": "single"}' };
+        const { req, res } = getMockRequestAndResponse(mockFareTypeCookie, null, {}, writeHeadMock);
         (setCookieOnResponseObject as {}) = jest.fn();
         direction(req, res);
         expect(writeHeadMock).toBeCalledWith(302, {
@@ -19,10 +20,33 @@ describe('direction', () => {
         });
     });
 
-    it('should return 302 redirect to /inputMethod when session is valid and request body is present', () => {
+    it('should return 302 redirect to /inputMethod when session is valid, request body is present and fareType is single', () => {
         (isSessionValid as {}) = jest.fn().mockReturnValue(true);
         (getUuidFromCookie as {}) = jest.fn().mockReturnValue({ uuid: 'testUuid' });
-        const { req, res } = getMockRequestAndResponse({}, { journeyPattern: 'test_journey' }, {}, writeHeadMock);
+        const mockFareTypeCookie = { 'fdbt-fareType': '{"fareType": "single"}' };
+        const { req, res } = getMockRequestAndResponse(
+            mockFareTypeCookie,
+            { journeyPattern: 'test_journey' },
+            {},
+            writeHeadMock,
+        );
+        (setCookieOnResponseObject as {}) = jest.fn();
+        direction(req, res);
+        expect(writeHeadMock).toBeCalledWith(302, {
+            Location: '/inputMethod',
+        });
+    });
+
+    it('should return 302 redirect to /selectJourney when session is valid, request body is present and fareType is returnSingle', () => {
+        (isSessionValid as {}) = jest.fn().mockReturnValue(true);
+        (getUuidFromCookie as {}) = jest.fn().mockReturnValue({ uuid: 'testUuid' });
+        const mockFareTypeCookie = { 'fdbt-fareType': '{"fareType": "returnSingle"}' };
+        const { req, res } = getMockRequestAndResponse(
+            mockFareTypeCookie,
+            { journeyPattern: 'test_journey' },
+            {},
+            writeHeadMock,
+        );
         (setCookieOnResponseObject as {}) = jest.fn();
         direction(req, res);
         expect(writeHeadMock).toBeCalledWith(302, {

--- a/tests/pages/direction.test.tsx
+++ b/tests/pages/direction.test.tsx
@@ -79,7 +79,29 @@ describe('pages', () => {
             });
         });
 
-        it('redirect to the inputMethod page when there is a circular journey', async () => {
+        it('redirects to the inputMethod page when there is a circular journey, but only when fareType is returnSingle', async () => {
+            (({ ...getServiceByNocCodeAndLineName } as jest.Mock).mockImplementation(() => mockSingleService));
+
+            const writeHeadMock = jest.fn();
+
+            const operator = 'HCTY';
+            const lineName = 'X6A';
+
+            const ctx = getMockContext(
+                { operator, serviceLineName: lineName, fareType: 'returnSingle' },
+                {},
+                '',
+                writeHeadMock,
+            );
+
+            await getServerSideProps(ctx);
+
+            expect(writeHeadMock).toBeCalledWith(302, {
+                Location: '/inputMethod',
+            });
+        });
+
+        it('redirects to the inputMethod page when there is a circular journey, but only on the return ticket user journey', async () => {
             (({ ...getServiceByNocCodeAndLineName } as jest.Mock).mockImplementation(() => mockSingleService));
 
             const writeHeadMock = jest.fn();

--- a/tests/pages/direction.test.tsx
+++ b/tests/pages/direction.test.tsx
@@ -101,28 +101,6 @@ describe('pages', () => {
             });
         });
 
-        it('redirects to the inputMethod page when there is a circular journey, but only on the return ticket user journey', async () => {
-            (({ ...getServiceByNocCodeAndLineName } as jest.Mock).mockImplementation(() => mockSingleService));
-
-            const writeHeadMock = jest.fn();
-
-            const operator = 'HCTY';
-            const lineName = 'X6A';
-
-            const ctx = getMockContext(
-                { operator, serviceLineName: lineName, fareType: 'returnSingle' },
-                {},
-                '',
-                writeHeadMock,
-            );
-
-            await getServerSideProps(ctx);
-
-            expect(writeHeadMock).toBeCalledWith(302, {
-                Location: '/inputMethod',
-            });
-        });
-
         it('throws an error if no journey patterns can be found', async () => {
             (({ ...getServiceByNocCodeAndLineName } as jest.Mock).mockImplementation(() => Promise.resolve(null)));
             const ctx = getMockContext();


### PR DESCRIPTION
# Description

As part of the merge of TFN-377, a bug has been introduced where the circular/non-circular logic is being applied to the single ticket user journey.

The API for the direction page needs to be smart enough to route the user depending on where they have previously been (using the faretype cookie).

# Testing instructions

-   With any Operator and Service combination, follow the 'Single - Point to Point' user journey to validate that the direction page no longer routes to the new selectJourney page.
-   Selecting 'Warrington's Own Buses', follow the 'Return - Single Service' user journey and choose service (i) 709 and (ii) 25. Service 709 should only have one journey in it's Journey Patterns and will be treated as a circular journey (hence, redirect to /inputMethod and then following the same user journey as a 'Single - Point to Point' service. Service 25 will have multiple journeys in it's Journey Patterns and will be treated as a non-circular journey (hence, redirect to /selectJourney page)

# Type of change

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

# Checklist:

-   [X] Able to run pr locally
-   [ ] Lighthouse performed
-   [X] Followed acceptance criteria
-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [X] I have added tests that prove my fix is effective or that my feature works
