### PR TITLE
Feature/tfn 680 previous netex

### DIFF
--- a/server/middleware/authentication.ts
+++ b/server/middleware/authentication.ts
@@ -49,7 +49,7 @@ export const setDisableAuthCookies = (server: Express): void => {
                 cookies.set(DISABLE_AUTH_COOKIE, 'true', cookieOptions);
                 cookies.set(
                     ID_TOKEN_COOKIE,
-                    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206bm9jIjoiQkxBQ3xXQlRSIiwiZW1haWwiOiJ0ZXN0QGV4YW1wbGUuY29tIn0.whYRRnQmDvVnZDBXsFQpcTx6aE7N48Zo0ebTefJT8Tc',
+                    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206bm9jIjoiQkxBQyIsImVtYWlsIjoidGVzdEBleGFtcGxlLmNvbSJ9.iQTTEOSf0HZNQsNep3P4npgDp1gyJi8uJHpcGKH7PIM',
                     cookieOptions,
                 );
                 cookies.set(

--- a/server/middleware/authentication.ts
+++ b/server/middleware/authentication.ts
@@ -49,7 +49,7 @@ export const setDisableAuthCookies = (server: Express): void => {
                 cookies.set(DISABLE_AUTH_COOKIE, 'true', cookieOptions);
                 cookies.set(
                     ID_TOKEN_COOKIE,
-                    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206bm9jIjoiQkxBQyIsImVtYWlsIjoidGVzdEBleGFtcGxlLmNvbSJ9.iQTTEOSf0HZNQsNep3P4npgDp1gyJi8uJHpcGKH7PIM',
+                    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206bm9jIjoiQkxBQ3xXQlRSIiwiZW1haWwiOiJ0ZXN0QGV4YW1wbGUuY29tIn0.whYRRnQmDvVnZDBXsFQpcTx6aE7N48Zo0ebTefJT8Tc',
                     cookieOptions,
                 );
                 cookies.set(

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,76 @@
+import React, { ReactElement } from 'react';
+
+interface PaginationProps {
+    numberPerPage: number;
+    numberOfResults: number;
+    currentPage: number;
+    link: string;
+}
+
+const Pagination = ({ numberPerPage, numberOfResults, currentPage, link }: PaginationProps): ReactElement => {
+    const getSummary = (): string => {
+        let start = (currentPage - 1) * numberPerPage + 1;
+        let end = start + numberPerPage - 1;
+
+        if (end > numberOfResults) {
+            end = numberOfResults;
+        }
+
+        if (start > numberOfResults) {
+            start = numberOfResults;
+        }
+
+        return `Showing ${start} - ${end} of ${numberOfResults} results`;
+    };
+
+    const numberOfPages = Math.ceil(numberOfResults / numberPerPage);
+    const previousPage = currentPage - 1;
+    const nextPage = currentPage + 1;
+
+    return (
+        <nav role="navigation" aria-label="Pagination">
+            <div className="pagination__summary">{getSummary()}</div>
+            <ul className="pagination govuk-body">
+                {previousPage > 0 && (
+                    <li className="pagination__item">
+                        <a
+                            className="pagination__link"
+                            href={`${link}?page=${previousPage}`}
+                            aria-label="Previous page"
+                        >
+                            <span aria-hidden="true" role="presentation">
+                                &laquo;
+                            </span>{' '}
+                            Previous
+                        </a>
+                    </li>
+                )}
+                {[...Array(numberOfPages)].map((_, i) => (
+                    // eslint-disable-next-line react/no-array-index-key
+                    <li className="pagination__item pagination-page" key={i}>
+                        <a
+                            className={`pagination__link ${currentPage === i + 1 ? 'current' : ''}`}
+                            href={`${link}?page=${i + 1}`}
+                            aria-current={currentPage === i + 1 ? 'true' : 'false'}
+                            aria-label={`Page ${i + 1}${currentPage === i + 1 && ', current page'}`}
+                        >
+                            {i + 1}
+                        </a>
+                    </li>
+                ))}
+                {nextPage <= numberOfPages && (
+                    <li className="pagination__item">
+                        <a className="pagination__link" href={`${link}?page=${nextPage}`} aria-label="Next page">
+                            Next{' '}
+                            <span aria-hidden="true" role="presentation">
+                                &raquo;
+                            </span>
+                        </a>
+                    </li>
+                )}
+            </ul>
+        </nav>
+    );
+};
+
+export default Pagination;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -118,3 +118,5 @@ export const PASSENGER_TYPES_WITH_GROUP: PassengerAttributes[] = [
 ];
 
 export const INTERNAL_NOC = 'IWBusCo';
+
+export const CREATED_FILES_NUM_PER_PAGE = 10;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -100,6 +100,7 @@ export const STAGE = process.env.STAGE || 'dev';
 export const RAW_USER_DATA_BUCKET_NAME = `fdbt-raw-user-data-${STAGE}`;
 export const USER_DATA_BUCKET_NAME = `fdbt-user-data-${STAGE}`;
 export const MATCHING_DATA_BUCKET_NAME = `fdbt-matching-data-${STAGE}`;
+export const NETEX_BUCKET_NAME = `fdbt-netex-data-${STAGE}`;
 
 export const PASSENGER_TYPES_LIST: PassengerAttributes[] = [
     { passengerTypeDisplay: 'Adult', passengerTypeValue: 'adult' },

--- a/src/data/s3.ts
+++ b/src/data/s3.ts
@@ -167,12 +167,16 @@ export const putDataInS3 = async (
 };
 
 export const getNetexSignedUrl = async (key: string): Promise<string> => {
-    const request = {
-        Bucket: NETEX_BUCKET_NAME,
-        Key: key,
-    };
+    try {
+        const request = {
+            Bucket: NETEX_BUCKET_NAME,
+            Key: key,
+        };
 
-    return s3.getSignedUrlPromise('getObject', request);
+        return s3.getSignedUrlPromise('getObject', request);
+    } catch (error) {
+        throw new Error(`Failed to get signed url for key: ${key}`);
+    }
 };
 
 export const getMatchingDataObject = async (

--- a/src/data/s3.ts
+++ b/src/data/s3.ts
@@ -1,7 +1,8 @@
 import AWS from 'aws-sdk';
-import { USER_DATA_BUCKET_NAME, RAW_USER_DATA_BUCKET_NAME } from '../constants';
+import { USER_DATA_BUCKET_NAME, RAW_USER_DATA_BUCKET_NAME, NETEX_BUCKET_NAME } from '../constants';
 import { MatchingFareZones } from '../interfaces/matchingInterface';
 import logger from '../utils/logger';
+import { S3NetexFile } from '../interfaces';
 
 export interface FareStage {
     stageName: string;
@@ -158,4 +159,18 @@ export const putDataInS3 = async (
     });
 
     await putStringInS3(bucketName, key, JSON.stringify(data), contentType);
+};
+
+export const retrieveNetexForNoc = async (noc: string): Promise<S3NetexFile[]> => {
+    const request: AWS.S3.ListObjectsV2Request = {
+        Bucket: NETEX_BUCKET_NAME,
+        Prefix: noc,
+    };
+
+    const response = await s3.listObjectsV2(request).promise();
+    const contents = response.Contents ?? [];
+
+    return contents.map(item => ({
+        name: item.Key ?? '',
+    }));
 };

--- a/src/design/Components.scss
+++ b/src/design/Components.scss
@@ -44,3 +44,50 @@
     display: flex;
     align-items: flex-end;
 }
+
+.padding {
+    padding-left: 15px;
+}
+
+.pagination {
+    padding: 0;
+}
+.pagination__item {
+    display: inline-block;
+    list-style: none;
+}
+.pagination__link {
+    display: block;
+    padding: 5px 10px;
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+        background: #f8f8f8;
+        outline: 3px solid #ffbf47;
+    }
+
+    &.current {
+        color: #0b0c0c;
+        font-weight: 700;
+        border: none;
+        pointer-events: none;
+        cursor: default;
+
+        &:hover,
+        &:focus {
+            color: #0b0c0c;
+            background: none;
+        }
+    }
+}
+
+.pagination__summary {
+    font-family: 'Inter UI', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    padding: 8px 0;
+
+    @media (min-width: 642px) {
+        float: right;
+    }
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -246,3 +246,7 @@ export interface Stop {
     indicator?: string;
     street?: string;
 }
+
+export interface S3NetexFile {
+    name: string;
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -249,4 +249,15 @@ export interface Stop {
 
 export interface S3NetexFile {
     name: string;
+    noc: string;
+    reference: string;
+    fareType: string;
+    productNames?: string;
+    passengerType: string;
+    serviceNames?: string;
+    lineName?: string;
+    zoneName?: string;
+    sopNames: string;
+    date: string;
+    signedUrl: string;
 }

--- a/src/interfaces/typeGuards.ts
+++ b/src/interfaces/typeGuards.ts
@@ -1,0 +1,17 @@
+import { PeriodTicket, PointToPointTicket, PeriodMultipleServicesTicket, FlatFareTicket, PeriodGeoZoneTicket } from '.';
+
+export const isNotEmpty = <T>(value: T | null | undefined): value is T => value !== null && value !== undefined;
+
+export const isPeriodTicket = (ticket: PeriodTicket | PointToPointTicket): ticket is PeriodTicket =>
+    (ticket as PeriodTicket).products?.[0]?.productName !== undefined;
+
+export const isMultipleServicesTicket = (
+    ticket: PeriodTicket | PointToPointTicket,
+): ticket is PeriodMultipleServicesTicket | FlatFareTicket =>
+    (ticket as PeriodMultipleServicesTicket).selectedServices !== undefined;
+
+export const isPointToPointTicket = (ticket: PeriodTicket | PointToPointTicket): ticket is PointToPointTicket =>
+    (ticket as PointToPointTicket).lineName !== undefined;
+
+export const isGeoZoneTicket = (ticket: PeriodTicket | PointToPointTicket): ticket is PeriodGeoZoneTicket =>
+    (ticket as PeriodGeoZoneTicket).zoneName !== undefined;

--- a/src/pages/createdFiles.tsx
+++ b/src/pages/createdFiles.tsx
@@ -1,9 +1,17 @@
 import React, { ReactElement } from 'react';
 import { NextPageContext } from 'next';
+import startCase from 'lodash/startCase';
 import TwoThirdsLayout from '../layout/Layout';
-import { getAttributeFromIdToken } from '../utils';
-import { retrieveNetexForNoc } from '../data/s3';
-import { S3NetexFile } from '../interfaces';
+import { getNocFromIdToken } from '../utils';
+import { retrieveNetexForNocs, getMatchingDataObject, getNetexSignedUrl } from '../data/s3';
+import { S3NetexFile, PeriodTicket, PointToPointTicket, BaseProduct } from '../interfaces';
+import {
+    isPointToPointTicket,
+    isGeoZoneTicket,
+    isPeriodTicket,
+    isMultipleServicesTicket,
+    isNotEmpty,
+} from '../interfaces/typeGuards';
 
 const title = 'Created Files - Fares Data Build Tool';
 const description = 'Created Files page for the Fares Data Build Tool';
@@ -12,45 +20,170 @@ interface CreateFilesProps {
     files: S3NetexFile[];
 }
 
-const CreatedFiles = ({ files }: CreateFilesProps): ReactElement => {
-    return (
-        <TwoThirdsLayout title={title} description={description}>
-            <h1 className="govuk-heading-l">Previously created files</h1>
-            <div className="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
-                {files.map((file, index) => (
-                    <div className="govuk-accordion__section" key={file.name}>
-                        <div className="govuk-accordion__section-header">
-                            <h2 className="govuk-accordion__section-heading">
-                                <span
-                                    className="govuk-accordion__section-button"
-                                    id={`accordion-default-heading-${index}`}
-                                >
-                                    {file.name}
-                                </span>
-                            </h2>
-                        </div>
-                        <div
-                            id={`accordion-default-content-${index}`}
-                            className="govuk-accordion__section-content"
-                            aria-labelledby={`accordion-default-heading-${index}`}
-                        >
-                            <p className="govuk-body">HELLO</p>
-                        </div>
-                    </div>
-                ))}
-            </div>
-        </TwoThirdsLayout>
-    );
+const buildName = (file: PointToPointTicket | PeriodTicket): string => {
+    let name = `${file.nocCode} - ${startCase(file.type)} - ${startCase(file.passengerType)}`;
+
+    if (isPointToPointTicket(file)) {
+        name += ` - Line ${file.lineName}`;
+    } else if (isGeoZoneTicket(file)) {
+        name += ` - ${file.zoneName}`;
+    }
+
+    return name;
 };
 
-export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props: CreateFilesProps }> => {
-    const noc = getAttributeFromIdToken(ctx, 'custom:noc');
+const enrichNetexFileData = async (files: AWS.S3.Object[]): Promise<S3NetexFile[]> => {
+    const requestPromises = files.map(async file => {
+        if (!file.Key) {
+            return null;
+        }
 
-    const files = await retrieveNetexForNoc(noc || '');
+        const signedUrl = await getNetexSignedUrl(file.Key);
+
+        return {
+            matchingData: await getMatchingDataObject(file.Key.replace('.xml', '.json')),
+            signedUrl,
+        };
+    });
+
+    const response = await Promise.all(requestPromises);
+
+    return response
+        .map(item => {
+            if (!item?.matchingData?.Body) {
+                return null;
+            }
+
+            const matchingData: PointToPointTicket | PeriodTicket = JSON.parse(item.matchingData.Body.toString());
+
+            return {
+                name: buildName(matchingData),
+                noc: matchingData.nocCode,
+                reference: matchingData.uuid,
+                fareType: matchingData.type,
+                passengerType: matchingData.passengerType,
+                date: item.matchingData.LastModified?.toUTCString() ?? '',
+                productNames: isPeriodTicket(matchingData)
+                    ? matchingData.products.map(product => product.productName).join(', ')
+                    : '',
+                serviceNames: isMultipleServicesTicket(matchingData)
+                    ? matchingData.selectedServices.map(service => service.lineName).join(', ')
+                    : '',
+                lineName: isPointToPointTicket(matchingData) ? matchingData.lineName : '',
+                zoneName: isGeoZoneTicket(matchingData) ? matchingData.zoneName : '',
+                sopNames: (matchingData.products as BaseProduct[])
+                    .map(product => product.salesOfferPackages.map(sop => sop.name))
+                    .join(', '),
+                signedUrl: item.signedUrl,
+            };
+        })
+        .filter(isNotEmpty);
+};
+
+const CreatedFiles = ({ files }: CreateFilesProps): ReactElement => (
+    <TwoThirdsLayout title={title} description={description}>
+        <h1 className="govuk-heading-l">Previously created files</h1>
+        <div className="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+            {files.map((file, index) => (
+                <div className="govuk-accordion__section" key={file.reference}>
+                    <div className="govuk-accordion__section-header">
+                        <h2 className="govuk-accordion__section-heading">
+                            <span className="govuk-accordion__section-button" id={`accordion-default-heading-${index}`}>
+                                {file.name}
+                            </span>
+                        </h2>
+                    </div>
+                    <div
+                        id={`accordion-default-content-${index}`}
+                        className="govuk-accordion__section-content"
+                        aria-labelledby={`accordion-default-heading-${index}`}
+                    >
+                        <div className="govuk-body">
+                            <span className="govuk-body govuk-!-font-weight-bold">Reference: </span> {file.reference}
+                            <br />
+                            <span className="govuk-body govuk-!-font-weight-bold">National Operator Code: </span>{' '}
+                            {file.noc}
+                            <br />
+                            <span className="govuk-body govuk-!-font-weight-bold">Fare Type: </span>{' '}
+                            {startCase(file.fareType)}
+                            <br />
+                            <span className="govuk-body govuk-!-font-weight-bold">Passenger Type: </span>{' '}
+                            {startCase(file.passengerType)}
+                            <br />
+                            <span className="govuk-body govuk-!-font-weight-bold">Sales Offer Package(s): </span>{' '}
+                            {startCase(file.sopNames)}
+                            <br />
+                            {file.serviceNames && (
+                                <>
+                                    <span className="govuk-body govuk-!-font-weight-bold">Service(s): </span>{' '}
+                                    {file.serviceNames}
+                                    <br />
+                                </>
+                            )}
+                            {file.productNames && (
+                                <>
+                                    <span className="govuk-body govuk-!-font-weight-bold">Product(s): </span>{' '}
+                                    {file.productNames}
+                                    <br />
+                                </>
+                            )}
+                            {file.lineName && (
+                                <>
+                                    <span className="govuk-body govuk-!-font-weight-bold">Line Name: </span>{' '}
+                                    {file.lineName}
+                                    <br />
+                                </>
+                            )}
+                            {file.zoneName && (
+                                <>
+                                    <span className="govuk-body govuk-!-font-weight-bold">Zone Name: </span>{' '}
+                                    {file.zoneName}
+                                    <br />
+                                </>
+                            )}
+                            <span className="govuk-body govuk-!-font-weight-bold">Date of Creation: </span> {file.date}
+                            <br />
+                            <br />
+                            <a href={file.signedUrl} className="govuk-button" download>
+                                Download
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            ))}
+        </div>
+    </TwoThirdsLayout>
+);
+
+export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props: CreateFilesProps } | null> => {
+    const nocList = getNocFromIdToken(ctx)?.split('|');
+
+    if (!nocList) {
+        throw new Error('no NOCs found in ID token');
+    }
+
+    const files = await retrieveNetexForNocs(nocList);
+    const filesToEnrich = files
+        .sort((a, b) => {
+            if (!a.LastModified || !b.LastModified) {
+                return 0;
+            }
+
+            if (a.LastModified < b.LastModified) {
+                return 1;
+            }
+
+            if (a.LastModified > b.LastModified) {
+                return -1;
+            }
+
+            return 0;
+        })
+        .slice(0, 100);
 
     return {
         props: {
-            files,
+            files: await enrichNetexFileData(filesToEnrich),
         },
     };
 };

--- a/src/pages/createdFiles.tsx
+++ b/src/pages/createdFiles.tsx
@@ -1,0 +1,58 @@
+import React, { ReactElement } from 'react';
+import { NextPageContext } from 'next';
+import TwoThirdsLayout from '../layout/Layout';
+import { getAttributeFromIdToken } from '../utils';
+import { retrieveNetexForNoc } from '../data/s3';
+import { S3NetexFile } from '../interfaces';
+
+const title = 'Created Files - Fares Data Build Tool';
+const description = 'Created Files page for the Fares Data Build Tool';
+
+interface CreateFilesProps {
+    files: S3NetexFile[];
+}
+
+const CreatedFiles = ({ files }: CreateFilesProps): ReactElement => {
+    return (
+        <TwoThirdsLayout title={title} description={description}>
+            <h1 className="govuk-heading-l">Previously created files</h1>
+            <div className="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+                {files.map((file, index) => (
+                    <div className="govuk-accordion__section" key={file.name}>
+                        <div className="govuk-accordion__section-header">
+                            <h2 className="govuk-accordion__section-heading">
+                                <span
+                                    className="govuk-accordion__section-button"
+                                    id={`accordion-default-heading-${index}`}
+                                >
+                                    {file.name}
+                                </span>
+                            </h2>
+                        </div>
+                        <div
+                            id={`accordion-default-content-${index}`}
+                            className="govuk-accordion__section-content"
+                            aria-labelledby={`accordion-default-heading-${index}`}
+                        >
+                            <p className="govuk-body">HELLO</p>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </TwoThirdsLayout>
+    );
+};
+
+export const getServerSideProps = async (ctx: NextPageContext): Promise<{ props: CreateFilesProps }> => {
+    const noc = getAttributeFromIdToken(ctx, 'custom:noc');
+
+    const files = await retrieveNetexForNoc(noc || '');
+
+    return {
+        props: {
+            files,
+        },
+    };
+};
+
+export default CreatedFiles;

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -30,6 +30,11 @@ const Home = ({ multipleOperators }: HomeProps & CustomAppProps): ReactElement =
                     >
                         Create NeTEx data for your fares
                     </a>
+                    <br />
+                    <br />
+                    <a href="/createdFiles" className="govuk-link govuk-!-font-size-19" id="created-link">
+                        Download previously created NeTEx data
+                    </a>
                 </div>
                 <div className="govuk-!-margin-top-9">
                     <p className="govuk-body govuk-!-font-weight-bold content-one-quarter">Operator settings</p>

--- a/tests/components/Pagination.test.tsx
+++ b/tests/components/Pagination.test.tsx
@@ -1,0 +1,113 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import Pagination from '../../src/components/Pagination';
+
+describe('Pagination', () => {
+    it.each([
+        [13, 121, 10],
+        [1, 5, 10],
+        [9, 27, 3],
+    ])('should show %s pages, when there are %s results, with %s per page', (expectedPages, numResults, numPerPage) => {
+        const wrapper = shallow(
+            <Pagination
+                currentPage={1}
+                link="https://test.example.com"
+                numberOfResults={numResults}
+                numberPerPage={numPerPage}
+            />,
+        );
+
+        expect(wrapper.find('.pagination-page')).toHaveLength(expectedPages);
+    });
+
+    it('should not show previous button if current page is 1', () => {
+        const wrapper = shallow(
+            <Pagination currentPage={1} link="https://test.example.com" numberOfResults={10} numberPerPage={2} />,
+        );
+
+        expect(
+            wrapper
+                .find('li')
+                .first()
+                .text(),
+        ).not.toBe('« Previous');
+    });
+
+    it('should show previous button if current page is not 1', () => {
+        const wrapper = shallow(
+            <Pagination currentPage={2} link="https://test.example.com" numberOfResults={10} numberPerPage={2} />,
+        );
+
+        expect(
+            wrapper
+                .find('li')
+                .first()
+                .text(),
+        ).toBe('« Previous');
+    });
+
+    it('should show correct previous link', () => {
+        const wrapper = shallow(
+            <Pagination currentPage={3} link="https://test.example.com" numberOfResults={10} numberPerPage={2} />,
+        );
+
+        expect(
+            wrapper
+                .find('a')
+                .first()
+                .props().href,
+        ).toBe('https://test.example.com?page=2');
+    });
+
+    it('should not show next button if current page is last page', () => {
+        const wrapper = shallow(
+            <Pagination currentPage={5} link="https://test.example.com" numberOfResults={10} numberPerPage={2} />,
+        );
+
+        expect(
+            wrapper
+                .find('li')
+                .last()
+                .text(),
+        ).not.toBe('Next »');
+    });
+
+    it('should show next button if current page is not last page', () => {
+        const wrapper = shallow(
+            <Pagination currentPage={1} link="https://test.example.com" numberOfResults={10} numberPerPage={2} />,
+        );
+
+        expect(
+            wrapper
+                .find('li')
+                .last()
+                .text(),
+        ).toBe('Next »');
+    });
+
+    it('should show correct next link', () => {
+        const wrapper = shallow(
+            <Pagination currentPage={3} link="https://test.example.com" numberOfResults={10} numberPerPage={2} />,
+        );
+
+        expect(
+            wrapper
+                .find('a')
+                .last()
+                .props().href,
+        ).toBe('https://test.example.com?page=4');
+    });
+
+    it('should mark current page as current', () => {
+        const wrapper = shallow(
+            <Pagination currentPage={5} link="https://test.example.com" numberOfResults={10} numberPerPage={2} />,
+        );
+
+        expect(
+            wrapper
+                .find('.current')
+                .last()
+                .text(),
+        ).toBe('5');
+    });
+});

--- a/tests/pages/__snapshots__/createdFiles.test.tsx.snap
+++ b/tests/pages/__snapshots__/createdFiles.test.tsx.snap
@@ -1,0 +1,214 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pages createdFiles should render correctly 1`] = `
+<Component
+  description="Created Files page for the Fares Data Build Tool"
+  title="Created Files - Fares Data Build Tool"
+>
+  <h1
+    className="govuk-heading-l"
+  >
+    Previously created files
+  </h1>
+  <div
+    className="govuk-accordion"
+    data-module="govuk-accordion"
+    id="accordion-default"
+  >
+    <div
+      className="govuk-accordion__section"
+      key="TEST12345"
+    >
+      <div
+        className="govuk-accordion__section-header"
+      >
+        <h2
+          className="govuk-accordion__section-heading"
+        >
+          <span
+            className="govuk-accordion__section-button"
+            id="accordion-default-heading-0"
+          >
+            Test Name
+          </span>
+        </h2>
+      </div>
+      <div
+        aria-labelledby="accordion-default-heading-0"
+        className="govuk-accordion__section-content"
+        id="accordion-default-content-0"
+      >
+        <div
+          className="govuk-body"
+        >
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Reference: 
+          </span>
+           
+          TEST12345
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            National Operator Code: 
+          </span>
+           
+          TEST
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Fare Type: 
+          </span>
+           
+          Single
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Passenger Type: 
+          </span>
+           
+          Adult
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Sales Offer Package(s): 
+          </span>
+           
+          Test SOP Name Test SOP Name 2
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Line Name: 
+          </span>
+           
+          X01
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Date of Creation: 
+          </span>
+           
+          Tue, 01 Sep 2020 14:46:58 GMT
+          <br />
+          <br />
+          <a
+            className="govuk-button"
+            download={true}
+            href="https://test.example.com/dscsdcd"
+          >
+            Download
+          </a>
+        </div>
+      </div>
+    </div>
+    <div
+      className="govuk-accordion__section"
+      key="TEST54321"
+    >
+      <div
+        className="govuk-accordion__section-header"
+      >
+        <h2
+          className="govuk-accordion__section-heading"
+        >
+          <span
+            className="govuk-accordion__section-button"
+            id="accordion-default-heading-1"
+          >
+            Test Name 2
+          </span>
+        </h2>
+      </div>
+      <div
+        aria-labelledby="accordion-default-heading-1"
+        className="govuk-accordion__section-content"
+        id="accordion-default-content-1"
+      >
+        <div
+          className="govuk-body"
+        >
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Reference: 
+          </span>
+           
+          TEST54321
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            National Operator Code: 
+          </span>
+           
+          TEST2
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Fare Type: 
+          </span>
+           
+          Flat Fare
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Passenger Type: 
+          </span>
+           
+          Child
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Sales Offer Package(s): 
+          </span>
+           
+          Test SOP Name 2
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Service(s): 
+          </span>
+           
+          1, 56, X02
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Product(s): 
+          </span>
+           
+          Product 1, Product 2
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Date of Creation: 
+          </span>
+           
+          Wed, 02 Sep 2020 14:46:58 GMT
+          <br />
+          <br />
+          <a
+            className="govuk-button"
+            download={true}
+            href="https://test.example.com/gfnhgddd"
+          >
+            Download
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</Component>
+`;

--- a/tests/pages/__snapshots__/createdFiles.test.tsx.snap
+++ b/tests/pages/__snapshots__/createdFiles.test.tsx.snap
@@ -10,6 +10,12 @@ exports[`pages createdFiles should render correctly 1`] = `
   >
     Previously created files
   </h1>
+  <span
+    className="govuk-hint"
+    id="fare-type-operator-hint"
+  >
+    This page will show any NeTEx files created in the last 60 days
+  </span>
   <div
     className="govuk-accordion"
     data-module="govuk-accordion"
@@ -210,5 +216,11 @@ exports[`pages createdFiles should render correctly 1`] = `
       </div>
     </div>
   </div>
+  <Pagination
+    currentPage={1}
+    link="/createdFiles"
+    numberOfResults={10}
+    numberPerPage={5}
+  />
 </Component>
 `;

--- a/tests/pages/__snapshots__/home.test.tsx.snap
+++ b/tests/pages/__snapshots__/home.test.tsx.snap
@@ -34,6 +34,15 @@ exports[`pages home page should render correctly 1`] = `
         >
           Create NeTEx data for your fares
         </a>
+        <br />
+        <br />
+        <a
+          className="govuk-link govuk-!-font-size-19"
+          href="/createdFiles"
+          id="created-link"
+        >
+          Download previously created NeTEx data
+        </a>
       </div>
       <div
         className="govuk-!-margin-top-9"
@@ -110,6 +119,15 @@ exports[`pages home page should render correctly with no multiple operators 1`] 
           id="faretype-link"
         >
           Create NeTEx data for your fares
+        </a>
+        <br />
+        <br />
+        <a
+          className="govuk-link govuk-!-font-size-19"
+          href="/createdFiles"
+          id="created-link"
+        >
+          Download previously created NeTEx data
         </a>
       </div>
       <div

--- a/tests/pages/createdFiles.test.tsx
+++ b/tests/pages/createdFiles.test.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import CreatedFiles from '../../src/pages/createdFiles';
+import { S3NetexFile } from '../../src/interfaces';
+
+const netexFiles: S3NetexFile[] = [
+    {
+        name: 'Test Name',
+        fareType: 'single',
+        noc: 'TEST',
+        passengerType: 'adult',
+        reference: 'TEST12345',
+        date: 'Tue, 01 Sep 2020 14:46:58 GMT',
+        signedUrl: 'https://test.example.com/dscsdcd',
+        sopNames: 'Test SOP Name, Test SOP Name 2',
+        lineName: 'X01',
+    },
+    {
+        name: 'Test Name 2',
+        fareType: 'flatFare',
+        noc: 'TEST2',
+        passengerType: 'child',
+        reference: 'TEST54321',
+        date: 'Wed, 02 Sep 2020 14:46:58 GMT',
+        signedUrl: 'https://test.example.com/gfnhgddd',
+        sopNames: 'Test SOP Name 2',
+        serviceNames: '1, 56, X02',
+        productNames: 'Product 1, Product 2',
+    },
+];
+
+describe('pages', () => {
+    describe('createdFiles', () => {
+        it('should render correctly', () => {
+            const tree = shallow(<CreatedFiles files={netexFiles} />);
+            expect(tree).toMatchSnapshot();
+        });
+    });
+});

--- a/tests/pages/createdFiles.test.tsx
+++ b/tests/pages/createdFiles.test.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import CreatedFiles from '../../src/pages/createdFiles';
+import CreatedFiles, { getServerSideProps } from '../../src/pages/createdFiles';
 import { S3NetexFile } from '../../src/interfaces';
+import * as s3 from '../../src/data/s3';
+import { getMockContext, expectedMatchingJsonSingle } from '../testData/mockData';
+
+jest.mock('../../src/data/s3.ts');
 
 const netexFiles: S3NetexFile[] = [
     {
@@ -31,9 +35,113 @@ const netexFiles: S3NetexFile[] = [
 
 describe('pages', () => {
     describe('createdFiles', () => {
+        const ctx = getMockContext();
+        let retrieveNetexForNocsSpy: jest.SpyInstance;
+        let getMatchingDataObjectSpy: jest.SpyInstance;
+        let getNetexSignedUrlSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            retrieveNetexForNocsSpy = jest.spyOn(s3, 'retrieveNetexForNocs').mockImplementation(() =>
+                Promise.resolve([
+                    {
+                        LastModified: new Date(new Date().setFullYear(2019)),
+                        Key: 'testKey.xml',
+                    },
+                    {
+                        LastModified: new Date(new Date().setFullYear(2020)),
+                        Key: 'testKey2.xml',
+                    },
+                ]),
+            );
+
+            getMatchingDataObjectSpy = jest.spyOn(s3, 'getMatchingDataObject').mockImplementation(() =>
+                Promise.resolve({
+                    Body: JSON.stringify(expectedMatchingJsonSingle),
+                } as any),
+            );
+
+            getNetexSignedUrlSpy = jest
+                .spyOn(s3, 'getNetexSignedUrl')
+                .mockImplementation(() => Promise.resolve('https://test.example.com/gfnhgddd'));
+        });
+
+        afterEach(() => {
+            jest.resetAllMocks();
+        });
+
         it('should render correctly', () => {
             const tree = shallow(<CreatedFiles files={netexFiles} />);
             expect(tree).toMatchSnapshot();
+        });
+
+        describe('getServerSideProps', () => {
+            it('calls retrieveNetexForNocs on load', async () => {
+                await getServerSideProps(ctx);
+
+                expect(retrieveNetexForNocsSpy).toBeCalledTimes(1);
+            });
+
+            it('calls getMatchingDataObject for each netex file', async () => {
+                await getServerSideProps(ctx);
+
+                expect(getMatchingDataObjectSpy).toBeCalledTimes(2);
+                expect(getMatchingDataObjectSpy).toBeCalledWith('testKey.json');
+                expect(getMatchingDataObjectSpy).toBeCalledWith('testKey2.json');
+            });
+
+            it('calls getNetexSignedUrl for each netex file', async () => {
+                await getServerSideProps(ctx);
+
+                expect(getNetexSignedUrlSpy).toBeCalledTimes(2);
+                expect(getMatchingDataObjectSpy).toBeCalledWith('testKey.json');
+                expect(getMatchingDataObjectSpy).toBeCalledWith('testKey2.json');
+            });
+
+            it('sorts files by date', async () => {
+                await getServerSideProps(ctx);
+
+                expect(getMatchingDataObjectSpy.mock.calls[0][0]).toBe('testKey2.json');
+                expect(getMatchingDataObjectSpy.mock.calls[1][0]).toBe('testKey.json');
+            });
+
+            it('returns correct file data', async () => {
+                const result = await getServerSideProps(ctx);
+
+                expect(result).toEqual({
+                    props: {
+                        files: [
+                            {
+                                date: '',
+                                fareType: 'single',
+                                lineName: '215',
+                                name: 'DCCL - Single - Adult - Line 215',
+                                noc: 'DCCL',
+                                passengerType: 'Adult',
+                                productNames: '',
+                                reference: '1e0459b3-082e-4e70-89db-96e8ae173e10',
+                                serviceNames: '',
+                                signedUrl: 'https://test.example.com/gfnhgddd',
+                                sopNames: 'Adult - Weekly Rider - Cash, Card - OnBus, TicketMachine, Shop',
+                                zoneName: '',
+                            },
+                            {
+                                date: '',
+                                fareType: 'single',
+                                lineName: '215',
+                                name: 'DCCL - Single - Adult - Line 215',
+                                noc: 'DCCL',
+                                passengerType: 'Adult',
+                                productNames: '',
+                                reference: '1e0459b3-082e-4e70-89db-96e8ae173e10',
+                                serviceNames: '',
+                                signedUrl: 'https://test.example.com/gfnhgddd',
+                                sopNames: 'Adult - Weekly Rider - Cash, Card - OnBus, TicketMachine, Shop',
+                                zoneName: '',
+                            },
+                        ],
+                    },
+                });
+            });
         });
     });
 });

--- a/tests/pages/createdFiles.test.tsx
+++ b/tests/pages/createdFiles.test.tsx
@@ -57,6 +57,7 @@ describe('pages', () => {
             getMatchingDataObjectSpy = jest.spyOn(s3, 'getMatchingDataObject').mockImplementation(() =>
                 Promise.resolve({
                     Body: JSON.stringify(expectedMatchingJsonSingle),
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 } as any),
             );
 
@@ -70,8 +71,24 @@ describe('pages', () => {
         });
 
         it('should render correctly', () => {
-            const tree = shallow(<CreatedFiles files={netexFiles} />);
+            const tree = shallow(
+                <CreatedFiles files={netexFiles} numberOfResults={10} currentPage={1} numberPerPage={5} />,
+            );
             expect(tree).toMatchSnapshot();
+        });
+
+        it('should render pagination if number of results more than number per page', () => {
+            const tree = shallow(
+                <CreatedFiles files={netexFiles} numberOfResults={10} currentPage={1} numberPerPage={5} />,
+            );
+            expect(tree.find('Pagination')).toHaveLength(1);
+        });
+
+        it('should not render pagination if number of results less than number per page', () => {
+            const tree = shallow(
+                <CreatedFiles files={netexFiles} numberOfResults={2} currentPage={1} numberPerPage={5} />,
+            );
+            expect(tree.find('Pagination')).toHaveLength(0);
         });
 
         describe('getServerSideProps', () => {
@@ -109,6 +126,7 @@ describe('pages', () => {
 
                 expect(result).toEqual({
                     props: {
+                        currentPage: 1,
                         files: [
                             {
                                 date: '',
@@ -139,6 +157,8 @@ describe('pages', () => {
                                 zoneName: '',
                             },
                         ],
+                        numberOfResults: 2,
+                        numberPerPage: 10,
                     },
                 });
             });


### PR DESCRIPTION
# Description

- Add page to display previously created netex for the logged in user
- Ability to download previous netex
- Pagination when over 10 previous files

# Testing instructions

- Get latest dev repo and run `make add-data-to-buckets`, files should now be visible at `/createdFiles`
- To show pagination change `CREATED_FILES_NUM_PER_PAGE` in the constants file to something small

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Lighthouse performed (Accessibility 90+ minimum)
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
