### PR TITLE
fix: Force proof documents to always be an array

### DIFF
--- a/src/pages/api/definePassengerType.ts
+++ b/src/pages/api/definePassengerType.ts
@@ -93,17 +93,10 @@ export const formatRequestBody = (req: NextApiRequest): {} => {
             return;
         }
         if (entry[0] === 'proofDocuments') {
-            if (!isArray(entry[1])) {
-                const proofDocuments = entry[1] as string;
-                filteredReqBody[entry[0]] = [proofDocuments];
-                return;
-            }
-            const proofDocuments = entry[1] as string[];
-            filteredReqBody[entry[0]] = proofDocuments;
+            filteredReqBody[entry[0]] = !isArray(entry[1]) ? [entry[1] as string] : (entry[1] as string[]);
             return;
         }
-        const entryValue = entry[1] as string;
-        filteredReqBody[entry[0]] = entryValue;
+        filteredReqBody[entry[0]] = entry[1] as string;
     });
     return filteredReqBody;
 };

--- a/tests/pages/api/definePassengerType.test.ts
+++ b/tests/pages/api/definePassengerType.test.ts
@@ -1,6 +1,6 @@
 import definePassengerType, {
     passengerTypeDetailsSchema,
-    removeWhitespaceFromTextInput,
+    formatRequestBody,
 } from '../../../src/pages/api/definePassengerType';
 import * as apiUtils from '../../../src/pages/api/apiUtils';
 import { getMockRequestAndResponse } from '../../testData/mockData';
@@ -50,14 +50,25 @@ describe('definePassengerType', () => {
         });
     });
 
-    describe('removeWhitespaceFromTextInput', () => {
+    describe('formatRequestBody', () => {
         it('should remove whitespace from the request body text inputs of ageRangeMin and ageRangeMax', () => {
+            const reqBodyParams = { ageRange: 'Yes', proof: 'No' };
             const { req } = getMockRequestAndResponse({
                 cookieValues: {},
-                body: { ageRangeMin: '   2   4', ageRangeMax: '   10   0       ' },
+                body: { ageRangeMin: '   2   4', ageRangeMax: '   10   0       ', ...reqBodyParams },
             });
-            const filtered = removeWhitespaceFromTextInput(req);
-            expect(filtered).toEqual({ ageRangeMin: '24', ageRangeMax: '100' });
+            const filtered = formatRequestBody(req);
+            expect(filtered).toEqual({ ageRangeMin: '24', ageRangeMax: '100', ...reqBodyParams });
+        });
+
+        it('should force proof documents to always be an array, even if there is only one selected', () => {
+            const reqBodyParams = { ageRange: 'No', proof: 'Yes' };
+            const { req } = getMockRequestAndResponse({
+                cookieValues: {},
+                body: { proofDocuments: 'membershipCard', ...reqBodyParams },
+            });
+            const filtered = formatRequestBody(req);
+            expect(filtered).toEqual({ proofDocuments: ['membershipCard'], ...reqBodyParams });
         });
     });
 


### PR DESCRIPTION
# Description

-   This PR addresses the issue raised in TFN-558. Formatting has been added to the 'filteredReqBody' in the definePassengerType API to force the proof documents to always be passed through into the cookies and matching data as an array, even if the user only selects one proof document.

# Testing instructions

-   Pull down this branch and run the site locally.
-   Navigate through the definePassengerType page, select/enter different variations of data and validate that the proof documents are always passed into the cookies as an array.

# Type of change

-   [ ] feat - A new feature
-   [X] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [X] Able to run pr locally
-   [ ] Lighthouse performed (Accessibility 90+ minimum)
-   [X] Followed acceptance criteria
-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [X] I have added tests that prove my fix is effective or that my feature works
