### PR TITLE
fix: add error page back in

### DIFF
--- a/src/pages/error.tsx
+++ b/src/pages/error.tsx
@@ -1,0 +1,15 @@
+import React, { ReactElement } from 'react';
+import { NextPageContext } from 'next';
+import Error from './_error';
+
+interface ErrorProps {
+    statusCode: number;
+}
+
+const ErrorPage = ({ statusCode }: ErrorProps): ReactElement => <Error statusCode={statusCode} />;
+
+export const getServerSideProps = (ctx: NextPageContext): {} => {
+    return { props: { statusCode: ctx?.res?.statusCode } };
+};
+
+export default ErrorPage;


### PR DESCRIPTION
# Description

Add error page back in

# Testing instructions

-   Navigate to /error, it should show the error page rather than page not found

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [ ] Lighthouse performed
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
