### PR TITLE
Fix issue with circular journey auto redirect

### DIFF
--- a/src/pages/api/direction.ts
+++ b/src/pages/api/direction.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { getDomain, setCookieOnResponseObject, redirectTo, redirectToError, getUuidFromCookie } from './apiUtils/index';
-import { FARETYPE_COOKIE, JOURNEY_COOKIE } from '../../constants/index';
+import { JOURNEY_COOKIE } from '../../constants/index';
 import { isSessionValid } from './service/validator';
 
 export default (req: NextApiRequest, res: NextApiResponse): void => {
@@ -11,9 +11,7 @@ export default (req: NextApiRequest, res: NextApiResponse): void => {
 
         const { directionJourneyPattern } = req.body;
 
-        const fareTypeCookie = JSON.parse(req.cookies[FARETYPE_COOKIE]).fareType;
-
-        if (!directionJourneyPattern || !fareTypeCookie) {
+        if (!directionJourneyPattern) {
             redirectTo(res, '/direction');
             return;
         }
@@ -26,10 +24,6 @@ export default (req: NextApiRequest, res: NextApiResponse): void => {
 
         const cookieValue = JSON.stringify({ directionJourneyPattern, uuid });
         setCookieOnResponseObject(getDomain(req), JOURNEY_COOKIE, cookieValue, req, res);
-
-        if (fareTypeCookie === 'returnSingle') {
-            redirectTo(res, '/selectJourneyDirection');
-        }
 
         redirectTo(res, '/inputMethod');
     } catch (error) {

--- a/tests/pages/api/direction.test.ts
+++ b/tests/pages/api/direction.test.ts
@@ -37,23 +37,6 @@ describe('direction', () => {
         });
     });
 
-    it('should return 302 redirect to /selectJourneyDirection when session is valid, request body is present and fareType is returnSingle', () => {
-        (isSessionValid as {}) = jest.fn().mockReturnValue(true);
-        (getUuidFromCookie as {}) = jest.fn().mockReturnValue({ uuid: 'testUuid' });
-        const mockFareTypeCookie = { 'fdbt-fareType': '{"fareType": "returnSingle"}' };
-        const { req, res } = getMockRequestAndResponse(
-            mockFareTypeCookie,
-            { directionJourneyPattern: 'test_journey' },
-            {},
-            writeHeadMock,
-        );
-        (setCookieOnResponseObject as {}) = jest.fn();
-        direction(req, res);
-        expect(writeHeadMock).toBeCalledWith(302, {
-            Location: '/selectJourneyDirection',
-        });
-    });
-
     it('should return 302 redirect to /error when session is not valid', () => {
         const { req, res } = getMockRequestAndResponse({ operator: null }, null, {}, writeHeadMock);
         direction(req, res);


### PR DESCRIPTION
# Description

When going through return single journey it should redirect automatically the inputmethod page if the journey is circular.

# Testing instructions

Test for circular

Run the web application
Select 'Warrington' bus operator
Service page and select the 'Return - Single Service'.
This should redirect to the /inputMethod as they only have a circular service, i.e. one service
Testing for non-circular

Non circular journey

Run web application
Select durham operator
Select any service and continue
On directions page select one option from the dropdown and continue
Will redirect to new page (NOT implemented) /journeySelection


# Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

# Checklist:

-   [x] Able to run pr locally
-   [n/a ] Lighthouse performed
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
