### PR TITLE
enable virus scanning to work on Fargate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,12 @@ WORKDIR /home/node/app
 
 COPY package*.json ./
 
-RUN npm install --ignore-scripts && apk update && apk upgrade && apk add --no-cache -t .clamv-run-deps openrc clamav clamav-daemon clamav-libunrar && \
-    openrc default && rc-update add freshclam && rc-update add clamd
+RUN apk update && apk upgrade && apk add --no-cache -t .clamv-run-deps git openrc clamav clamav-daemon clamav-libunrar && \
+    npm install --ignore-scripts && mkdir /run/clamav && chown -R clamav:clamav /run/clamav && freshclam
 
 COPY --from=build /tmp/.next ./.next
 COPY --from=build /tmp/dist ./dist
 
 EXPOSE 80
 
-CMD ["npm", "start"]
+CMD ["sh", "-c", "sleep 20 && (freshclam && (clamd -F & freshclam -d)) & npm start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /home/node/app
 
 COPY package*.json ./
 
-RUN apk update && apk upgrade && apk add --no-cache -t .clamv-run-deps git openrc clamav clamav-daemon clamav-libunrar && \
+RUN apk update && apk upgrade && apk add --no-cache -t .clamv-run-deps openrc clamav clamav-daemon clamav-libunrar && \
     npm install --ignore-scripts && mkdir /run/clamav && chown -R clamav:clamav /run/clamav && freshclam
 
 COPY --from=build /tmp/.next ./.next

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The site runs middleware to require an auth session against AWS Cognito, if you 
 
 ## Running ClamAV virus scanning tool locally
 
-There are two pages on the fdbt site which accept file uploads. Upon file upload, the site will run the ClamAV virus scanning tool (see https://www.npmjs.com/package/clamscan for more info) to validate that the uploaded file does no contain any viruses. When running the site locally, the ClamAV virus scanning tool will NOT run by default. If virus scanning is enabled, there are a couple of steps required to get set up and allow the tool to run. The below steps detail how to get ClamAV set up on MacOS:
+There are two pages on the fdbt site which accept file uploads. Upon file upload, the site will run the ClamAV virus scanning tool (see [https://www.npmjs.com/package/clamscan](https://www.npmjs.com/package/clamscan) for more info) to validate that the uploaded file does no contain any viruses. When running the site locally, the ClamAV virus scanning tool will NOT run by default. If virus scanning is enabled, there are a couple of steps required to get set up and allow the tool to run. The below steps detail how to get ClamAV set up on MacOS:
 
 - The easiest way to get the ClamAV package is by running 'brew install clamav'
 - You will then need to create a 'freshclam.conf' file. This file will allow you to obtain a copy of the ClamAV databases. The file should be added to '/usr/local/etc/clamav/freshclam.conf' and should contain the following:

--- a/src/pages/api/apiUtils/fileUpload.ts
+++ b/src/pages/api/apiUtils/fileUpload.ts
@@ -87,7 +87,7 @@ export const containsViruses = async (pathToFileToScan: string): Promise<boolean
         clamdscan: {
             timeout: 60000,
             local_fallback: false,
-            path: process.env.NODE_ENV === 'development' ? '/usr/local/bin/clamdscan' : '/usr/bin/clamdscan', // Path to the clamdscan binary on your server
+            path: process.env.NODE_ENV === 'development' ? '/usr/local/bin/clamdscan' : '/usr/bin/clamdscan',
             multiscan: true,
             reload_db: false,
             active: true,

--- a/src/pages/api/apiUtils/fileUpload.ts
+++ b/src/pages/api/apiUtils/fileUpload.ts
@@ -78,32 +78,22 @@ export const validateFile = (fileData: formidable.File, fileContents: string): s
 
 export const containsViruses = async (pathToFileToScan: string): Promise<boolean> => {
     const ClamScan = new NodeClam().init({
-        remove_infected: false, // If true, removes infected files
-        quarantine_infected: false, // False: Don't quarantine, Path: Moves files to this place.
-        scan_log: null, // Path to a writeable log file to write scan results into
-        debug_mode: false, // Whether or not to log info/debug/error msgs to the console
-        file_list: null, // path to file containing list of files to scan (for scan_files method)
-        scan_recursively: true, // If true, deep scan folders recursively
-        clamscan: {
-            path: '/usr/local/bin/clamscan', // Path to clamscan binary on your server
-            db: null, // Path to a custom virus definition database
-            scan_archives: true, // If true, scan archives (ex. zip, rar, tar, dmg, iso, etc...)
-            active: true, // If true, this module will consider using the clamscan binary
-        },
+        remove_infected: false,
+        quarantine_infected: false,
+        scan_log: null,
+        debug_mode: false,
+        file_list: null,
+        scan_recursively: true,
         clamdscan: {
-            socket: false, // Socket file for connecting via TCP
-            host: false, // IP of host to connect to TCP interface
-            port: false, // Port of host to use when connecting via TCP interface
-            timeout: 60000, // Timeout for scanning files
-            local_fallback: false, // Do no fail over to binary-method of scanning
-            path: process.env.NODE_ENV === 'development' ? 'usr/local/bin/clamdscan' : 'usr/bin/clamdscan', // Path to the clamdscan binary on your server
-            config_file: null, // Specify config file if it's in an unusual place
-            multiscan: true, // Scan using all available cores! Yay!
-            reload_db: false, // If true, will re-load the DB on every call (slow)
-            active: true, // If true, this module will consider using the clamdscan binary
-            bypass_test: false, // Check to see if socket is available when applicable
+            timeout: 60000,
+            local_fallback: false,
+            path: process.env.NODE_ENV === 'development' ? '/usr/local/bin/clamdscan' : '/usr/bin/clamdscan', // Path to the clamdscan binary on your server
+            multiscan: true,
+            reload_db: false,
+            active: true,
+            bypass_test: false,
         },
-        preference: 'clamdscan', // If clamdscan is found and active, it will be used by default
+        preference: 'clamdscan',
     });
 
     const clamscan = await ClamScan;


### PR DESCRIPTION
# Description

-   Enable ClamAV to run on Fargate

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [ ] Able to run pr locally
-   [ ] Followed acceptance criteria
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
