### PR TITLE
set correct path to static scripts and next folders

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -29,9 +29,11 @@ const unauthenticatedGetRoutes = [
 const unauthenticatedPostRoutes = ['/api/login', '/api/register', '/api/forgotPassword', '/api/resetPassword'];
 
 const setStaticRoutes = (server: Express): void => {
+    const rootPath = process.env.NODE_ENV === 'development' ? `${__dirname}/..` : `${__dirname}/../..`;
+
     server.use(
         '/assets',
-        express.static(`${__dirname}/../node_modules/govuk-frontend/govuk/assets`, {
+        express.static(`${rootPath}/node_modules/govuk-frontend/govuk/assets`, {
             maxAge: '365d',
             immutable: true,
         }),
@@ -39,7 +41,7 @@ const setStaticRoutes = (server: Express): void => {
 
     server.use(
         '/_next/static',
-        express.static(`${__dirname}/../.next/static`, {
+        express.static(`${rootPath}/.next/static`, {
             maxAge: '365d',
             immutable: true,
         }),
@@ -47,7 +49,7 @@ const setStaticRoutes = (server: Express): void => {
 
     server.use(
         '/scripts',
-        express.static(`${__dirname}/../node_modules/govuk-frontend/govuk`, {
+        express.static(`${rootPath}/node_modules/govuk-frontend/govuk`, {
             maxAge: '365d',
             immutable: true,
         }),


### PR DESCRIPTION
# Description

-   Fix paths to static folders when running in docker

# Testing instructions

-  Scripts and fonts should load

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

