### PR TITLE
fix: hardcode index to zero for single products in the SOP page

### DIFF
--- a/src/pages/selectSalesOfferPackage.tsx
+++ b/src/pages/selectSalesOfferPackage.tsx
@@ -58,8 +58,8 @@ export interface SelectSalesOfferPackageProps {
 
 const generateCheckbox = (
     salesOfferPackagesList: SalesOfferPackage[],
-    productName?: string,
     productIndex?: number,
+    productName?: string,
     selected?: { [key: string]: string },
 ): ReactElement[] => {
     return salesOfferPackagesList.map((offer, index) => {
@@ -114,13 +114,13 @@ const createSalesOffer = (
             return (
                 <>
                     <p className="govuk-body govuk-!-font-weight-bold content-one-quarter">{productName}</p>
-                    {generateCheckbox(salesOfferPackagesList, productName, index, selected)}
+                    {generateCheckbox(salesOfferPackagesList, index, productName, selected)}
                 </>
             );
         });
     }
 
-    return generateCheckbox(salesOfferPackagesList);
+    return generateCheckbox(salesOfferPackagesList, 0);
 };
 
 const SelectSalesOfferPackage = ({

--- a/src/pages/selectSalesOfferPackage.tsx
+++ b/src/pages/selectSalesOfferPackage.tsx
@@ -58,7 +58,7 @@ export interface SelectSalesOfferPackageProps {
 
 const generateCheckbox = (
     salesOfferPackagesList: SalesOfferPackage[],
-    productIndex?: number,
+    productIndex: number,
     productName?: string,
     selected?: { [key: string]: string },
 ): ReactElement[] => {

--- a/tests/pages/__snapshots__/selectSalesOfferPackage.test.tsx.snap
+++ b/tests/pages/__snapshots__/selectSalesOfferPackage.test.tsx.snap
@@ -113,7 +113,7 @@ exports[`pages serviceList should render an error when an error message is passe
               <input
                 className="govuk-checkboxes__input"
                 defaultChecked={false}
-                id="product-undefined-checkbox-0"
+                id="product-0-checkbox-0"
                 name="Onboard (cash)"
                 type="checkbox"
                 value="{\\"name\\":\\"Onboard (cash)\\",\\"description\\":\\"Purchasable on board the bus, with cash, as a paper ticket.\\",\\"purchaseLocations\\":[\\"onBoard\\"],\\"paymentMethods\\":[\\"cash\\"],\\"ticketFormats\\":[\\"paperTicket\\"]}"
@@ -132,7 +132,7 @@ exports[`pages serviceList should render an error when an error message is passe
               <input
                 className="govuk-checkboxes__input"
                 defaultChecked={false}
-                id="product-undefined-checkbox-1"
+                id="product-0-checkbox-1"
                 name="Onboard (contactless)"
                 type="checkbox"
                 value="{\\"name\\":\\"Onboard (contactless)\\",\\"description\\":\\"Purchasable on board the bus, with a contactless card or device, as a paper ticket.\\",\\"purchaseLocations\\":[\\"onBoard\\"],\\"paymentMethods\\":[\\"contactlessPaymentCard\\"],\\"ticketFormats\\":[\\"paperTicket\\"]}"
@@ -151,7 +151,7 @@ exports[`pages serviceList should render an error when an error message is passe
               <input
                 className="govuk-checkboxes__input"
                 defaultChecked={false}
-                id="product-undefined-checkbox-2"
+                id="product-0-checkbox-2"
                 name="Online (smart card)"
                 type="checkbox"
                 value="{\\"name\\":\\"Online (smart card)\\",\\"description\\":\\"Purchasable online, with a debit/credit card or direct debit transaction, on a smart card or similar.\\",\\"purchaseLocations\\":[\\"online\\"],\\"paymentMethods\\":[\\"directDebit\\",\\"creditCard\\",\\"debitCard\\"],\\"ticketFormats\\":[\\"smartCard\\"]}"
@@ -170,7 +170,7 @@ exports[`pages serviceList should render an error when an error message is passe
               <input
                 className="govuk-checkboxes__input"
                 defaultChecked={false}
-                id="product-undefined-checkbox-3"
+                id="product-0-checkbox-3"
                 name="Mobile App"
                 type="checkbox"
                 value="{\\"name\\":\\"Mobile App\\",\\"description\\":\\"Purchasable on a mobile device application, with a debit/credit card or direct debit transaction, stored on the mobile application.\\",\\"purchaseLocations\\":[\\"mobileDevice\\"],\\"paymentMethods\\":[\\"debitCard\\",\\"creditCard\\",\\"mobilePhone\\",\\"directDebit\\"],\\"ticketFormats\\":[\\"mobileApp\\"]}"
@@ -303,7 +303,7 @@ exports[`pages serviceList should render correctly 1`] = `
               <input
                 className="govuk-checkboxes__input"
                 defaultChecked={false}
-                id="product-undefined-checkbox-0"
+                id="product-0-checkbox-0"
                 name="Onboard (cash)"
                 type="checkbox"
                 value="{\\"name\\":\\"Onboard (cash)\\",\\"description\\":\\"Purchasable on board the bus, with cash, as a paper ticket.\\",\\"purchaseLocations\\":[\\"onBoard\\"],\\"paymentMethods\\":[\\"cash\\"],\\"ticketFormats\\":[\\"paperTicket\\"]}"
@@ -322,7 +322,7 @@ exports[`pages serviceList should render correctly 1`] = `
               <input
                 className="govuk-checkboxes__input"
                 defaultChecked={false}
-                id="product-undefined-checkbox-1"
+                id="product-0-checkbox-1"
                 name="Onboard (contactless)"
                 type="checkbox"
                 value="{\\"name\\":\\"Onboard (contactless)\\",\\"description\\":\\"Purchasable on board the bus, with a contactless card or device, as a paper ticket.\\",\\"purchaseLocations\\":[\\"onBoard\\"],\\"paymentMethods\\":[\\"contactlessPaymentCard\\"],\\"ticketFormats\\":[\\"paperTicket\\"]}"
@@ -341,7 +341,7 @@ exports[`pages serviceList should render correctly 1`] = `
               <input
                 className="govuk-checkboxes__input"
                 defaultChecked={false}
-                id="product-undefined-checkbox-2"
+                id="product-0-checkbox-2"
                 name="Online (smart card)"
                 type="checkbox"
                 value="{\\"name\\":\\"Online (smart card)\\",\\"description\\":\\"Purchasable online, with a debit/credit card or direct debit transaction, on a smart card or similar.\\",\\"purchaseLocations\\":[\\"online\\"],\\"paymentMethods\\":[\\"directDebit\\",\\"creditCard\\",\\"debitCard\\"],\\"ticketFormats\\":[\\"smartCard\\"]}"
@@ -360,7 +360,7 @@ exports[`pages serviceList should render correctly 1`] = `
               <input
                 className="govuk-checkboxes__input"
                 defaultChecked={false}
-                id="product-undefined-checkbox-3"
+                id="product-0-checkbox-3"
                 name="Mobile App"
                 type="checkbox"
                 value="{\\"name\\":\\"Mobile App\\",\\"description\\":\\"Purchasable on a mobile device application, with a debit/credit card or direct debit transaction, stored on the mobile application.\\",\\"purchaseLocations\\":[\\"mobileDevice\\"],\\"paymentMethods\\":[\\"debitCard\\",\\"creditCard\\",\\"mobilePhone\\",\\"directDebit\\"],\\"ticketFormats\\":[\\"mobileApp\\"]}"


### PR DESCRIPTION
# Description

-   When the generate checkboxes method was running, if there was only a single product then there was no index being passed to the method, as it was optional. This meant that for a single product, the id's were including 'undefined' in them, which is not ideal and also makes the UI tests not work.

# Testing instructions

-   Run site locally, go to single product SOP page, and observe id's are correct.

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Lighthouse performed (Accessibility 90+ minimum)
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
-   [snapshots] I have added tests that prove my fix is effective or that my feature works
