### PR TITLE
Remove proof for adult and infant in group passenger types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14854,9 +14854,12 @@
             "integrity": "sha1-1WgS4cAXpuTnw+Ojeh2m143TyT4="
         },
         "serialize-javascript": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-            "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
+            "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+            "requires": {
+                "randombytes": "^2.1.0"
+            }
         },
         "serve-static": {
             "version": "1.14.1",
@@ -15860,15 +15863,15 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-            "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.4.tgz",
+            "integrity": "sha512-U4mACBHIegmfoEe5fdongHESNJWqsGU+W0S/9+BmYGVQDw1+c2Ow05TpMhxjPK1sRb7cuYq1BPl1e5YHJMTCqA==",
             "requires": {
                 "cacache": "^12.0.2",
                 "find-cache-dir": "^2.1.0",
                 "is-wsl": "^1.1.0",
                 "schema-utils": "^1.0.0",
-                "serialize-javascript": "^2.1.2",
+                "serialize-javascript": "^3.1.0",
                 "source-map": "^0.6.1",
                 "terser": "^4.1.2",
                 "webpack-sources": "^1.4.0",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -109,5 +109,3 @@ export const PASSENGER_TYPES_WITH_GROUP: PassengerAttributes[] = [
     { passengerTypeDisplay: 'Group (more than one passenger)', passengerTypeValue: 'group' },
     ...PASSENGER_TYPES_LIST,
 ];
-
-export const NO_PROOF_REQUIRED = ['infant', 'adult'];

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -109,3 +109,5 @@ export const PASSENGER_TYPES_WITH_GROUP: PassengerAttributes[] = [
     { passengerTypeDisplay: 'Group (more than one passenger)', passengerTypeValue: 'group' },
     ...PASSENGER_TYPES_LIST,
 ];
+
+export const NO_PROOF_REQUIRED = ['infant', 'adult'];

--- a/src/pages/api/definePassengerType.ts
+++ b/src/pages/api/definePassengerType.ts
@@ -15,7 +15,6 @@ import {
     GROUP_PASSENGER_TYPES_ATTRIBUTE,
     PASSENGER_TYPE_COOKIE,
     GROUP_SIZE_ATTRIBUTE,
-    NO_PROOF_REQUIRED,
 } from '../../constants/index';
 import { isSessionValid } from './apiUtils/validator';
 import { ErrorInfo, NextApiRequestWithSession } from '../../interfaces';
@@ -105,7 +104,7 @@ export const passengerTypeDetailsSchema = yup
             .oneOf(['Yes', 'No'])
             .required(radioButtonError),
         proof: yup.string().when('groupPassengerType', {
-            is: groupPassengerTypeNameValue => !NO_PROOF_REQUIRED.includes(groupPassengerTypeNameValue),
+            is: groupPassengerTypeNameValue => groupPassengerTypeNameValue !== 'adult',
             then: yup
                 .string()
                 .oneOf(['Yes', 'No'])

--- a/src/pages/api/definePassengerType.ts
+++ b/src/pages/api/definePassengerType.ts
@@ -15,6 +15,7 @@ import {
     GROUP_PASSENGER_TYPES_ATTRIBUTE,
     PASSENGER_TYPE_COOKIE,
     GROUP_SIZE_ATTRIBUTE,
+    NO_PROOF_REQUIRED,
 } from '../../constants/index';
 import { isSessionValid } from './apiUtils/validator';
 import { ErrorInfo, NextApiRequestWithSession } from '../../interfaces';
@@ -32,7 +33,6 @@ interface FilteredRequestBody {
     proofDocuments?: string[];
 }
 
-export const noProofRequired = ['infant', 'adult'];
 const radioButtonError = 'Choose one of the options below';
 const ageRangeNumberError = 'Enter a whole number between 0-150';
 const numberOfPassengersError = 'Enter a whole number between 0 and your max group size';
@@ -104,8 +104,8 @@ export const passengerTypeDetailsSchema = yup
             .string()
             .oneOf(['Yes', 'No'])
             .required(radioButtonError),
-        proof: yup.string().when('groupPassengerTypeName', {
-            is: groupPassengerTypeNameValue => !noProofRequired.includes(groupPassengerTypeNameValue),
+        proof: yup.string().when('groupPassengerType', {
+            is: groupPassengerTypeNameValue => !NO_PROOF_REQUIRED.includes(groupPassengerTypeNameValue),
             then: yup
                 .string()
                 .oneOf(['Yes', 'No'])

--- a/src/pages/api/definePassengerType.ts
+++ b/src/pages/api/definePassengerType.ts
@@ -32,6 +32,7 @@ interface FilteredRequestBody {
     proofDocuments?: string[];
 }
 
+export const noProofRequired = ['infant', 'adult'];
 const radioButtonError = 'Choose one of the options below';
 const ageRangeNumberError = 'Enter a whole number between 0-150';
 const numberOfPassengersError = 'Enter a whole number between 0 and your max group size';
@@ -103,10 +104,13 @@ export const passengerTypeDetailsSchema = yup
             .string()
             .oneOf(['Yes', 'No'])
             .required(radioButtonError),
-        proof: yup
-            .string()
-            .oneOf(['Yes', 'No'])
-            .required(radioButtonError),
+        proof: yup.string().when('groupPassengerTypeName', {
+            is: groupPassengerTypeNameValue => !noProofRequired.includes(groupPassengerTypeNameValue),
+            then: yup
+                .string()
+                .oneOf(['Yes', 'No'])
+                .required(radioButtonError),
+        }),
         ageRangeMin: yup.number().when('ageRange', {
             is: 'Yes',
             then: yup

--- a/src/pages/definePassengerType.tsx
+++ b/src/pages/definePassengerType.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { parseCookies } from 'nookies';
 import TwoThirdsLayout from '../layout/Layout';
-import { PASSENGER_TYPE_COOKIE, GROUP_PASSENGER_TYPES_ATTRIBUTE } from '../constants';
+import { PASSENGER_TYPE_COOKIE, GROUP_PASSENGER_TYPES_ATTRIBUTE, NO_PROOF_REQUIRED } from '../constants';
 import ErrorSummary from '../components/ErrorSummary';
 import RadioConditionalInput, {
     RadioConditionalInputFieldset,
@@ -52,7 +52,11 @@ export const getErrorsByIds = (ids: string[], errors: ErrorInfo[]): ErrorInfo[] 
     return compactErrors;
 };
 
-export const getFieldsets = (errors: ErrorInfo[], passengerType?: string): RadioConditionalInputFieldset[] => {
+export const getFieldsets = (
+    errors: ErrorInfo[],
+    passengerType?: string,
+    group?: false,
+): RadioConditionalInputFieldset[] => {
     const fieldsets = [];
 
     const ageRangeFieldset: RadioConditionalInputFieldset = {
@@ -148,7 +152,11 @@ export const getFieldsets = (errors: ErrorInfo[], passengerType?: string): Radio
 
     fieldsets.push(ageRangeFieldset);
 
-    if (passengerType !== 'adult' && passengerType !== 'infant') {
+    console.log('group', group);
+    console.log('passengerType', passengerType);
+    console.log('!NO_PROOF_REQUIRED.includes(passengerType))', !NO_PROOF_REQUIRED.includes(passengerType));
+    if (!group || (group && passengerType && !NO_PROOF_REQUIRED.includes(passengerType))) {
+
         fieldsets.push(proofRequiredFieldset);
     }
 
@@ -286,8 +294,9 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: De
     const group = !!groupPassengerTypes;
 
     if (group) {
+        console.log('group', group);
         const groupPassengerType = ctx.query.groupPassengerType as string;
-        fieldsets = getFieldsets(errors, groupPassengerType);
+        fieldsets = getFieldsets(errors, groupPassengerType, group);
         numberOfPassengerTypeFieldset = getNumberOfPassengerTypeFieldset(errors, groupPassengerType);
 
         return {

--- a/src/pages/definePassengerType.tsx
+++ b/src/pages/definePassengerType.tsx
@@ -145,7 +145,13 @@ export const getFieldsets = (errors: ErrorInfo[], passengerType?: string): Radio
         ],
         radioError: getErrorsByIds(['define-passenger-proof'], errors),
     };
-    fieldsets.push(ageRangeFieldset, proofRequiredFieldset);
+
+    fieldsets.push(ageRangeFieldset);
+
+    if (passengerType !== 'adult' && passengerType !== 'infant') {
+        fieldsets.push(proofRequiredFieldset);
+    }
+
     return fieldsets;
 };
 

--- a/tests/pages/definePassengerType.test.tsx
+++ b/tests/pages/definePassengerType.test.tsx
@@ -64,11 +64,11 @@ describe('pages', () => {
         });
 
         it('should alter the heading content when a passenger type is provided', () => {
-            const passengerType = 'adult';
+            const passengerType = 'child';
             const emptyErrors: ErrorInfo[] = [];
             const fieldsets = getFieldsets(emptyErrors, passengerType);
-            expect(fieldsets[0].heading.content).toEqual('Do adult passengers have an age range?');
-            expect(fieldsets[1].heading.content).toEqual('Do adult passengers require a proof document?');
+            expect(fieldsets[0].heading.content).toEqual('Do child passengers have an age range?');
+            expect(fieldsets[1].heading.content).toEqual('Do child passengers require a proof document?');
         });
     });
 
@@ -91,7 +91,7 @@ describe('pages', () => {
                     errorMessage: 'Enter a number between 1 and 30',
                 },
             ];
-            const passengerType = 'adult';
+            const passengerType = 'child';
             const fieldset = getNumberOfPassengerTypeFieldset(errors, passengerType);
             expect(fieldset).toEqual(mockNumberOfPassengerTypeFieldsetWithErrors);
         });
@@ -174,7 +174,7 @@ describe('pages', () => {
                 url: '/definePassengerType?groupPassengerType=adult',
                 cookies: {
                     passengerType: {
-                        passengerType: 'adult',
+                        passengerType: 'child',
                         errors,
                     },
                 },
@@ -194,7 +194,7 @@ describe('pages', () => {
                     },
                 },
                 query: {
-                    groupPassengerType: 'adult',
+                    groupPassengerType: 'child',
                 },
             });
             const result = getServerSideProps(ctx);

--- a/tests/pages/definePassengerType.test.tsx
+++ b/tests/pages/definePassengerType.test.tsx
@@ -70,6 +70,22 @@ describe('pages', () => {
             expect(fieldsets[0].heading.content).toEqual('Do child passengers have an age range?');
             expect(fieldsets[1].heading.content).toEqual('Do child passengers require a proof document?');
         });
+
+        it('should not show the proof of documents if passenger types is infant', () => {
+            const passengerType = 'infant';
+            const emptyErrors: ErrorInfo[] = [];
+            const fieldsets = getFieldsets(emptyErrors, passengerType);
+
+            expect(fieldsets.length).toEqual(1);
+        });
+
+        it('should not show the proof of documents if passenger types is adult', () => {
+            const passengerType = 'adult';
+            const emptyErrors: ErrorInfo[] = [];
+            const fieldsets = getFieldsets(emptyErrors, passengerType);
+
+            expect(fieldsets.length).toEqual(1);
+        });
     });
 
     describe('getNumberOfPassengerTypeFieldset', () => {

--- a/tests/pages/definePassengerType.test.tsx
+++ b/tests/pages/definePassengerType.test.tsx
@@ -72,15 +72,6 @@ describe('pages', () => {
             expect(fieldsets[1].heading.content).toEqual('Do child passengers require a proof document?');
         });
 
-        it.only('should not show the proof of documents if passenger types is infant', () => {
-            const passengerType = 'infant';
-            const emptyErrors: ErrorInfo[] = [];
-            const fieldsets = getFieldsets(emptyErrors, passengerType);
-
-            console.log('fields', fieldsets);
-            expect(fieldsets.length).toEqual(1);
-        });
-
         it('should not show the proof of documents if passenger types is adult', () => {
             const passengerType = 'adult';
             const emptyErrors: ErrorInfo[] = [];
@@ -88,6 +79,14 @@ describe('pages', () => {
 
             expect(fieldsets.length).toEqual(1);
         });
+
+        // it('should show the proof field if passenger type is any apart from adult', () => {
+        //     const passengerType = 'child';
+        //     const emptyErrors: ErrorInfo[] = [];
+        //     const fieldsets = getFieldsets(emptyErrors, passengerType);
+        //
+        //     expect(fieldsets.length).toEqual(2);
+        // });
     });
 
     describe('getNumberOfPassengerTypeFieldset', () => {
@@ -130,7 +129,7 @@ describe('pages', () => {
             [
                 'group',
                 {
-                    cookies: { passengerType: null },
+                    cookies: { passengerType: 'child' },
                     session: {
                         [GROUP_PASSENGER_TYPES_ATTRIBUTE]: ['adult', 'child'],
                     },
@@ -161,7 +160,7 @@ describe('pages', () => {
             const ctx = getMockContext({
                 cookies: {
                     passengerType: {
-                        passengerType: 'adult',
+                        passengerType: 'child',
                         errors,
                     },
                 },

--- a/tests/pages/definePassengerType.test.tsx
+++ b/tests/pages/definePassengerType.test.tsx
@@ -20,11 +20,13 @@ import {
 import { ErrorInfo } from '../../src/interfaces';
 import { GROUP_PASSENGER_TYPES_ATTRIBUTE, GROUP_DEFINITION_ATTRIBUTE } from '../../src/constants';
 
+const defaultPassengerType = 'child';
+
 describe('pages', () => {
     describe('getFieldsets', () => {
         it('should return fieldsets with no errors when no errors are passed', () => {
             const emptyErrors: ErrorInfo[] = [];
-            const fieldsets = getFieldsets(emptyErrors);
+            const fieldsets = getFieldsets(emptyErrors, defaultPassengerType);
             expect(fieldsets).toEqual(mockDefinePassengerTypeFieldsets);
         });
 
@@ -64,18 +66,18 @@ describe('pages', () => {
         });
 
         it('should alter the heading content when a passenger type is provided', () => {
-            const passengerType = 'child';
             const emptyErrors: ErrorInfo[] = [];
-            const fieldsets = getFieldsets(emptyErrors, passengerType);
+            const fieldsets = getFieldsets(emptyErrors, defaultPassengerType);
             expect(fieldsets[0].heading.content).toEqual('Do child passengers have an age range?');
             expect(fieldsets[1].heading.content).toEqual('Do child passengers require a proof document?');
         });
 
-        it('should not show the proof of documents if passenger types is infant', () => {
+        it.only('should not show the proof of documents if passenger types is infant', () => {
             const passengerType = 'infant';
             const emptyErrors: ErrorInfo[] = [];
             const fieldsets = getFieldsets(emptyErrors, passengerType);
 
+            console.log('fields', fieldsets);
             expect(fieldsets.length).toEqual(1);
         });
 
@@ -91,8 +93,7 @@ describe('pages', () => {
     describe('getNumberOfPassengerTypeFieldset', () => {
         it('should return a fieldset containing two text inputs with no errors when no errors are passed', () => {
             const errors: ErrorInfo[] = [];
-            const passengerType = 'child';
-            const fieldset = getNumberOfPassengerTypeFieldset(errors, passengerType);
+            const fieldset = getNumberOfPassengerTypeFieldset(errors, defaultPassengerType);
             expect(fieldset).toEqual(mockNumberOfPassengerTypeFieldset);
         });
 
@@ -107,8 +108,7 @@ describe('pages', () => {
                     errorMessage: 'Enter a number between 1 and 30',
                 },
             ];
-            const passengerType = 'child';
-            const fieldset = getNumberOfPassengerTypeFieldset(errors, passengerType);
+            const fieldset = getNumberOfPassengerTypeFieldset(errors, defaultPassengerType);
             expect(fieldset).toEqual(mockNumberOfPassengerTypeFieldsetWithErrors);
         });
     });

--- a/tests/testData/mockData.ts
+++ b/tests/testData/mockData.ts
@@ -2496,7 +2496,7 @@ export const mockNumberOfPassengerTypeFieldset: TextInputFieldset = {
 export const mockNumberOfPassengerTypeFieldsetWithErrors: TextInputFieldset = {
     heading: {
         id: 'number-of-passenger-type-heading',
-        content: 'How many adult passengers can be in the group?',
+        content: 'How many child passengers can be in the group?',
     },
     inputs: [
         {


### PR DESCRIPTION
# Description

For infant and adult in group passenger types the proof option is not required when defining the passengers.

# Testing instructions

- Select a faretype
- Once submitted change the url to http://localhost:5555/groupPassengerTypes
- Select adult, infant and continue
- for adult and infant the options should not show for proof
- Try the above again but select child and adult and the child should see the proof option


# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [ ] Lighthouse performed (Accessibility 90+ minimum)
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
