### PR TITLE
remove fares triangle table roles, fix operator search for internal NOC

### DIFF
--- a/src/data/auroradb.ts
+++ b/src/data/auroradb.ts
@@ -423,13 +423,15 @@ export const getSearchOperators = async (searchText: string, nocCode: string): P
         search: searchText,
     });
 
+    const nocCodeParameter = replaceInternalNocCode(nocCode);
+
     const searchQuery = `SELECT nocCode, operatorPublicName FROM nocTable WHERE nocCode IN (
                              SELECT DISTINCT nocCode FROM tndsOperatorService WHERE regionCode IN (
                                 SELECT DISTINCT regionCode FROM tndsOperatorService WHERE nocCode = ?)
                         ) AND operatorPublicName LIKE ?`;
 
     try {
-        return await executeQuery<Operator[]>(searchQuery, [nocCode, `%${searchText}%`]);
+        return await executeQuery<Operator[]>(searchQuery, [nocCodeParameter, `%${searchText}%`]);
     } catch (error) {
         throw new Error(`Could not retrieve operators from AuroraDB: ${error.stack}`);
     }

--- a/src/pages/priceEntry.tsx
+++ b/src/pages/priceEntry.tsx
@@ -95,17 +95,16 @@ const PriceEntry = ({
                     </span>
                     {errors.length > 0 ? createErrorSpans(errors) : null}
 
-                    <div className="fare-triangle-container" role="table">
-                        <div className="fare-triangle" role="rowgroup">
+                    <div className="fare-triangle-container">
+                        <div className="fare-triangle">
                             {stageNamesArray.map((rowStage, rowIndex) => (
-                                <div id={`row-${rowIndex}`} className="fare-triangle-row" role="row" key={rowStage}>
-                                    <span className="govuk-heading-s fare-triangle-label-left" role="rowheader">
+                                <div id={`row-${rowIndex}`} className="fare-triangle-row" key={rowStage}>
+                                    <span className="govuk-heading-s fare-triangle-label-left">
                                         <span>{rowIndex > 0 ? rowStage : null}</span>
                                     </span>
                                     {stageNamesArray.slice(0, rowIndex).map(columnStage => (
                                         <React.Fragment key={columnStage}>
                                             <span
-                                                role="cell"
                                                 className={`fare-triangle-input ${
                                                     rowIndex % 2 === 0
                                                         ? 'fare-triangle-input-white'
@@ -133,11 +132,7 @@ const PriceEntry = ({
                                             </label>
                                         </React.Fragment>
                                     ))}
-                                    <div
-                                        role="columnheader"
-                                        aria-sort="none"
-                                        className="govuk-heading-s fare-triangle-label-right"
-                                    >
+                                    <div aria-sort="none" className="govuk-heading-s fare-triangle-label-right">
                                         {rowStage}
                                     </div>
                                 </div>

--- a/tests/pages/__snapshots__/priceEntry.test.tsx.snap
+++ b/tests/pages/__snapshots__/priceEntry.test.tsx.snap
@@ -39,28 +39,23 @@ exports[`Price Entry Page should render correctly 1`] = `
       </span>
       <div
         className="fare-triangle-container"
-        role="table"
       >
         <div
           className="fare-triangle"
-          role="rowgroup"
         >
           <div
             className="fare-triangle-row"
             id="row-0"
             key="Briggate"
-            role="row"
           >
             <span
               className="govuk-heading-s fare-triangle-label-left"
-              role="rowheader"
             >
               <span />
             </span>
             <div
               aria-sort="none"
               className="govuk-heading-s fare-triangle-label-right"
-              role="columnheader"
             >
               Briggate
             </div>
@@ -69,11 +64,9 @@ exports[`Price Entry Page should render correctly 1`] = `
             className="fare-triangle-row"
             id="row-1"
             key="Chapeltown"
-            role="row"
           >
             <span
               className="govuk-heading-s fare-triangle-label-left"
-              role="rowheader"
             >
               <span>
                 Chapeltown
@@ -81,7 +74,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </span>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -105,7 +97,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             <div
               aria-sort="none"
               className="govuk-heading-s fare-triangle-label-right"
-              role="columnheader"
             >
               Chapeltown
             </div>
@@ -114,11 +105,9 @@ exports[`Price Entry Page should render correctly 1`] = `
             className="fare-triangle-row"
             id="row-2"
             key="Chapel Allerton"
-            role="row"
           >
             <span
               className="govuk-heading-s fare-triangle-label-left"
-              role="rowheader"
             >
               <span>
                 Chapel Allerton
@@ -126,7 +115,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </span>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -149,7 +137,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -173,7 +160,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             <div
               aria-sort="none"
               className="govuk-heading-s fare-triangle-label-right"
-              role="columnheader"
             >
               Chapel Allerton
             </div>
@@ -182,11 +168,9 @@ exports[`Price Entry Page should render correctly 1`] = `
             className="fare-triangle-row"
             id="row-3"
             key="Moortown"
-            role="row"
           >
             <span
               className="govuk-heading-s fare-triangle-label-left"
-              role="rowheader"
             >
               <span>
                 Moortown
@@ -194,7 +178,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </span>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -217,7 +200,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -240,7 +222,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -264,7 +245,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             <div
               aria-sort="none"
               className="govuk-heading-s fare-triangle-label-right"
-              role="columnheader"
             >
               Moortown
             </div>
@@ -273,11 +253,9 @@ exports[`Price Entry Page should render correctly 1`] = `
             className="fare-triangle-row"
             id="row-4"
             key="Harrogate Road"
-            role="row"
           >
             <span
               className="govuk-heading-s fare-triangle-label-left"
-              role="rowheader"
             >
               <span>
                 Harrogate Road
@@ -285,7 +263,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </span>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -308,7 +285,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -331,7 +307,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -354,7 +329,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -378,7 +352,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             <div
               aria-sort="none"
               className="govuk-heading-s fare-triangle-label-right"
-              role="columnheader"
             >
               Harrogate Road
             </div>
@@ -387,11 +360,9 @@ exports[`Price Entry Page should render correctly 1`] = `
             className="fare-triangle-row"
             id="row-5"
             key="Harehills"
-            role="row"
           >
             <span
               className="govuk-heading-s fare-triangle-label-left"
-              role="rowheader"
             >
               <span>
                 Harehills
@@ -399,7 +370,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </span>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -422,7 +392,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -445,7 +414,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -468,7 +436,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -491,7 +458,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -515,7 +481,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             <div
               aria-sort="none"
               className="govuk-heading-s fare-triangle-label-right"
-              role="columnheader"
             >
               Harehills
             </div>
@@ -524,11 +489,9 @@ exports[`Price Entry Page should render correctly 1`] = `
             className="fare-triangle-row"
             id="row-6"
             key="Gipton"
-            role="row"
           >
             <span
               className="govuk-heading-s fare-triangle-label-left"
-              role="rowheader"
             >
               <span>
                 Gipton
@@ -536,7 +499,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </span>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -559,7 +521,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -582,7 +543,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -605,7 +565,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -628,7 +587,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -651,7 +609,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -675,7 +632,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             <div
               aria-sort="none"
               className="govuk-heading-s fare-triangle-label-right"
-              role="columnheader"
             >
               Gipton
             </div>
@@ -684,11 +640,9 @@ exports[`Price Entry Page should render correctly 1`] = `
             className="fare-triangle-row"
             id="row-7"
             key="Armley"
-            role="row"
           >
             <span
               className="govuk-heading-s fare-triangle-label-left"
-              role="rowheader"
             >
               <span>
                 Armley
@@ -696,7 +650,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </span>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -719,7 +672,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -742,7 +694,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -765,7 +716,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -788,7 +738,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -811,7 +760,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -834,7 +782,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -858,7 +805,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             <div
               aria-sort="none"
               className="govuk-heading-s fare-triangle-label-right"
-              role="columnheader"
             >
               Armley
             </div>
@@ -867,11 +813,9 @@ exports[`Price Entry Page should render correctly 1`] = `
             className="fare-triangle-row"
             id="row-8"
             key="Stanningley"
-            role="row"
           >
             <span
               className="govuk-heading-s fare-triangle-label-left"
-              role="rowheader"
             >
               <span>
                 Stanningley
@@ -879,7 +823,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </span>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -902,7 +845,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -925,7 +867,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -948,7 +889,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -971,7 +911,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -994,7 +933,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1017,7 +955,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1040,7 +977,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1064,7 +1000,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             <div
               aria-sort="none"
               className="govuk-heading-s fare-triangle-label-right"
-              role="columnheader"
             >
               Stanningley
             </div>
@@ -1073,11 +1008,9 @@ exports[`Price Entry Page should render correctly 1`] = `
             className="fare-triangle-row"
             id="row-9"
             key="Pudsey"
-            role="row"
           >
             <span
               className="govuk-heading-s fare-triangle-label-left"
-              role="rowheader"
             >
               <span>
                 Pudsey
@@ -1085,7 +1018,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </span>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1108,7 +1040,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1131,7 +1062,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1154,7 +1084,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1177,7 +1106,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1200,7 +1128,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1223,7 +1150,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1246,7 +1172,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1269,7 +1194,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1293,7 +1217,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             <div
               aria-sort="none"
               className="govuk-heading-s fare-triangle-label-right"
-              role="columnheader"
             >
               Pudsey
             </div>
@@ -1302,11 +1225,9 @@ exports[`Price Entry Page should render correctly 1`] = `
             className="fare-triangle-row"
             id="row-10"
             key="Seacroft"
-            role="row"
           >
             <span
               className="govuk-heading-s fare-triangle-label-left"
-              role="rowheader"
             >
               <span>
                 Seacroft
@@ -1314,7 +1235,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </span>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1337,7 +1257,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1360,7 +1279,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1383,7 +1301,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1406,7 +1323,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1429,7 +1345,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1452,7 +1367,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1475,7 +1389,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1498,7 +1411,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1521,7 +1433,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1545,7 +1456,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             <div
               aria-sort="none"
               className="govuk-heading-s fare-triangle-label-right"
-              role="columnheader"
             >
               Seacroft
             </div>
@@ -1554,11 +1464,9 @@ exports[`Price Entry Page should render correctly 1`] = `
             className="fare-triangle-row"
             id="row-11"
             key="Rothwell"
-            role="row"
           >
             <span
               className="govuk-heading-s fare-triangle-label-left"
-              role="rowheader"
             >
               <span>
                 Rothwell
@@ -1566,7 +1474,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </span>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1589,7 +1496,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1612,7 +1518,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1635,7 +1540,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1658,7 +1562,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1681,7 +1584,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1704,7 +1606,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1727,7 +1628,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1750,7 +1650,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1773,7 +1672,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1796,7 +1694,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1820,7 +1717,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             <div
               aria-sort="none"
               className="govuk-heading-s fare-triangle-label-right"
-              role="columnheader"
             >
               Rothwell
             </div>
@@ -1829,11 +1725,9 @@ exports[`Price Entry Page should render correctly 1`] = `
             className="fare-triangle-row"
             id="row-12"
             key="Dewsbury"
-            role="row"
           >
             <span
               className="govuk-heading-s fare-triangle-label-left"
-              role="rowheader"
             >
               <span>
                 Dewsbury
@@ -1841,7 +1735,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </span>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1864,7 +1757,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1887,7 +1779,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1910,7 +1801,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1933,7 +1823,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1956,7 +1845,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -1979,7 +1867,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -2002,7 +1889,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -2025,7 +1911,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -2048,7 +1933,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -2071,7 +1955,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -2094,7 +1977,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-white"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -2118,7 +2000,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             <div
               aria-sort="none"
               className="govuk-heading-s fare-triangle-label-right"
-              role="columnheader"
             >
               Dewsbury
             </div>
@@ -2127,11 +2008,9 @@ exports[`Price Entry Page should render correctly 1`] = `
             className="fare-triangle-row"
             id="row-13"
             key="Wakefield"
-            role="row"
           >
             <span
               className="govuk-heading-s fare-triangle-label-left"
-              role="rowheader"
             >
               <span>
                 Wakefield
@@ -2139,7 +2018,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </span>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -2162,7 +2040,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -2185,7 +2062,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -2208,7 +2084,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -2231,7 +2106,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -2254,7 +2128,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -2277,7 +2150,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -2300,7 +2172,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -2323,7 +2194,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -2346,7 +2216,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -2369,7 +2238,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -2392,7 +2260,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -2415,7 +2282,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             </label>
             <span
               className="fare-triangle-input fare-triangle-input-light-grey"
-              role="cell"
             >
               <input
                 aria-describedby="price-entry-hint"
@@ -2439,7 +2305,6 @@ exports[`Price Entry Page should render correctly 1`] = `
             <div
               aria-sort="none"
               className="govuk-heading-s fare-triangle-label-right"
-              role="columnheader"
             >
               Wakefield
             </div>


### PR DESCRIPTION
# Description

- Remove fares triangle table roles to improve navigation for screen readers
- Swap internal NOC when doing operator search to return results

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [ ] Able to run pr locally
-   [ ] Followed acceptance criteria
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
