### PR TITLE
add home page after login

### DIFF
--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -34,7 +34,11 @@ const Header = ({ isAuthed, csrfToken }: HeaderProps): ReactElement => (
             </div>
 
             <div className="govuk-header__content">
-                <a href="/" id="title-link" className="govuk-header__link govuk-header__link--service-name">
+                <a
+                    href={isAuthed ? '/home' : '/'}
+                    id="title-link"
+                    className="govuk-header__link govuk-header__link--service-name"
+                >
                     Fares Data Build Tool
                 </a>
             </div>

--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -50,7 +50,7 @@ const AccountDetails = ({ emailAddress, nocCode }: AccountDetailsProps): ReactEl
                 </div>
             </div>
             <a
-                href="/"
+                href="/home"
                 role="button"
                 draggable="false"
                 className="govuk-button"

--- a/src/pages/api/login.ts
+++ b/src/pages/api/login.ts
@@ -53,7 +53,7 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
                 setCookieOnResponseObject(REFRESH_TOKEN_COOKIE, refreshToken, req, res);
 
                 console.info('login successful', { noc: nocCode });
-                redirectTo(res, '/fareType');
+                redirectTo(res, '/home');
             } else {
                 throw new Error('Auth response invalid');
             }

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,0 +1,50 @@
+import React, { ReactElement } from 'react';
+import { NextPage } from 'next';
+import { BaseLayout } from '../layout/Layout';
+
+const title = 'Fares Data Build Tool';
+const description = 'Fares Data Build Tool is a service that allows you to generate data in NeTEx format';
+
+const Home: NextPage = (): ReactElement => (
+    <BaseLayout title={title} description={description}>
+        <h1 className="govuk-heading-xl">Fares Data Build Tool</h1>
+        <div className="govuk-grid-row">
+            <div className="govuk-grid-column-two-thirds">
+                <div>
+                    <p className="govuk-body govuk-!-font-weight-bold content-one-quarter">
+                        Create & download fares data
+                    </p>
+                    <p className="govuk-body">
+                        For bus operators running commercial bus services in England, and local authorities that need to
+                        create or access NeTEx data for the services they operate.
+                    </p>
+                    <a href="/fareType" className="govuk-link govuk-!-font-size-19" id="faretype-link">
+                        Create NeTEx data for your fares
+                    </a>
+                </div>
+                <div className="govuk-!-margin-top-9">
+                    <p className="govuk-body govuk-!-font-weight-bold content-one-quarter">Operator settings</p>
+                    <p className="govuk-body">
+                        For updating the information we use about your services when creating NeTEx data.
+                    </p>
+
+                    <a href="/account" className="govuk-link govuk-!-font-size-19" id="account-link">
+                        My account settings
+                    </a>
+                </div>
+            </div>
+            <div className="govuk-grid-column-one-third">
+                <p className="govuk-body govuk-!-font-weight-bold content-one-quarter">Public information</p>
+                <a href="/contact" className="govuk-link govuk-!-font-size-19" id="contact-link">
+                    Contact Us
+                </a>
+            </div>
+        </div>
+    </BaseLayout>
+);
+
+export const getServerSideProps = (): {} => {
+    return { props: {} };
+};
+
+export default Home;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,7 +5,7 @@ import TwoThirdsLayout from '../layout/Layout';
 const title = 'Fares Data Build Tool';
 const description = 'Fares Data Build Tool is a service that allows you to generate data in NeTEx format';
 
-const Home: NextPage = (): ReactElement => (
+const Start: NextPage = (): ReactElement => (
     <TwoThirdsLayout title={title} description={description}>
         <h1 className="govuk-heading-xl">Fares Data Build Tool</h1>
 
@@ -57,4 +57,4 @@ export const getServerSideProps = (): {} => {
     return { props: {} };
 };
 
-export default Home;
+export default Start;

--- a/src/pages/thankyou.tsx
+++ b/src/pages/thankyou.tsx
@@ -41,7 +41,7 @@ const ThankYou = ({ uuid, emailAddress }: ThankYouProps): ReactElement => (
             </a>
         </p>
         <br />
-        <a href="/fareType" role="button" draggable="false" className="govuk-button" data-module="govuk-button">
+        <a href="/home" role="button" draggable="false" className="govuk-button" data-module="govuk-button">
             Add another fare
         </a>
     </TwoThirdsLayout>

--- a/src/utils/breadcrumbs.ts
+++ b/src/utils/breadcrumbs.ts
@@ -164,7 +164,7 @@ export default (ctx: NextPageContext): { generate: () => Breadcrumb[] } => {
         const breadcrumbList: Breadcrumb[] = [
             {
                 name: 'Home',
-                link: '/',
+                link: '/home',
                 show: true,
             },
             {

--- a/tests/layout/Header.test.tsx
+++ b/tests/layout/Header.test.tsx
@@ -10,6 +10,6 @@ describe('Header', () => {
 
     it('expect title_link to be root', () => {
         const tree = shallow(<Header isAuthed csrfToken="" />);
-        expect(tree.find('#title-link').prop('href')).toEqual('/');
+        expect(tree.find('#title-link').prop('href')).toEqual('/home');
     });
 });

--- a/tests/layout/__snapshots__/Header.test.tsx.snap
+++ b/tests/layout/__snapshots__/Header.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`Header should render correctly 1`] = `
     >
       <a
         className="govuk-header__link govuk-header__link--service-name"
-        href="/"
+        href="/home"
         id="title-link"
       >
         Fares Data Build Tool

--- a/tests/pages/__snapshots__/account.test.tsx.snap
+++ b/tests/pages/__snapshots__/account.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`pages account should render correctly 1`] = `
     className="govuk-button"
     data-module="govuk-button"
     draggable="false"
-    href="/"
+    href="/home"
     id="home-button"
     role="button"
   >

--- a/tests/pages/__snapshots__/home.test.tsx.snap
+++ b/tests/pages/__snapshots__/home.test.tsx.snap
@@ -1,0 +1,78 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pages home page should render correctly 1`] = `
+<Component
+  description="Fares Data Build Tool is a service that allows you to generate data in NeTEx format"
+  title="Fares Data Build Tool"
+>
+  <h1
+    className="govuk-heading-xl"
+  >
+    Fares Data Build Tool
+  </h1>
+  <div
+    className="govuk-grid-row"
+  >
+    <div
+      className="govuk-grid-column-two-thirds"
+    >
+      <div>
+        <p
+          className="govuk-body govuk-!-font-weight-bold content-one-quarter"
+        >
+          Create & download fares data
+        </p>
+        <p
+          className="govuk-body"
+        >
+          For bus operators running commercial bus services in England, and local authorities that need to create or access NeTEx data for the services they operate.
+        </p>
+        <a
+          className="govuk-link govuk-!-font-size-19"
+          href="/fareType"
+          id="faretype-link"
+        >
+          Create NeTEx data for your fares
+        </a>
+      </div>
+      <div
+        className="govuk-!-margin-top-9"
+      >
+        <p
+          className="govuk-body govuk-!-font-weight-bold content-one-quarter"
+        >
+          Operator settings
+        </p>
+        <p
+          className="govuk-body"
+        >
+          For updating the information we use about your services when creating NeTEx data.
+        </p>
+        <a
+          className="govuk-link govuk-!-font-size-19"
+          href="/account"
+          id="account-link"
+        >
+          My account settings
+        </a>
+      </div>
+    </div>
+    <div
+      className="govuk-grid-column-one-third"
+    >
+      <p
+        className="govuk-body govuk-!-font-weight-bold content-one-quarter"
+      >
+        Public information
+      </p>
+      <a
+        className="govuk-link govuk-!-font-size-19"
+        href="/contact"
+        id="contact-link"
+      >
+        Contact Us
+      </a>
+    </div>
+  </div>
+</Component>
+`;

--- a/tests/pages/__snapshots__/thankyou.test.tsx.snap
+++ b/tests/pages/__snapshots__/thankyou.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`pages thankyou should render correctly 1`] = `
     className="govuk-button"
     data-module="govuk-button"
     draggable="false"
-    href="/fareType"
+    href="/home"
     role="button"
   >
     Add another fare

--- a/tests/pages/api/login.test.ts
+++ b/tests/pages/api/login.test.ts
@@ -86,7 +86,7 @@ describe('login', () => {
 
         expect(authSignInSpy).toHaveBeenCalledWith('test@test.com', 'abcdefghi');
         expect(writeHeadMock).toBeCalledWith(302, {
-            Location: '/fareType',
+            Location: '/home',
         });
     });
 

--- a/tests/pages/home.test.tsx
+++ b/tests/pages/home.test.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import Home from '../../src/pages/home';
+
+describe('pages', () => {
+    describe('home page', () => {
+        it('should render correctly', () => {
+            const tree = shallow(<Home />);
+            expect(tree).toMatchSnapshot();
+        });
+    });
+});

--- a/tests/testData/mockData.ts
+++ b/tests/testData/mockData.ts
@@ -2252,7 +2252,7 @@ export const mockFromHomeBreadcrumbs: Breadcrumb[] = [];
 export const mockSingleAdultCsvUploadFromMatchingBreadcrumbs: Breadcrumb[] = [
     {
         name: 'Home',
-        link: '/',
+        link: '/home',
         show: true,
     },
     {
@@ -2300,7 +2300,7 @@ export const mockSingleAdultCsvUploadFromMatchingBreadcrumbs: Breadcrumb[] = [
 export const mockReturnAnyoneManualFromOutboundMatchingBreadcrumbs: Breadcrumb[] = [
     {
         name: 'Home',
-        link: '/',
+        link: '/home',
         show: true,
     },
     {
@@ -2358,7 +2358,7 @@ export const mockReturnAnyoneManualFromOutboundMatchingBreadcrumbs: Breadcrumb[]
 export const mockPeriodGeoZoneSeniorFromCsvZoneUploadBreadcrumbs: Breadcrumb[] = [
     {
         name: 'Home',
-        link: '/',
+        link: '/home',
         show: true,
     },
     {
@@ -2391,7 +2391,7 @@ export const mockPeriodGeoZoneSeniorFromCsvZoneUploadBreadcrumbs: Breadcrumb[] =
 export const mockFlatFareStudentFromDefinePassengerTypeBreadcrumbs: Breadcrumb[] = [
     {
         name: 'Home',
-        link: '/',
+        link: '/home',
         show: true,
     },
     {
@@ -2414,7 +2414,7 @@ export const mockFlatFareStudentFromDefinePassengerTypeBreadcrumbs: Breadcrumb[]
 export const mockMultiServicesAnyoneFromMultipleProductValidityBreadcrumbs: Breadcrumb[] = [
     {
         name: 'Home',
-        link: '/',
+        link: '/home',
         show: true,
     },
     {
@@ -2457,7 +2457,7 @@ export const mockMultiServicesAnyoneFromMultipleProductValidityBreadcrumbs: Brea
 export const mockMultiServicesAnyoneFromPeriodValidityBreadcrumbs: Breadcrumb[] = [
     {
         name: 'Home',
-        link: '/',
+        link: '/home',
         show: true,
     },
     {


### PR DESCRIPTION
# Description

New landing page when logging in. I have renamed the current home page to start as it makes sense for the logged in journey to have the home.

# Testing instructions

-  Login into the site and it should redirect to the new home page. 
-  Check links work

<img width="542" alt="Screenshot 2020-07-08 at 10 34 02" src="https://user-images.githubusercontent.com/1183416/86902958-94490780-c106-11ea-9253-d07a984f79b6.png">


# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Lighthouse performed (Accessibility 90+ minimum)
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
