### PR TITLE
fix path to server index in start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "build:next": "next build",
         "build:server": "tsc --project tsconfig.server.json",
         "build": "npm run build:next && npm run build:server",
-        "start": "NODE_ENV=production PORT=80 node dist/index.js",
+        "start": "NODE_ENV=production PORT=80 node dist/server/index.js",
         "lint": "eslint . --ext .ts,.tsx",
         "lint:fix": "eslint --fix . --ext .ts,.tsx"
     },

--- a/server/middleware/authentication.ts
+++ b/server/middleware/authentication.ts
@@ -18,7 +18,7 @@ const jwks = jwksClient({
 
 const getKey = (header: JwtHeader, callback: SigningKeyCallback): void => {
     jwks.getSigningKey(header.kid ?? '', (err, key) => {
-        const signingKey = key.getPublicKey();
+        const signingKey = key?.getPublicKey();
         callback(err ?? null, signingKey);
     });
 };


### PR DESCRIPTION
# Description

-   Update npm start script to correctly point at the server index when running in docker

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy
