### PR TITLE
Feature/tfn 629 multiple noc reg

### DIFF
--- a/src/pages/api/register.ts
+++ b/src/pages/api/register.ts
@@ -85,7 +85,11 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
             if (ChallengeName === 'NEW_PASSWORD_REQUIRED' && ChallengeParameters?.userAttributes && Session) {
                 const parameters = JSON.parse(ChallengeParameters.userAttributes);
 
-                if (!parameters['custom:noc'] || parameters['custom:noc'] !== nocCode) {
+                const cognitoNocs: string[] = parameters['custom:noc'].split('|');
+
+                const valid: boolean = cognitoNocs.includes(nocCode);
+
+                if (cognitoNocs.length === 0 || !valid) {
                     logger.warn('', {
                         context: 'api.register',
                         message: 'NOC does not match',

--- a/src/pages/api/register.ts
+++ b/src/pages/api/register.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { isArray } from 'lodash';
+import isArray from 'lodash/isArray';
 import { redirectTo, redirectToError, setCookieOnResponseObject, checkEmailValid } from './apiUtils';
 import { USER_COOKIE } from '../../constants';
 import { InputCheck } from '../../interfaces';
@@ -86,7 +86,7 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
             if (ChallengeName === 'NEW_PASSWORD_REQUIRED' && ChallengeParameters?.userAttributes && Session) {
                 const parameters = JSON.parse(ChallengeParameters.userAttributes);
 
-                const cognitoNocs: string[] = parameters['custom:noc'].split('|');
+                const cognitoNocs: string[] | string = parameters['custom:noc'].split('|');
 
                 let valid = false;
 

--- a/src/pages/api/register.ts
+++ b/src/pages/api/register.ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
+import { isArray } from 'lodash';
 import { redirectTo, redirectToError, setCookieOnResponseObject, checkEmailValid } from './apiUtils';
 import { USER_COOKIE } from '../../constants';
 import { InputCheck } from '../../interfaces';
@@ -87,7 +88,13 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
 
                 const cognitoNocs: string[] = parameters['custom:noc'].split('|');
 
-                const valid: boolean = cognitoNocs.includes(nocCode);
+                let valid = false;
+
+                if (isArray(cognitoNocs)) {
+                    valid = cognitoNocs.includes(nocCode);
+                } else {
+                    valid = cognitoNocs === nocCode;
+                }
 
                 if (cognitoNocs.length === 0 || !valid) {
                     logger.warn('', {

--- a/tests/pages/api/register.test.ts
+++ b/tests/pages/api/register.test.ts
@@ -8,18 +8,18 @@ import { USER_COOKIE } from '../../../src/constants';
 
 jest.mock('../../../src/data/auroradb.ts');
 
-const mockAuthResponse: CognitoIdentityServiceProvider.AdminInitiateAuthResponse = {
-    ChallengeName: 'NEW_PASSWORD_REQUIRED',
-    ChallengeParameters: {
-        USER_ID_FOR_SRP: 'd3eddd2a-a1c6-4201-82d3-bdab8dcbb586',
-        userAttributes: JSON.stringify({
-            'custom:noc': 'DCCL|TEST',
-        }),
-    },
-    Session: 'session',
-};
-
 describe('register', () => {
+    const mockAuthResponse: CognitoIdentityServiceProvider.AdminInitiateAuthResponse = {
+        ChallengeName: 'NEW_PASSWORD_REQUIRED',
+        ChallengeParameters: {
+            USER_ID_FOR_SRP: 'd3eddd2a-a1c6-4201-82d3-bdab8dcbb586',
+            userAttributes: JSON.stringify({
+                'custom:noc': 'DCCL',
+            }),
+        },
+        Session: 'session',
+    };
+
     const getServicesByNocCodeSpy = jest.spyOn(auroradb, 'getServicesByNocCode');
     const authSignInSpy = jest.spyOn(auth, 'initiateAuth');
     const authCompletePasswordSpy = jest.spyOn(auth, 'respondToNewPasswordChallenge');
@@ -398,6 +398,49 @@ describe('register', () => {
             Location: '/confirmRegistration',
         });
     });
+});
+
+describe('register pipe split logic', () => {
+    const mockAuthResponse: CognitoIdentityServiceProvider.AdminInitiateAuthResponse = {
+        ChallengeName: 'NEW_PASSWORD_REQUIRED',
+        ChallengeParameters: {
+            USER_ID_FOR_SRP: 'd3eddd2a-a1c6-4201-82d3-bdab8dcbb586',
+            userAttributes: JSON.stringify({
+                'custom:noc': 'DCCL|TEST|1234',
+            }),
+        },
+        Session: 'session',
+    };
+
+    const getServicesByNocCodeSpy = jest.spyOn(auroradb, 'getServicesByNocCode');
+    const authSignInSpy = jest.spyOn(auth, 'initiateAuth');
+    const authCompletePasswordSpy = jest.spyOn(auth, 'respondToNewPasswordChallenge');
+    const authUpdateAttributesSpy = jest.spyOn(auth, 'updateUserAttributes');
+    const authSignOutSpy = jest.spyOn(auth, 'globalSignOut');
+    const setCookieSpy = jest.spyOn(apiUtils, 'setCookieOnResponseObject');
+
+    beforeEach(() => {
+        authSignInSpy.mockImplementation(() => Promise.resolve(mockAuthResponse));
+        authCompletePasswordSpy.mockImplementation(() => Promise.resolve());
+        authSignOutSpy.mockImplementation(() => Promise.resolve());
+        authUpdateAttributesSpy.mockImplementation(() => Promise.resolve());
+        getServicesByNocCodeSpy.mockImplementation(() =>
+            Promise.resolve([
+                {
+                    lineName: '2AC',
+                    startDate: '01012020',
+                    description: 'linename for service ',
+                    serviceCode: 'NW_05_BLAC_2C_1',
+                },
+            ]),
+        );
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    const writeHeadMock = jest.fn();
 
     it('should split NOCs into seperate ones if seperated by a pipe, and check if the users matches any', async () => {
         const { req, res } = getMockRequestAndResponse({
@@ -429,5 +472,54 @@ describe('register', () => {
         expect(writeHeadMock).toBeCalledWith(302, {
             Location: '/confirmRegistration',
         });
+    });
+
+    it('should error if no NOCs match', async () => {
+        authSignInSpy.mockImplementation(() =>
+            Promise.resolve({
+                ChallengeName: 'NEW_PASSWORD_REQUIRED',
+                ChallengeParameters: {
+                    USER_ID_FOR_SRP: 'd3eddd2a-a1c6-4201-82d3-bdab8dcbb586',
+                    userAttributes: JSON.stringify({
+                        'custom:noc': 'FAKE',
+                    }),
+                },
+                Session: 'session',
+            }),
+        );
+
+        const mockUserCookieValue = {
+            inputChecks: [
+                {
+                    inputValue: 'test@test.com',
+                    id: 'email',
+                    error: '',
+                },
+                { inputValue: '', id: 'password', error: '' },
+                { inputValue: 'DCCL', id: 'noc-code', error: '' },
+                {
+                    inputValue: '',
+                    id: 'email',
+                    error: 'There was a problem creating your account',
+                },
+            ],
+        };
+
+        const { req, res } = getMockRequestAndResponse({
+            cookieValues: {},
+            body: {
+                email: 'test@test.com',
+                password: 'abcdefghi',
+                confirmPassword: 'abcdefghi',
+                nocCode: 'DCCL',
+                regKey: 'abcdefg',
+            },
+            uuid: '',
+            mockWriteHeadFn: writeHeadMock,
+        });
+
+        await register(req, res);
+
+        expect(setCookieSpy).toHaveBeenCalledWith(USER_COOKIE, JSON.stringify(mockUserCookieValue), req, res);
     });
 });


### PR DESCRIPTION
# Description

-   To allow the register users page to cope with multiple NOC codes, as they can be entered via the cognito script with NOC codes split with a pipe ( | ). 

# Testing instructions

-   Unit tests prove API works, needs to be tested with the script once in develop.

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [ ] Lighthouse performed (Accessibility 90+ minimum)
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
