### PR TITLE
Fixed redirection when passengerType is 'Anyone'

### DIFF
--- a/src/pages/api/passengerType.ts
+++ b/src/pages/api/passengerType.ts
@@ -33,7 +33,7 @@ export default (req: NextApiRequest, res: NextApiResponse): void => {
 
             setCookieOnResponseObject(getDomain(req), PASSENGER_TYPE_COOKIE, cookieValue, req, res);
 
-            if (passengerType === 'Any') {
+            if (passengerType === 'anyone') {
                 redirectOnFareType(req, res);
                 return;
             }

--- a/tests/pages/api/passengerType.test.ts
+++ b/tests/pages/api/passengerType.test.ts
@@ -87,8 +87,8 @@ describe('passengerType', () => {
         });
     });
 
-    it('should call redirectOnFareType when the user selects Any', () => {
-        const { req, res } = getMockRequestAndResponse({}, { passengerType: 'Any' }, {}, writeHeadMock);
+    it('should call redirectOnFareType when the user selects Anyone', () => {
+        const { req, res } = getMockRequestAndResponse({}, { passengerType: 'anyone' }, {}, writeHeadMock);
         const redirectOnFareType = jest.spyOn(utils, 'redirectOnFareType');
 
         passengerType(req, res);


### PR DESCRIPTION
# Description

-   This PR fixes the previous changes to site which broke the redirect functionality on the passengerType page. The passengerType page should always 'redirectOnFareType' when the user selects 'Anyone'.

# Testing instructions

-   Pull down this branch and run the site locally.
-   Check that the passengerType page uses the 'redirectOnFareType' functionality when you select 'Anyone' and that the page redirects to 'definePassengerType' when any other selection is made.

# Type of change

-   [ ] feat - A new feature
-   [X] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [X] Able to run pr locally
-   [ ] Lighthouse performed (Accessibility 90+ minimum)
-   [X] Followed acceptance criteria
-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
