### PR TITLE
Fix/amended matching fare zone types

### DIFF
--- a/src/pages/api/matching.ts
+++ b/src/pages/api/matching.ts
@@ -154,7 +154,6 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
         const matchingJson = getMatchingJson(service, userFareStages, matchingFareZones, fareTypeObject.fareType);
 
         setCookieOnResponseObject(getDomain(req), MATCHING_COOKIE, JSON.stringify({ error: false }), req, res);
-        console.log(matchingJson);
         await putMatchingDataInS3(matchingJson, uuid);
 
         redirectTo(res, '/thankyou');

--- a/src/pages/api/matching.ts
+++ b/src/pages/api/matching.ts
@@ -36,7 +36,7 @@ interface MatchingData extends MatchingBaseData {
 }
 
 interface MatchingReturnData extends MatchingBaseData {
-    outboundMatchingFareZones: {
+    outboundFareZones: {
         name: string;
         stops: Stop[];
         prices: {
@@ -44,7 +44,7 @@ interface MatchingReturnData extends MatchingBaseData {
             fareZones: string[];
         }[];
     }[];
-    inboundMatchingFareZones: [];
+    inboundFareZones: [];
 }
 
 interface MatchingFareZones {
@@ -100,8 +100,8 @@ const getMatchingJson = (
         return {
             ...service,
             type: 'return',
-            outboundMatchingFareZones: getFareZones(userFareStages, matchingFareZones),
-            inboundMatchingFareZones: [],
+            outboundFareZones: getFareZones(userFareStages, matchingFareZones),
+            inboundFareZones: [],
         };
     }
 
@@ -154,7 +154,7 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
         const matchingJson = getMatchingJson(service, userFareStages, matchingFareZones, fareTypeObject.fareType);
 
         setCookieOnResponseObject(getDomain(req), MATCHING_COOKIE, JSON.stringify({ error: false }), req, res);
-
+        console.log(matchingJson);
         await putMatchingDataInS3(matchingJson, uuid);
 
         redirectTo(res, '/thankyou');

--- a/tests/pages/_document.test.tsx
+++ b/tests/pages/_document.test.tsx
@@ -21,6 +21,7 @@ describe('_document', () => {
         hybridAmp: false,
         staticMarkup: false,
         isDevelopment: false,
+        hasCssMode: false,
         devFiles: [''],
         files: [''],
         polyfillFiles: [''],

--- a/tests/pages/api/inboundMatching.test.ts
+++ b/tests/pages/api/inboundMatching.test.ts
@@ -5,7 +5,7 @@ import {
     service,
     mockMatchingUserFareStagesWithUnassignedStages,
     mockMatchingUserFareStagesWithAllStagesAssigned,
-    expectedInboundOutboundMatchingJson,
+    expectedMatchingJsonReturnNonCircular,
 } from '../../testData/mockData';
 import * as s3 from '../../../src/data/s3';
 import { MatchingFareZones } from '../../../src/interfaces/matchingInterface';
@@ -87,7 +87,7 @@ describe('Inbound Matching API', () => {
             expect.any(String),
             'application/json; charset=utf-8',
         );
-        expect(expectedInboundOutboundMatchingJson).toEqual(actualMatchingData);
+        expect(expectedMatchingJsonReturnNonCircular).toEqual(actualMatchingData);
     });
 
     it('correctly redirects to inboundMatching page when there are fare stages that have not been assigned to stops', async () => {

--- a/tests/pages/api/matching.test.ts
+++ b/tests/pages/api/matching.test.ts
@@ -5,7 +5,8 @@ import {
     service,
     mockMatchingUserFareStagesWithUnassignedStages,
     mockMatchingUserFareStagesWithAllStagesAssigned,
-    expectedMatchingJson,
+    expectedMatchingJsonSingle,
+    expectedMatchingJsonReturnCircular,
 } from '../../testData/mockData';
 import * as s3 from '../../../src/data/s3';
 
@@ -33,7 +34,7 @@ describe('Matching API', () => {
         jest.resetAllMocks();
     });
 
-    it('correctly generates matching JSON and uploads to S3', async () => {
+    it('correctly generates matching JSON for a single ticket and uploads to S3', async () => {
         const { req, res } = getMockRequestAndResponse(
             {},
             {
@@ -46,13 +47,37 @@ describe('Matching API', () => {
         );
         await matching(req, res);
 
-        expect(putStringInS3Spy).toBeCalledTimes(1);
+        const actualMatchingData = JSON.parse((putStringInS3Spy as jest.Mock).mock.calls[0][2]);
         expect(putStringInS3Spy).toBeCalledWith(
             'fdbt-matching-data-dev',
             '1e0459b3-082e-4e70-89db-96e8ae173e10_215_DCCL.json',
-            JSON.stringify(expectedMatchingJson),
+            expect.any(String),
             'application/json; charset=utf-8',
         );
+        expect(expectedMatchingJsonSingle).toEqual(actualMatchingData);
+    });
+
+    it('correctly generates matching JSON for a return circular ticket and uploads to S3', async () => {
+        const { req, res } = getMockRequestAndResponse(
+            { fareType: 'return' },
+            {
+                ...selections,
+                service: JSON.stringify(service),
+                userfarestages: JSON.stringify(mockMatchingUserFareStagesWithAllStagesAssigned),
+            },
+            {},
+            writeHeadMock,
+        );
+        await matching(req, res);
+
+        const actualMatchingData = JSON.parse((putStringInS3Spy as jest.Mock).mock.calls[0][2]);
+        expect(putStringInS3Spy).toBeCalledWith(
+            'fdbt-matching-data-dev',
+            '1e0459b3-082e-4e70-89db-96e8ae173e10_215_DCCL.json',
+            expect.any(String),
+            'application/json; charset=utf-8',
+        );
+        expect(expectedMatchingJsonReturnCircular).toEqual(actualMatchingData);
     });
 
     it('correctly redirects to matching page when there are fare stages that have not been assigned to stops', async () => {

--- a/tests/testData/mockData.ts
+++ b/tests/testData/mockData.ts
@@ -937,7 +937,7 @@ export const mockMatchingUserFareStagesWithAllStagesAssigned = {
     ],
 };
 
-export const expectedMatchingJson = {
+export const expectedMatchingJsonSingle = {
     type: 'pointToPoint',
     lineName: '215',
     nocCode: 'DCCL',
@@ -1052,7 +1052,7 @@ export const expectedMatchingJson = {
     ],
 };
 
-export const expectedInboundOutboundMatchingJson = {
+export const expectedMatchingJsonReturnNonCircular = {
     type: 'return',
     lineName: '215',
     nocCode: 'DCCL',
@@ -1193,6 +1193,122 @@ export const expectedInboundOutboundMatchingJson = {
                     ],
                 },
             ],
+        },
+    ],
+};
+
+export const expectedMatchingJsonReturnCircular = {
+    type: 'return',
+    lineName: '215',
+    nocCode: 'DCCL',
+    operatorShortName: 'DCC',
+    serviceDescription: 'Worthing - Seaham - Crawley',
+    inboundFareZones: [],
+    outboundFareZones: [
+        {
+            name: 'Acomb Green Lane',
+            stops: [
+                {
+                    stopName: 'Yoden Way - Chapel Hill Road',
+                    naptanCode: 'duratdmj',
+                    atcoCode: '13003521G',
+                    localityCode: 'E0045956',
+                    localityName: 'Peterlee',
+                    indicator: 'W-bound',
+                    street: 'Yodan Way',
+                    qualifierName: '',
+                },
+            ],
+            prices: [
+                { price: '1.10', fareZones: ['Mattison Way', 'Nursery Drive', 'Holl Bank/Beech Ave'] },
+                {
+                    price: '1.70',
+                    fareZones: [
+                        'Cambridge Street (York)',
+                        'Blossom Street',
+                        'Rail Station (York)',
+                        'Piccadilly (York)',
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'Mattison Way',
+            stops: [
+                {
+                    stopName: 'Yoden Way',
+                    naptanCode: 'duratdmt',
+                    atcoCode: '13003522F',
+                    localityCode: 'E0010183',
+                    localityName: 'Horden',
+                    indicator: 'SW-bound',
+                    street: 'Yoden Way',
+                    qualifierName: '',
+                },
+            ],
+            prices: [
+                { price: '1.10', fareZones: ['Nursery Drive', 'Holl Bank/Beech Ave'] },
+                {
+                    price: '1.70',
+                    fareZones: [
+                        'Cambridge Street (York)',
+                        'Blossom Street',
+                        'Rail Station (York)',
+                        'Piccadilly (York)',
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'Holl Bank/Beech Ave',
+            stops: [
+                {
+                    stopName: 'Surtees Rd-Edenhill Rd',
+                    naptanCode: 'durapgdw',
+                    atcoCode: '13003219H',
+                    localityCode: 'E0045956',
+                    localityName: 'Peterlee',
+                    indicator: 'NW-bound',
+                    street: 'Surtees Road',
+                    qualifierName: '',
+                },
+            ],
+            prices: [
+                { price: '1.10', fareZones: ['Cambridge Street (York)', 'Blossom Street'] },
+                { price: '1.70', fareZones: ['Rail Station (York)', 'Piccadilly (York)'] },
+            ],
+        },
+        {
+            name: 'Blossom Street',
+            stops: [
+                {
+                    stopName: 'Bus Station',
+                    naptanCode: 'duratdma',
+                    atcoCode: '13003519H',
+                    localityCode: 'E0045956',
+                    localityName: 'Peterlee',
+                    indicator: 'H',
+                    street: 'Bede Way',
+                    qualifierName: '',
+                },
+            ],
+            prices: [{ price: '1.00', fareZones: ['Rail Station (York)', 'Piccadilly (York)'] }],
+        },
+        {
+            name: 'Piccadilly (York)',
+            stops: [
+                {
+                    stopName: 'Kell Road',
+                    naptanCode: 'duraptwp',
+                    atcoCode: '13003345D',
+                    localityCode: 'E0010183',
+                    localityName: 'Horden',
+                    indicator: 'SE-bound',
+                    street: 'Kell Road',
+                    qualifierName: '',
+                },
+            ],
+            prices: {},
         },
     ],
 };


### PR DESCRIPTION
# Description

-   This PR introduces a fix which changes our MatchingData types to be consistent. We had instances of 'InboundMatchingFareZones' and 'OutboundMatchingFareZones' which needed to be 'InboundFareZones' and 'OutboundFareZones'

# Testing instructions

-   Pull down this branch and run the site locally.
-   Run through the 'Return - Single Service' journey for a return circular and return non-circular service (Warrington's Own Buses - 709 is a circular service and Warrington's Own Buses - 25 is a non circular service) and validate that the matching data contains an array of InboundFareZones and OutboundFareZones rather than InboundMatchingFareZones and OutboundMatchingFareZones.

# Type of change

-   [ ] feat - A new feature
-   [X] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [X] Able to run pr locally
-   [ ] Lighthouse performed
-   [X] Followed acceptance criteria
-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [X] I have added tests that prove my fix is effective or that my feature works
