### PR TITLE
feat: Added multi op as an option for faretype

### DIFF
--- a/src/pages/api/apiUtils/index.ts
+++ b/src/pages/api/apiUtils/index.ts
@@ -83,6 +83,9 @@ export const redirectOnFareType = (req: NextApiRequestWithSession, res: NextApiR
             case 'flatFare':
                 redirectTo(res, '/serviceList');
                 return;
+            case 'multiOp':
+                redirectTo(res, '/ticketRepresentation');
+                return;
             default:
                 throw new Error('Fare Type we expect was not received.');
         }

--- a/src/pages/fareType.tsx
+++ b/src/pages/fareType.tsx
@@ -97,6 +97,21 @@ const FareTypePage = ({ operator, errors = [], csrfToken }: FareTypeProps & Cust
                                             Flat Fare Ticket - Single Journey
                                         </label>
                                     </div>
+                                    <div className="govuk-radios__item">
+                                        <input
+                                            className="govuk-radios__input"
+                                            id="fare-type-multi-operator"
+                                            name="multiOp"
+                                            type="radio"
+                                            value="multiOp"
+                                        />
+                                        <label
+                                            className="govuk-label govuk-radios__label"
+                                            htmlFor="fare-type-multi-operator"
+                                        >
+                                            Multi-operator - A ticket that covers more than one operator
+                                        </label>
+                                    </div>
                                 </div>
                             </FormElementWrapper>
                         </fieldset>

--- a/tests/pages/__snapshots__/faretype.test.tsx.snap
+++ b/tests/pages/__snapshots__/faretype.test.tsx.snap
@@ -113,6 +113,23 @@ exports[`pages fareType should render correctly 1`] = `
                 Flat Fare Ticket - Single Journey
               </label>
             </div>
+            <div
+              className="govuk-radios__item"
+            >
+              <input
+                className="govuk-radios__input"
+                id="fare-type-multi-operator"
+                name="multiOp"
+                type="radio"
+                value="multiOp"
+              />
+              <label
+                className="govuk-label govuk-radios__label"
+                htmlFor="fare-type-multi-operator"
+              >
+                Multi-operator - A ticket that covers more than one operator
+              </label>
+            </div>
           </div>
         </FormElementWrapper>
       </fieldset>
@@ -259,6 +276,23 @@ exports[`pages fareType should render error messaging when errors are passed to 
                 htmlFor="fare-type-flat-fare"
               >
                 Flat Fare Ticket - Single Journey
+              </label>
+            </div>
+            <div
+              className="govuk-radios__item"
+            >
+              <input
+                className="govuk-radios__input"
+                id="fare-type-multi-operator"
+                name="multiOp"
+                type="radio"
+                value="multiOp"
+              />
+              <label
+                className="govuk-label govuk-radios__label"
+                htmlFor="fare-type-multi-operator"
+              >
+                Multi-operator - A ticket that covers more than one operator
               </label>
             </div>
           </div>

--- a/tests/pages/api/apiUtils/index.test.ts
+++ b/tests/pages/api/apiUtils/index.test.ts
@@ -100,7 +100,7 @@ describe('apiUtils', () => {
             });
         });
 
-        it('should return 302 redirect to /periodType when the period ticket option is selected', () => {
+        it('should return 302 redirect to /ticketRepresentation when the period ticket option is selected', () => {
             const { req, res } = getMockRequestAndResponse({
                 body: {},
                 uuid: {},
@@ -123,6 +123,19 @@ describe('apiUtils', () => {
             redirectOnFareType(req, res);
             expect(writeHeadMock).toBeCalledWith(302, {
                 Location: '/serviceList',
+            });
+        });
+
+        it('should return 302 redirect to /ticketRepresentation when the multi operator ticket option is selected', () => {
+            const { req, res } = getMockRequestAndResponse({
+                body: {},
+                uuid: {},
+                mockWriteHeadFn: writeHeadMock,
+                session: { [FARE_TYPE_ATTRIBUTE]: { fareType: 'multiOp' } },
+            });
+            redirectOnFareType(req, res);
+            expect(writeHeadMock).toBeCalledWith(302, {
+                Location: '/ticketRepresentation',
             });
         });
 

--- a/tests/pages/api/faretype.test.ts
+++ b/tests/pages/api/faretype.test.ts
@@ -20,6 +20,20 @@ describe('fareType', () => {
         });
     });
 
+    it('should add the fareType to the session', () => {
+        const writeHeadMock = jest.fn();
+        const { req, res } = getMockRequestAndResponse({
+            cookieValues: {},
+            body: { fareType: 'single' },
+            uuid: {},
+            mockWriteHeadFn: writeHeadMock,
+        });
+        fareType(req, res);
+        expect(writeHeadMock).toBeCalledWith(302, {
+            Location: '/passengerType',
+        });
+    });
+
     it('should return 302 redirect to /error when session is not valid', () => {
         const writeHeadMock = jest.fn();
         const { req, res } = getMockRequestAndResponse({


### PR DESCRIPTION
# Description

-   To let users go down the multi op route of the site.

# Testing instructions

-   Run locally, and select multi operator on faretype page.

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
