### PR TITLE
fix: CSV duplicate fare stage names 

### DIFF
--- a/src/pages/api/csvUpload.ts
+++ b/src/pages/api/csvUpload.ts
@@ -41,9 +41,8 @@ export const setUploadCookieAndRedirect = (req: NextApiRequest, res: NextApiResp
     }
 };
 
-export const containsDuplicateFareStages = (fareStageNames: string[]): boolean => {
-    return uniq(fareStageNames).length !== fareStageNames.length;
-};
+export const containsDuplicateFareStages = (fareStageNames: string[]): boolean =>
+    uniq(fareStageNames).length !== fareStageNames.length;
 
 export const faresTriangleDataMapper = (
     dataToMap: string,
@@ -110,9 +109,7 @@ export const faresTriangleDataMapper = (
         })),
     };
 
-    const fareStageNames: string[] = mappedFareTriangle.fareStages.map(fareStage => {
-        return fareStage.stageName;
-    });
+    const fareStageNames: string[] = mappedFareTriangle.fareStages.map(fareStage => fareStage.stageName);
 
     if (containsDuplicateFareStages(fareStageNames)) {
         logger.warn('', {

--- a/src/pages/api/csvUpload.ts
+++ b/src/pages/api/csvUpload.ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import Cookies from 'cookies';
+import uniq from 'lodash/uniq';
 import {
     getUuidFromCookie,
     redirectToError,
@@ -38,6 +39,10 @@ export const setUploadCookieAndRedirect = (req: NextApiRequest, res: NextApiResp
     if (error) {
         redirectTo(res, '/csvUpload');
     }
+};
+
+export const containsDuplicateFareStages = (fareStageNames: string[]): boolean => {
+    return uniq(fareStageNames).length !== fareStageNames.length;
 };
 
 export const faresTriangleDataMapper = (
@@ -104,6 +109,20 @@ export const faresTriangleDataMapper = (
             prices: Object.values(item.prices),
         })),
     };
+
+    const fareStageNames: string[] = mappedFareTriangle.fareStages.map(fareStage => {
+        return fareStage.stageName;
+    });
+
+    if (containsDuplicateFareStages(fareStageNames)) {
+        logger.warn('', {
+            context: 'api.csvUpload',
+            message: `Duplicate fare stage names found, fare stage names: ${fareStageNames}`,
+        });
+
+        setUploadCookieAndRedirect(req, res, 'Fare stage names cannot be the same');
+        return null;
+    }
 
     const numberOfPrices = mappedFareTriangle.fareStages.flatMap(stage =>
         stage.prices.flatMap(price => price.fareZones),

--- a/tests/testData/csvFareTriangleData.ts
+++ b/tests/testData/csvFareTriangleData.ts
@@ -7,6 +7,15 @@ export const testCsv: string =
     'Blossom Street,170,170,110,110,100,Blossom Street,,\n' +
     'Rail Station (York),170,170,170,170,100,100,Rail Station (York),\n' +
     'Piccadilly (York),170,170,170,170,100,100,100,Piccadilly (York)';
+export const testCsvDuplicateFareStages: string =
+    ',Acomb Green Lane,,,,,,,\n' +
+    'Mattison Way,110,Mattison Way,,,,,,\n' +
+    'Nursery Drive,110,110,Nursery Drive,,,,,\n' +
+    'Holl Bank/Beech Ave,110,110,110,Holl Bank/Beech Ave,,,,\n' +
+    'Cambridge Street (York),170,170,110,110,Cambridge Street (York),,,\n' +
+    'Nursery Drive,170,170,110,110,100,Nursery Drive,,\n' +
+    'Rail Station (York),170,170,170,170,100,100,Rail Station (York),\n' +
+    'Piccadilly (York),170,170,170,170,100,100,100,Piccadilly (York)';
 
 export const testCsvWithEmptyLines: string =
     ',Acomb Green Lane,,,,,,,\n' +


### PR DESCRIPTION
# Description

-  Users were creating invalid Netex because the site allowed them to upload CSV's with duplicate fare stage names. This fix prevents that.

# Testing instructions

-   Run site through dev repo and attempt to upload a csv with duplicate fare stage names.

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [ ] Lighthouse performed (Accessibility 90+ minimum)
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
