### PR TITLE
Feature/tfn 390 fare triangle ui improvements

### DIFF
--- a/src/design/Pages.scss
+++ b/src/design/Pages.scss
@@ -14,7 +14,7 @@
             height: 40px;
             margin: 0;
             flex: 0 0 auto;
-            width: 80px;
+            width: 125px;
             white-space: nowrap;
 
             span {
@@ -59,7 +59,7 @@
         }
 
         .fare-triangle-input-mid-grey {
-            background-color: govuk-colour('mid-grey');
+            background-color: govuk-colour("light-grey");
         }
 
         .fare-triangle-input:not(:nth-child(1)) {
@@ -69,7 +69,7 @@
         .fare-triangle-label-right {
             flex: 0 0 auto;
             margin: auto 0;
-            width: 110px;
+            width: 125px;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;

--- a/src/design/Pages.scss
+++ b/src/design/Pages.scss
@@ -54,6 +54,14 @@
             flex: 0 0 auto;
         }
 
+        .fare-triangle-input-white {
+            background-color: govuk-colour('white');
+        }
+
+        .fare-triangle-input-mid-grey {
+            background-color: govuk-colour('mid-grey');
+        }
+
         .fare-triangle-input:not(:nth-child(1)) {
             border-left: none;
         }

--- a/src/design/Pages.scss
+++ b/src/design/Pages.scss
@@ -58,8 +58,8 @@
             background-color: govuk-colour('white');
         }
 
-        .fare-triangle-input-mid-grey {
-            background-color: govuk-colour("light-grey");
+        .fare-triangle-input-light-grey {
+            background-color: govuk-colour('light-grey');
         }
 
         .fare-triangle-input:not(:nth-child(1)) {

--- a/src/pages/priceEntry.tsx
+++ b/src/pages/priceEntry.tsx
@@ -47,7 +47,7 @@ const PriceEntry = ({ stageNamesArray }: PriceEntryProps): ReactElement => (
                                             className={`govuk-input govuk-input--width-4 fare-triangle-input ${
                                                 rowIndex % 2 === 0
                                                     ? 'fare-triangle-input-white'
-                                                    : 'fare-triangle-input-mid-grey'
+                                                    : 'fare-triangle-input-light-grey'
                                             }`}
                                             id={`cell-${rowIndex}-${columnIndex}`}
                                             name={`${rowStage}-${columnStage}`}

--- a/src/pages/priceEntry.tsx
+++ b/src/pages/priceEntry.tsx
@@ -44,7 +44,11 @@ const PriceEntry = ({ stageNamesArray }: PriceEntryProps): ReactElement => (
                                 >
                                     {stageNamesArray.slice(0, rowIndex).map((columnStage, columnIndex) => (
                                         <input
-                                            className="govuk-input govuk-input--width-4 fare-triangle-input"
+                                            className={`govuk-input govuk-input--width-4 fare-triangle-input ${
+                                                rowIndex % 2 === 0
+                                                    ? 'fare-triangle-input-white'
+                                                    : 'fare-triangle-input-mid-grey'
+                                            }`}
                                             id={`cell-${rowIndex}-${columnIndex}`}
                                             name={`${rowStage}-${columnStage}`}
                                             type="number"

--- a/tests/pages/__snapshots__/priceEntry.test.tsx.snap
+++ b/tests/pages/__snapshots__/priceEntry.test.tsx.snap
@@ -174,7 +174,7 @@ exports[`Price Entry Page should render correctly 1`] = `
               key="Chapeltown"
             >
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-1-0"
                 key="Briggate"
                 max="10000"
@@ -232,7 +232,7 @@ exports[`Price Entry Page should render correctly 1`] = `
               key="Moortown"
             >
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-3-0"
                 key="Briggate"
                 max="10000"
@@ -244,7 +244,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-3-1"
                 key="Chapeltown"
                 max="10000"
@@ -256,7 +256,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-3-2"
                 key="Chapel Allerton"
                 max="10000"
@@ -338,7 +338,7 @@ exports[`Price Entry Page should render correctly 1`] = `
               key="Harehills"
             >
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-5-0"
                 key="Briggate"
                 max="10000"
@@ -350,7 +350,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-5-1"
                 key="Chapeltown"
                 max="10000"
@@ -362,7 +362,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-5-2"
                 key="Chapel Allerton"
                 max="10000"
@@ -374,7 +374,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-5-3"
                 key="Moortown"
                 max="10000"
@@ -386,7 +386,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-5-4"
                 key="Harrogate Road"
                 max="10000"
@@ -492,7 +492,7 @@ exports[`Price Entry Page should render correctly 1`] = `
               key="Armley"
             >
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-7-0"
                 key="Briggate"
                 max="10000"
@@ -504,7 +504,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-7-1"
                 key="Chapeltown"
                 max="10000"
@@ -516,7 +516,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-7-2"
                 key="Chapel Allerton"
                 max="10000"
@@ -528,7 +528,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-7-3"
                 key="Moortown"
                 max="10000"
@@ -540,7 +540,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-7-4"
                 key="Harrogate Road"
                 max="10000"
@@ -552,7 +552,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-7-5"
                 key="Harehills"
                 max="10000"
@@ -564,7 +564,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-7-6"
                 key="Gipton"
                 max="10000"
@@ -694,7 +694,7 @@ exports[`Price Entry Page should render correctly 1`] = `
               key="Pudsey"
             >
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-9-0"
                 key="Briggate"
                 max="10000"
@@ -706,7 +706,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-9-1"
                 key="Chapeltown"
                 max="10000"
@@ -718,7 +718,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-9-2"
                 key="Chapel Allerton"
                 max="10000"
@@ -730,7 +730,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-9-3"
                 key="Moortown"
                 max="10000"
@@ -742,7 +742,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-9-4"
                 key="Harrogate Road"
                 max="10000"
@@ -754,7 +754,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-9-5"
                 key="Harehills"
                 max="10000"
@@ -766,7 +766,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-9-6"
                 key="Gipton"
                 max="10000"
@@ -778,7 +778,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-9-7"
                 key="Armley"
                 max="10000"
@@ -790,7 +790,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-9-8"
                 key="Stanningley"
                 max="10000"
@@ -944,7 +944,7 @@ exports[`Price Entry Page should render correctly 1`] = `
               key="Rothwell"
             >
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-11-0"
                 key="Briggate"
                 max="10000"
@@ -956,7 +956,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-11-1"
                 key="Chapeltown"
                 max="10000"
@@ -968,7 +968,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-11-2"
                 key="Chapel Allerton"
                 max="10000"
@@ -980,7 +980,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-11-3"
                 key="Moortown"
                 max="10000"
@@ -992,7 +992,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-11-4"
                 key="Harrogate Road"
                 max="10000"
@@ -1004,7 +1004,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-11-5"
                 key="Harehills"
                 max="10000"
@@ -1016,7 +1016,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-11-6"
                 key="Gipton"
                 max="10000"
@@ -1028,7 +1028,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-11-7"
                 key="Armley"
                 max="10000"
@@ -1040,7 +1040,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-11-8"
                 key="Stanningley"
                 max="10000"
@@ -1052,7 +1052,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-11-9"
                 key="Pudsey"
                 max="10000"
@@ -1064,7 +1064,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-11-10"
                 key="Seacroft"
                 max="10000"
@@ -1242,7 +1242,7 @@ exports[`Price Entry Page should render correctly 1`] = `
               key="Wakefield"
             >
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-13-0"
                 key="Briggate"
                 max="10000"
@@ -1254,7 +1254,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-13-1"
                 key="Chapeltown"
                 max="10000"
@@ -1266,7 +1266,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-13-2"
                 key="Chapel Allerton"
                 max="10000"
@@ -1278,7 +1278,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-13-3"
                 key="Moortown"
                 max="10000"
@@ -1290,7 +1290,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-13-4"
                 key="Harrogate Road"
                 max="10000"
@@ -1302,7 +1302,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-13-5"
                 key="Harehills"
                 max="10000"
@@ -1314,7 +1314,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-13-6"
                 key="Gipton"
                 max="10000"
@@ -1326,7 +1326,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-13-7"
                 key="Armley"
                 max="10000"
@@ -1338,7 +1338,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-13-8"
                 key="Stanningley"
                 max="10000"
@@ -1350,7 +1350,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-13-9"
                 key="Pudsey"
                 max="10000"
@@ -1362,7 +1362,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-13-10"
                 key="Seacroft"
                 max="10000"
@@ -1374,7 +1374,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-13-11"
                 key="Rothwell"
                 max="10000"
@@ -1386,7 +1386,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-light-grey"
                 id="cell-13-12"
                 key="Dewsbury"
                 max="10000"

--- a/tests/pages/__snapshots__/priceEntry.test.tsx.snap
+++ b/tests/pages/__snapshots__/priceEntry.test.tsx.snap
@@ -174,7 +174,7 @@ exports[`Price Entry Page should render correctly 1`] = `
               key="Chapeltown"
             >
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-1-0"
                 key="Briggate"
                 max="10000"
@@ -197,7 +197,7 @@ exports[`Price Entry Page should render correctly 1`] = `
               key="Chapel Allerton"
             >
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-2-0"
                 key="Briggate"
                 max="10000"
@@ -209,7 +209,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-2-1"
                 key="Chapeltown"
                 max="10000"
@@ -232,7 +232,7 @@ exports[`Price Entry Page should render correctly 1`] = `
               key="Moortown"
             >
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-3-0"
                 key="Briggate"
                 max="10000"
@@ -244,7 +244,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-3-1"
                 key="Chapeltown"
                 max="10000"
@@ -256,7 +256,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-3-2"
                 key="Chapel Allerton"
                 max="10000"
@@ -279,7 +279,7 @@ exports[`Price Entry Page should render correctly 1`] = `
               key="Harrogate Road"
             >
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-4-0"
                 key="Briggate"
                 max="10000"
@@ -291,7 +291,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-4-1"
                 key="Chapeltown"
                 max="10000"
@@ -303,7 +303,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-4-2"
                 key="Chapel Allerton"
                 max="10000"
@@ -315,7 +315,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-4-3"
                 key="Moortown"
                 max="10000"
@@ -338,7 +338,7 @@ exports[`Price Entry Page should render correctly 1`] = `
               key="Harehills"
             >
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-5-0"
                 key="Briggate"
                 max="10000"
@@ -350,7 +350,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-5-1"
                 key="Chapeltown"
                 max="10000"
@@ -362,7 +362,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-5-2"
                 key="Chapel Allerton"
                 max="10000"
@@ -374,7 +374,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-5-3"
                 key="Moortown"
                 max="10000"
@@ -386,7 +386,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-5-4"
                 key="Harrogate Road"
                 max="10000"
@@ -409,7 +409,7 @@ exports[`Price Entry Page should render correctly 1`] = `
               key="Gipton"
             >
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-6-0"
                 key="Briggate"
                 max="10000"
@@ -421,7 +421,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-6-1"
                 key="Chapeltown"
                 max="10000"
@@ -433,7 +433,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-6-2"
                 key="Chapel Allerton"
                 max="10000"
@@ -445,7 +445,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-6-3"
                 key="Moortown"
                 max="10000"
@@ -457,7 +457,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-6-4"
                 key="Harrogate Road"
                 max="10000"
@@ -469,7 +469,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-6-5"
                 key="Harehills"
                 max="10000"
@@ -492,7 +492,7 @@ exports[`Price Entry Page should render correctly 1`] = `
               key="Armley"
             >
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-7-0"
                 key="Briggate"
                 max="10000"
@@ -504,7 +504,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-7-1"
                 key="Chapeltown"
                 max="10000"
@@ -516,7 +516,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-7-2"
                 key="Chapel Allerton"
                 max="10000"
@@ -528,7 +528,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-7-3"
                 key="Moortown"
                 max="10000"
@@ -540,7 +540,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-7-4"
                 key="Harrogate Road"
                 max="10000"
@@ -552,7 +552,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-7-5"
                 key="Harehills"
                 max="10000"
@@ -564,7 +564,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-7-6"
                 key="Gipton"
                 max="10000"
@@ -587,7 +587,7 @@ exports[`Price Entry Page should render correctly 1`] = `
               key="Stanningley"
             >
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-8-0"
                 key="Briggate"
                 max="10000"
@@ -599,7 +599,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-8-1"
                 key="Chapeltown"
                 max="10000"
@@ -611,7 +611,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-8-2"
                 key="Chapel Allerton"
                 max="10000"
@@ -623,7 +623,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-8-3"
                 key="Moortown"
                 max="10000"
@@ -635,7 +635,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-8-4"
                 key="Harrogate Road"
                 max="10000"
@@ -647,7 +647,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-8-5"
                 key="Harehills"
                 max="10000"
@@ -659,7 +659,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-8-6"
                 key="Gipton"
                 max="10000"
@@ -671,7 +671,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-8-7"
                 key="Armley"
                 max="10000"
@@ -694,7 +694,7 @@ exports[`Price Entry Page should render correctly 1`] = `
               key="Pudsey"
             >
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-9-0"
                 key="Briggate"
                 max="10000"
@@ -706,7 +706,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-9-1"
                 key="Chapeltown"
                 max="10000"
@@ -718,7 +718,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-9-2"
                 key="Chapel Allerton"
                 max="10000"
@@ -730,7 +730,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-9-3"
                 key="Moortown"
                 max="10000"
@@ -742,7 +742,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-9-4"
                 key="Harrogate Road"
                 max="10000"
@@ -754,7 +754,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-9-5"
                 key="Harehills"
                 max="10000"
@@ -766,7 +766,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-9-6"
                 key="Gipton"
                 max="10000"
@@ -778,7 +778,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-9-7"
                 key="Armley"
                 max="10000"
@@ -790,7 +790,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-9-8"
                 key="Stanningley"
                 max="10000"
@@ -813,7 +813,7 @@ exports[`Price Entry Page should render correctly 1`] = `
               key="Seacroft"
             >
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-10-0"
                 key="Briggate"
                 max="10000"
@@ -825,7 +825,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-10-1"
                 key="Chapeltown"
                 max="10000"
@@ -837,7 +837,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-10-2"
                 key="Chapel Allerton"
                 max="10000"
@@ -849,7 +849,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-10-3"
                 key="Moortown"
                 max="10000"
@@ -861,7 +861,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-10-4"
                 key="Harrogate Road"
                 max="10000"
@@ -873,7 +873,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-10-5"
                 key="Harehills"
                 max="10000"
@@ -885,7 +885,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-10-6"
                 key="Gipton"
                 max="10000"
@@ -897,7 +897,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-10-7"
                 key="Armley"
                 max="10000"
@@ -909,7 +909,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-10-8"
                 key="Stanningley"
                 max="10000"
@@ -921,7 +921,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-10-9"
                 key="Pudsey"
                 max="10000"
@@ -944,7 +944,7 @@ exports[`Price Entry Page should render correctly 1`] = `
               key="Rothwell"
             >
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-11-0"
                 key="Briggate"
                 max="10000"
@@ -956,7 +956,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-11-1"
                 key="Chapeltown"
                 max="10000"
@@ -968,7 +968,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-11-2"
                 key="Chapel Allerton"
                 max="10000"
@@ -980,7 +980,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-11-3"
                 key="Moortown"
                 max="10000"
@@ -992,7 +992,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-11-4"
                 key="Harrogate Road"
                 max="10000"
@@ -1004,7 +1004,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-11-5"
                 key="Harehills"
                 max="10000"
@@ -1016,7 +1016,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-11-6"
                 key="Gipton"
                 max="10000"
@@ -1028,7 +1028,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-11-7"
                 key="Armley"
                 max="10000"
@@ -1040,7 +1040,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-11-8"
                 key="Stanningley"
                 max="10000"
@@ -1052,7 +1052,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-11-9"
                 key="Pudsey"
                 max="10000"
@@ -1064,7 +1064,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-11-10"
                 key="Seacroft"
                 max="10000"
@@ -1087,7 +1087,7 @@ exports[`Price Entry Page should render correctly 1`] = `
               key="Dewsbury"
             >
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-12-0"
                 key="Briggate"
                 max="10000"
@@ -1099,7 +1099,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-12-1"
                 key="Chapeltown"
                 max="10000"
@@ -1111,7 +1111,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-12-2"
                 key="Chapel Allerton"
                 max="10000"
@@ -1123,7 +1123,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-12-3"
                 key="Moortown"
                 max="10000"
@@ -1135,7 +1135,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-12-4"
                 key="Harrogate Road"
                 max="10000"
@@ -1147,7 +1147,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-12-5"
                 key="Harehills"
                 max="10000"
@@ -1159,7 +1159,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-12-6"
                 key="Gipton"
                 max="10000"
@@ -1171,7 +1171,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-12-7"
                 key="Armley"
                 max="10000"
@@ -1183,7 +1183,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-12-8"
                 key="Stanningley"
                 max="10000"
@@ -1195,7 +1195,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-12-9"
                 key="Pudsey"
                 max="10000"
@@ -1207,7 +1207,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-12-10"
                 key="Seacroft"
                 max="10000"
@@ -1219,7 +1219,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-white"
                 id="cell-12-11"
                 key="Rothwell"
                 max="10000"
@@ -1242,7 +1242,7 @@ exports[`Price Entry Page should render correctly 1`] = `
               key="Wakefield"
             >
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-13-0"
                 key="Briggate"
                 max="10000"
@@ -1254,7 +1254,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-13-1"
                 key="Chapeltown"
                 max="10000"
@@ -1266,7 +1266,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-13-2"
                 key="Chapel Allerton"
                 max="10000"
@@ -1278,7 +1278,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-13-3"
                 key="Moortown"
                 max="10000"
@@ -1290,7 +1290,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-13-4"
                 key="Harrogate Road"
                 max="10000"
@@ -1302,7 +1302,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-13-5"
                 key="Harehills"
                 max="10000"
@@ -1314,7 +1314,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-13-6"
                 key="Gipton"
                 max="10000"
@@ -1326,7 +1326,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-13-7"
                 key="Armley"
                 max="10000"
@@ -1338,7 +1338,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-13-8"
                 key="Stanningley"
                 max="10000"
@@ -1350,7 +1350,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-13-9"
                 key="Pudsey"
                 max="10000"
@@ -1362,7 +1362,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-13-10"
                 key="Seacroft"
                 max="10000"
@@ -1374,7 +1374,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-13-11"
                 key="Rothwell"
                 max="10000"
@@ -1386,7 +1386,7 @@ exports[`Price Entry Page should render correctly 1`] = `
                 type="number"
               />
               <input
-                className="govuk-input govuk-input--width-4 fare-triangle-input"
+                className="govuk-input govuk-input--width-4 fare-triangle-input fare-triangle-input-mid-grey"
                 id="cell-13-12"
                 key="Dewsbury"
                 max="10000"


### PR DESCRIPTION
# Description

This PR amends the styling attached to the fare triangle rendered on the priceEntry page. The background colour of the cells has been changed so that each row alternates in colour between white and light-grey. The contrast between the text and background is WCAG AA compliant as per GDS guidelines (contrast ratio is 18.78:1 versus minimum of 4.5:1). The width of the labels has also been adjusted to be slightly wider in order to accommodate longer stage names without showing an ellipsis.

# Testing instructions

-   Pull down this branch and run the site using the fdbt-dev repo.
-   Navigate to the priceEntry page and verify that (i) alternating cells are different colours and (ii) the labels accommodate a fare stage name of suitable length.

# Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

# Checklist:

-   [X] Able to run pr locally
-   [X] Lighthouse performed
-   [X] Followed acceptance criteria
-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [X] I have added tests that prove my fix is effective or that my feature works

[priceEntry.pdf](https://github.com/fares-data-build-tool/fdbt-site/files/4581893/priceEntry.pdf)
