### PR TITLE
address text overlap on magnification on smaller screens

### DIFF
--- a/src/design/Layout.scss
+++ b/src/design/Layout.scss
@@ -202,12 +202,18 @@ svg:not(:root) {
 }
 
 .govuk-header__account-link {
-    position: absolute;
-    right: 0;
-    top: 50%;
-    transform: translateY(-50%);
-    width: 220px;
-    text-align: right;
+    @media (min-width: 401px) {
+        position: absolute;
+        right: 0;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 220px;
+        text-align: right;
+    }
+
+    @media (max-width: 400px) {
+        margin: 10px 0 20px;
+    }
 
     a {
         margin-right: 6px;


### PR DESCRIPTION
# Description

-   Prevent overlapping in header when zoomed on smaller screens

# Testing instructions

-   Magnify to 400% and shrink screen to 1280px, no text should overlap in the header, or any other part of the page

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
