### PR TITLE
fix: removed excess commas from predefined SOPs

### DIFF
--- a/src/pages/selectSalesOfferPackage.tsx
+++ b/src/pages/selectSalesOfferPackage.tsx
@@ -24,7 +24,7 @@ const defaultSalesOfferPackageOne: SalesOfferPackage = {
 const defaultSalesOfferPackageTwo: SalesOfferPackage = {
     name: 'Onboard (contactless)',
     description: 'Purchasable on board the bus, with a contactless card or device, as a paper ticket.',
-    purchaseLocations: ['onBoard,'],
+    purchaseLocations: ['onBoard'],
     paymentMethods: ['contactlessPaymentCard'],
     ticketFormats: ['paperTicket'],
 };
@@ -33,7 +33,7 @@ const defaultSalesOfferPackageThree: SalesOfferPackage = {
     name: 'Online (smart card)',
     description:
         'Purchasable online, with a debit/credit card or direct debit transaction, on a smart card or similar.',
-    purchaseLocations: ['online,'],
+    purchaseLocations: ['online'],
     paymentMethods: ['directDebit', 'creditCard', 'debitCard'],
     ticketFormats: ['smartCard'],
 };
@@ -42,7 +42,7 @@ const defaultSalesOfferPackageFour: SalesOfferPackage = {
     name: 'Mobile App',
     description:
         'Purchasable on a mobile device application, with a debit/credit card or direct debit transaction, stored on the mobile application.',
-    purchaseLocations: ['mobileDevice,'],
+    purchaseLocations: ['mobileDevice'],
     paymentMethods: ['debitCard', 'creditCard', 'mobilePhone', 'directDebit'],
     ticketFormats: ['mobileApp'],
 };

--- a/src/pages/selectSalesOfferPackage.tsx
+++ b/src/pages/selectSalesOfferPackage.tsx
@@ -13,7 +13,7 @@ const pageTitle = 'Select Sales Offer Package - Fares Data Build Tool';
 const pageDescription = 'Sales Offer Package selection page of the Fares Data Build Tool';
 const errorId = 'sales-offer-package-error';
 
-const defaultSalesOfferPackageOne: SalesOfferPackage = {
+export const defaultSalesOfferPackageOne: SalesOfferPackage = {
     name: 'Onboard (cash)',
     description: 'Purchasable on board the bus, with cash, as a paper ticket.',
     purchaseLocations: ['onBoard'],
@@ -21,7 +21,7 @@ const defaultSalesOfferPackageOne: SalesOfferPackage = {
     ticketFormats: ['paperTicket'],
 };
 
-const defaultSalesOfferPackageTwo: SalesOfferPackage = {
+export const defaultSalesOfferPackageTwo: SalesOfferPackage = {
     name: 'Onboard (contactless)',
     description: 'Purchasable on board the bus, with a contactless card or device, as a paper ticket.',
     purchaseLocations: ['onBoard'],
@@ -29,7 +29,7 @@ const defaultSalesOfferPackageTwo: SalesOfferPackage = {
     ticketFormats: ['paperTicket'],
 };
 
-const defaultSalesOfferPackageThree: SalesOfferPackage = {
+export const defaultSalesOfferPackageThree: SalesOfferPackage = {
     name: 'Online (smart card)',
     description:
         'Purchasable online, with a debit/credit card or direct debit transaction, on a smart card or similar.',
@@ -38,7 +38,7 @@ const defaultSalesOfferPackageThree: SalesOfferPackage = {
     ticketFormats: ['smartCard'],
 };
 
-const defaultSalesOfferPackageFour: SalesOfferPackage = {
+export const defaultSalesOfferPackageFour: SalesOfferPackage = {
     name: 'Mobile App',
     description:
         'Purchasable on a mobile device application, with a debit/credit card or direct debit transaction, stored on the mobile application.',
@@ -49,18 +49,18 @@ const defaultSalesOfferPackageFour: SalesOfferPackage = {
 
 export interface SelectSalesOfferPackageProps {
     salesOfferPackagesList: SalesOfferPackage[];
-    error: ErrorInfo[];
+    errors: ErrorInfo[];
 }
 
 const SelectSalesOfferPackage = ({
     salesOfferPackagesList,
     csrfToken,
-    error,
+    errors,
 }: SelectSalesOfferPackageProps & CustomAppProps): ReactElement => (
     <FullColumnLayout title={pageTitle} description={pageDescription}>
         <CsrfForm action="/api/selectSalesOfferPackage" method="post" csrfToken={csrfToken}>
             <>
-                <ErrorSummary errors={error} />
+                <ErrorSummary errors={errors} />
                 <div className="govuk-form-group">
                     <fieldset className="govuk-fieldset" aria-describedby="select-sales-offer-package-page-heading">
                         <legend className="govuk-fieldset__legend govuk-fieldset__legend--l">
@@ -69,8 +69,8 @@ const SelectSalesOfferPackage = ({
                             </h1>
                         </legend>
                         <span id="radio-error" className="govuk-error-message">
-                            <span className={error.length > 0 ? '' : 'govuk-visually-hidden'}>
-                                {error[0] ? error[0].errorMessage : ''}
+                            <span className={errors.length > 0 ? '' : 'govuk-visually-hidden'}>
+                                {errors[0] ? errors[0].errorMessage : ''}
                             </span>
                         </span>
                         <div>
@@ -94,7 +94,7 @@ const SelectSalesOfferPackage = ({
                         </div>
                     </fieldset>
                     <fieldset className="govuk-fieldset" aria-describedby="service-list-hint">
-                        <FormElementWrapper errors={error} errorId={errorId} errorClass="govuk-form-group--error">
+                        <FormElementWrapper errors={errors} errorId={errorId} errorClass="govuk-form-group--error">
                             <div className="govuk-checkboxes">
                                 {salesOfferPackagesList.map((salesOfferPackage: SalesOfferPackage, index) => {
                                     let { description } = salesOfferPackage;
@@ -164,14 +164,14 @@ export const getServerSideProps = async (
         defaultSalesOfferPackageFour,
     );
     const salesOfferPackageAttribute = getSessionAttribute(ctx.req, SALES_OFFER_PACKAGES_ATTRIBUTE);
-    const error: ErrorInfo[] = [];
+    const errors: ErrorInfo[] = [];
     if (salesOfferPackageAttribute && salesOfferPackageAttribute.errorMessage) {
         const errorInfo: ErrorInfo = { errorMessage: salesOfferPackageAttribute.errorMessage, id: errorId };
-        error.push(errorInfo);
+        errors.push(errorInfo);
         return {
             props: {
                 salesOfferPackagesList,
-                error,
+                errors,
             },
         };
     }
@@ -179,7 +179,7 @@ export const getServerSideProps = async (
     return {
         props: {
             salesOfferPackagesList,
-            error: [],
+            errors: [],
         },
     };
 };

--- a/tests/pages/__snapshots__/selectSalesOfferPackage.test.tsx.snap
+++ b/tests/pages/__snapshots__/selectSalesOfferPackage.test.tsx.snap
@@ -105,7 +105,116 @@ exports[`pages serviceList should render an error when an error message is passe
         >
           <div
             className="govuk-checkboxes"
-          />
+          >
+            <div
+              className="govuk-checkboxes__item"
+              key="checkbox-item-Onboard (cash)"
+            >
+              <input
+                className="govuk-checkboxes__input"
+                id="checkbox-0"
+                name="Onboard (cash)"
+                type="checkbox"
+                value="{\\"name\\":\\"Onboard (cash)\\",\\"description\\":\\"Purchasable on board the bus, with cash, as a paper ticket.\\",\\"purchaseLocations\\":[\\"onBoard\\"],\\"paymentMethods\\":[\\"cash\\"],\\"ticketFormats\\":[\\"paperTicket\\"]}"
+              />
+              <label
+                className="govuk-label govuk-checkboxes__label"
+                htmlFor="checkbox-0"
+              >
+                <span
+                  className="govuk-!-font-weight-bold"
+                >
+                   
+                  Onboard (cash)
+                   
+                </span>
+                 -
+                 
+                Purchasable on board the bus, with cash, as a paper ticket.
+              </label>
+            </div>
+            <div
+              className="govuk-checkboxes__item"
+              key="checkbox-item-Onboard (contactless)"
+            >
+              <input
+                className="govuk-checkboxes__input"
+                id="checkbox-1"
+                name="Onboard (contactless)"
+                type="checkbox"
+                value="{\\"name\\":\\"Onboard (contactless)\\",\\"description\\":\\"Purchasable on board the bus, with a contactless card or device, as a paper ticket.\\",\\"purchaseLocations\\":[\\"onBoard\\"],\\"paymentMethods\\":[\\"contactlessPaymentCard\\"],\\"ticketFormats\\":[\\"paperTicket\\"]}"
+              />
+              <label
+                className="govuk-label govuk-checkboxes__label"
+                htmlFor="checkbox-1"
+              >
+                <span
+                  className="govuk-!-font-weight-bold"
+                >
+                   
+                  Onboard (contactless)
+                   
+                </span>
+                 -
+                 
+                Purchasable on board the bus, with a contactless card or device, as a paper ticket.
+              </label>
+            </div>
+            <div
+              className="govuk-checkboxes__item"
+              key="checkbox-item-Online (smart card)"
+            >
+              <input
+                className="govuk-checkboxes__input"
+                id="checkbox-2"
+                name="Online (smart card)"
+                type="checkbox"
+                value="{\\"name\\":\\"Online (smart card)\\",\\"description\\":\\"Purchasable online, with a debit/credit card or direct debit transaction, on a smart card or similar.\\",\\"purchaseLocations\\":[\\"online\\"],\\"paymentMethods\\":[\\"directDebit\\",\\"creditCard\\",\\"debitCard\\"],\\"ticketFormats\\":[\\"smartCard\\"]}"
+              />
+              <label
+                className="govuk-label govuk-checkboxes__label"
+                htmlFor="checkbox-2"
+              >
+                <span
+                  className="govuk-!-font-weight-bold"
+                >
+                   
+                  Online (smart card)
+                   
+                </span>
+                 -
+                 
+                Purchasable online, with a debit/credit card or direct debit transaction, on a smart card or similar.
+              </label>
+            </div>
+            <div
+              className="govuk-checkboxes__item"
+              key="checkbox-item-Mobile App"
+            >
+              <input
+                className="govuk-checkboxes__input"
+                id="checkbox-3"
+                name="Mobile App"
+                type="checkbox"
+                value="{\\"name\\":\\"Mobile App\\",\\"description\\":\\"Purchasable on a mobile device application, with a debit/credit card or direct debit transaction, stored on the mobile application.\\",\\"purchaseLocations\\":[\\"mobileDevice\\"],\\"paymentMethods\\":[\\"debitCard\\",\\"creditCard\\",\\"mobilePhone\\",\\"directDebit\\"],\\"ticketFormats\\":[\\"mobileApp\\"]}"
+              />
+              <label
+                className="govuk-label govuk-checkboxes__label"
+                htmlFor="checkbox-3"
+              >
+                <span
+                  className="govuk-!-font-weight-bold"
+                >
+                   
+                  Mobile App
+                   
+                </span>
+                 -
+                 
+                Purchasable on a mobile device application, with a debit/credit card or direct debit transaction, stored on the mobile application.
+              </label>
+            </div>
+          </div>
         </FormElementWrapper>
       </fieldset>
     </div>
@@ -218,7 +327,116 @@ exports[`pages serviceList should render correctly 1`] = `
         >
           <div
             className="govuk-checkboxes"
-          />
+          >
+            <div
+              className="govuk-checkboxes__item"
+              key="checkbox-item-Onboard (cash)"
+            >
+              <input
+                className="govuk-checkboxes__input"
+                id="checkbox-0"
+                name="Onboard (cash)"
+                type="checkbox"
+                value="{\\"name\\":\\"Onboard (cash)\\",\\"description\\":\\"Purchasable on board the bus, with cash, as a paper ticket.\\",\\"purchaseLocations\\":[\\"onBoard\\"],\\"paymentMethods\\":[\\"cash\\"],\\"ticketFormats\\":[\\"paperTicket\\"]}"
+              />
+              <label
+                className="govuk-label govuk-checkboxes__label"
+                htmlFor="checkbox-0"
+              >
+                <span
+                  className="govuk-!-font-weight-bold"
+                >
+                   
+                  Onboard (cash)
+                   
+                </span>
+                 -
+                 
+                Purchasable on board the bus, with cash, as a paper ticket.
+              </label>
+            </div>
+            <div
+              className="govuk-checkboxes__item"
+              key="checkbox-item-Onboard (contactless)"
+            >
+              <input
+                className="govuk-checkboxes__input"
+                id="checkbox-1"
+                name="Onboard (contactless)"
+                type="checkbox"
+                value="{\\"name\\":\\"Onboard (contactless)\\",\\"description\\":\\"Purchasable on board the bus, with a contactless card or device, as a paper ticket.\\",\\"purchaseLocations\\":[\\"onBoard\\"],\\"paymentMethods\\":[\\"contactlessPaymentCard\\"],\\"ticketFormats\\":[\\"paperTicket\\"]}"
+              />
+              <label
+                className="govuk-label govuk-checkboxes__label"
+                htmlFor="checkbox-1"
+              >
+                <span
+                  className="govuk-!-font-weight-bold"
+                >
+                   
+                  Onboard (contactless)
+                   
+                </span>
+                 -
+                 
+                Purchasable on board the bus, with a contactless card or device, as a paper ticket.
+              </label>
+            </div>
+            <div
+              className="govuk-checkboxes__item"
+              key="checkbox-item-Online (smart card)"
+            >
+              <input
+                className="govuk-checkboxes__input"
+                id="checkbox-2"
+                name="Online (smart card)"
+                type="checkbox"
+                value="{\\"name\\":\\"Online (smart card)\\",\\"description\\":\\"Purchasable online, with a debit/credit card or direct debit transaction, on a smart card or similar.\\",\\"purchaseLocations\\":[\\"online\\"],\\"paymentMethods\\":[\\"directDebit\\",\\"creditCard\\",\\"debitCard\\"],\\"ticketFormats\\":[\\"smartCard\\"]}"
+              />
+              <label
+                className="govuk-label govuk-checkboxes__label"
+                htmlFor="checkbox-2"
+              >
+                <span
+                  className="govuk-!-font-weight-bold"
+                >
+                   
+                  Online (smart card)
+                   
+                </span>
+                 -
+                 
+                Purchasable online, with a debit/credit card or direct debit transaction, on a smart card or similar.
+              </label>
+            </div>
+            <div
+              className="govuk-checkboxes__item"
+              key="checkbox-item-Mobile App"
+            >
+              <input
+                className="govuk-checkboxes__input"
+                id="checkbox-3"
+                name="Mobile App"
+                type="checkbox"
+                value="{\\"name\\":\\"Mobile App\\",\\"description\\":\\"Purchasable on a mobile device application, with a debit/credit card or direct debit transaction, stored on the mobile application.\\",\\"purchaseLocations\\":[\\"mobileDevice\\"],\\"paymentMethods\\":[\\"debitCard\\",\\"creditCard\\",\\"mobilePhone\\",\\"directDebit\\"],\\"ticketFormats\\":[\\"mobileApp\\"]}"
+              />
+              <label
+                className="govuk-label govuk-checkboxes__label"
+                htmlFor="checkbox-3"
+              >
+                <span
+                  className="govuk-!-font-weight-bold"
+                >
+                   
+                  Mobile App
+                   
+                </span>
+                 -
+                 
+                Purchasable on a mobile device application, with a debit/credit card or direct debit transaction, stored on the mobile application.
+              </label>
+            </div>
+          </div>
         </FormElementWrapper>
       </fieldset>
     </div>

--- a/tests/pages/selectSalesOfferPackage.test.tsx
+++ b/tests/pages/selectSalesOfferPackage.test.tsx
@@ -3,6 +3,10 @@ import { shallow } from 'enzyme';
 import SelectSalesOfferPackage, {
     SelectSalesOfferPackageProps,
     getServerSideProps,
+    defaultSalesOfferPackageOne,
+    defaultSalesOfferPackageTwo,
+    defaultSalesOfferPackageThree,
+    defaultSalesOfferPackageFour,
 } from '../../src/pages/selectSalesOfferPackage';
 import { getMockContext } from '../testData/mockData';
 import { getSalesOfferPackagesByNocCode } from '../../src/data/auroradb';
@@ -12,30 +16,46 @@ jest.mock('../../src/data/auroradb');
 
 describe('pages', () => {
     const selectSalesOfferPackagePropsInfoNoError: SelectSalesOfferPackageProps = {
-        salesOfferPackagesList: [],
-        error: [],
+        salesOfferPackagesList: [
+            defaultSalesOfferPackageOne,
+            defaultSalesOfferPackageTwo,
+            defaultSalesOfferPackageThree,
+            defaultSalesOfferPackageFour,
+        ],
+        errors: [],
     };
 
     const selectSalesOfferPackagePropsInfoWithError: SelectSalesOfferPackageProps = {
-        salesOfferPackagesList: [],
-        error: [{ errorMessage: 'Choose at least one service from the options', id: 'sales-offer-package-error' }],
+        salesOfferPackagesList: [
+            defaultSalesOfferPackageOne,
+            defaultSalesOfferPackageTwo,
+            defaultSalesOfferPackageThree,
+            defaultSalesOfferPackageFour,
+        ],
+        errors: [{ errorMessage: 'Choose at least one service from the options', id: 'sales-offer-package-error' }],
     };
 
     describe('serviceList', () => {
         it('should render correctly', () => {
-            // eslint-disable-next-line react/jsx-props-no-spreading
             const tree = shallow(
-                // eslint-disable-next-line react/jsx-props-no-spreading
-                <SelectSalesOfferPackage {...selectSalesOfferPackagePropsInfoNoError} csrfToken="" pageProps={[]} />,
+                <SelectSalesOfferPackage
+                    salesOfferPackagesList={selectSalesOfferPackagePropsInfoNoError.salesOfferPackagesList}
+                    errors={selectSalesOfferPackagePropsInfoNoError.errors}
+                    csrfToken=""
+                    pageProps={[]}
+                />,
             );
             expect(tree).toMatchSnapshot();
         });
 
         it('should render an error when an error message is passed through to props', () => {
-            // eslint-disable-next-line react/jsx-props-no-spreading
             const tree = shallow(
-                // eslint-disable-next-line react/jsx-props-no-spreading
-                <SelectSalesOfferPackage {...selectSalesOfferPackagePropsInfoWithError} csrfToken="" pageProps={[]} />,
+                <SelectSalesOfferPackage
+                    salesOfferPackagesList={selectSalesOfferPackagePropsInfoWithError.salesOfferPackagesList}
+                    errors={selectSalesOfferPackagePropsInfoWithError.errors}
+                    csrfToken=""
+                    pageProps={[]}
+                />,
             );
             expect(tree).toMatchSnapshot();
         });
@@ -75,7 +95,7 @@ describe('pages', () => {
                         };
                     },
                 );
-                expect(result.props.error.length).toBe(0);
+                expect(result.props.errors.length).toBe(0);
                 expect(result.props.salesOfferPackagesList).toEqual(expectedSalesOfferPackageList);
             });
 


### PR DESCRIPTION
# Description

-   This PR removes excess commas found in the predefined sales offer packages we offer to a user. These commas were causing the generated NeTEx to fail validation

# Testing instructions

-   Pull down this branch and run the site locally. Run through a user journey on the site and validate that the purchaseLocations within each sales offer package of the matching json do not contain excess commas.

# Type of change

-   [ ] feat - A new feature
-   [X] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [ ] Lighthouse performed (Accessibility 90+ minimum)
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
