### PR TITLE
Changed page so that proof doesnt render for adults

### DIFF
--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -38,7 +38,7 @@ const Header = ({ isAuthed, csrfToken }: HeaderProps): ReactElement => (
                     id="title-link"
                     className="govuk-header__link govuk-header__link--service-name"
                 >
-                    Create Fares Data service
+                    Create Fares Data
                 </a>
             </div>
 

--- a/src/pages/definePassengerType.tsx
+++ b/src/pages/definePassengerType.tsx
@@ -304,20 +304,16 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: De
         };
     }
 
-    fieldsets = getFieldsets(errors, passengerType);
-
-    let passengerTypeToRender = '';
-
     if (!passengerType) {
         if (isPassengerTypeAttributeWithErrors(passengerTypeAttribute)) {
             throw new Error('Incorrect passenger type found');
         }
-        passengerTypeToRender = passengerTypeAttribute.passengerType;
-    } else {
-        passengerTypeToRender = passengerType;
+        passengerType = passengerTypeAttribute.passengerType;
     }
 
-    return { props: { group, errors, fieldsets, passengerType: passengerTypeToRender } };
+    fieldsets = getFieldsets(errors, passengerType);
+
+    return { props: { group, errors, fieldsets, passengerType } };
 };
 
 export default DefinePassengerType;

--- a/tests/layout/__snapshots__/Header.test.tsx.snap
+++ b/tests/layout/__snapshots__/Header.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`Header should render correctly 1`] = `
         href="/home"
         id="title-link"
       >
-        Create Fares Data service
+        Create Fares Data
       </a>
     </div>
     <div

--- a/tests/pages/definePassengerType.test.tsx
+++ b/tests/pages/definePassengerType.test.tsx
@@ -16,6 +16,8 @@ import {
     getMockContext,
     mockNumberOfPassengerTypeFieldset,
     mockNumberOfPassengerTypeFieldsetWithErrors,
+    mockAdultServerSideProps,
+    mockAdultDefinePassengerTypeFieldsetsWithRadioAndInputErrors,
 } from '../testData/mockData';
 import { ErrorInfo } from '../../src/interfaces';
 import {
@@ -217,27 +219,35 @@ describe('pages', () => {
                     );
                 },
             );
+            it('should not render the proof fieldset if user type is adult', () => {
+                const ctx = getMockContext({
+                    session: {
+                        [PASSENGER_TYPE_ATTRIBUTE]: { passengerType: 'adult' },
+                    },
+                });
+
+                const result = getServerSideProps(ctx);
+                expect(result.props.fieldsets).toEqual(mockAdultServerSideProps);
+            });
             it('should return props containing errors and valid fieldsets when radio and input errors are present on a non-group ticket user journey', () => {
                 const errors: ErrorInfo[] = [
-                    { errorMessage: 'Choose one of the options below', id: 'proof-required' },
                     { errorMessage: 'Enter a minimum or maximum age', id: 'age-range-min' },
                     { errorMessage: 'Enter a minimum or maximum age', id: 'age-range-max' },
                 ];
                 const ctx = getMockContext({
                     session: {
-                        [PASSENGER_TYPE_ATTRIBUTE]: { passengerType: 'Adult' },
-                        [DEFINE_PASSENGER_TYPE_ERRORS_ATTRIBUTE]: { passengerType: 'Adult', errors },
+                        [PASSENGER_TYPE_ATTRIBUTE]: { passengerType: 'adult' },
+                        [DEFINE_PASSENGER_TYPE_ERRORS_ATTRIBUTE]: { passengerType: 'adult', errors },
                     },
                 });
                 const result = getServerSideProps(ctx);
                 expect(result.props.group).toEqual(false);
                 expect(result.props.errors).toEqual(errors);
-                expect(result.props.fieldsets).toEqual(mockDefinePassengerTypeFieldsetsWithRadioAndInputErrors);
+                expect(result.props.fieldsets).toEqual(mockAdultDefinePassengerTypeFieldsetsWithRadioAndInputErrors);
             });
 
             it('should return props containing errors and valid fieldsets when radio and all input errors are present on a group ticket user journey', () => {
                 const errors: ErrorInfo[] = [
-                    { errorMessage: 'Choose one of the options below', id: 'proof-required' },
                     { errorMessage: 'Enter a minimum or maximum age', id: 'age-range-min' },
                     { errorMessage: 'Enter a minimum or maximum age', id: 'age-range-max' },
                     {

--- a/tests/testData/mockData.ts
+++ b/tests/testData/mockData.ts
@@ -2528,6 +2528,33 @@ export const mockPassengerTypeInputErrors: ErrorInfo[] = [
     },
 ];
 
+export const mockAdultServerSideProps: RadioConditionalInputFieldset[] = [
+    {
+        heading: { content: 'Do adult passengers have an age range?', id: 'define-passenger-age-range' },
+        radioError: [],
+        radios: [
+            {
+                dataAriaControls: 'age-range-required-conditional',
+                hint: {
+                    content: 'Enter a minimum and/or maximum age for this passenger type.',
+                    id: 'define-passenger-age-range-hint',
+                },
+                id: 'age-range-required',
+                inputErrors: [],
+                inputType: 'text',
+                inputs: [
+                    { id: 'age-range-min', label: 'Minimum Age (if applicable)', name: 'ageRangeMin' },
+                    { id: 'age-range-max', label: 'Maximum Age (if applicable)', name: 'ageRangeMax' },
+                ],
+                label: 'Yes',
+                name: 'ageRange',
+                value: 'Yes',
+            },
+            { id: 'age-range-not-required', label: 'No', name: 'ageRange', value: 'No' },
+        ],
+    },
+];
+
 export const mockDefinePassengerTypeFieldsetsWithRadioAndInputErrors: RadioConditionalInputFieldset[] = [
     {
         heading: {
@@ -2616,12 +2643,59 @@ export const mockDefinePassengerTypeFieldsetsWithRadioAndInputErrors: RadioCondi
             },
             { id: 'proof-not-required', name: 'proof', value: 'No', label: 'No' },
         ],
-        radioError: [
+        radioError: [],
+    },
+];
+
+export const mockAdultDefinePassengerTypeFieldsetsWithRadioAndInputErrors: RadioConditionalInputFieldset[] = [
+    {
+        heading: {
+            id: 'define-passenger-age-range',
+            content: expect.any(String),
+        },
+        radios: [
             {
-                errorMessage: 'Choose one of the options below',
-                id: 'proof-required',
+                id: 'age-range-required',
+                name: 'ageRange',
+                value: 'Yes',
+                dataAriaControls: 'age-range-required-conditional',
+                label: 'Yes',
+                hint: {
+                    id: 'define-passenger-age-range-hint',
+                    content: 'Enter a minimum and/or maximum age for this passenger type.',
+                },
+                inputType: 'text',
+                inputs: [
+                    {
+                        id: 'age-range-min',
+                        name: 'ageRangeMin',
+                        label: 'Minimum Age (if applicable)',
+                    },
+                    {
+                        id: 'age-range-max',
+                        name: 'ageRangeMax',
+                        label: 'Maximum Age (if applicable)',
+                    },
+                ],
+                inputErrors: [
+                    {
+                        errorMessage: 'Enter a minimum or maximum age',
+                        id: 'age-range-min',
+                    },
+                    {
+                        errorMessage: 'Enter a minimum or maximum age',
+                        id: 'age-range-max',
+                    },
+                ],
+            },
+            {
+                id: 'age-range-not-required',
+                name: 'ageRange',
+                value: 'No',
+                label: 'No',
             },
         ],
+        radioError: [],
     },
 ];
 


### PR DESCRIPTION
# Description

-   To ensure adults arent asked for proof documents when user is selecting user type.

# Testing instructions

-   Run site locally and check user pages, for group and non group.

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [ ] Able to run pr locally
-   [ ] Followed acceptance criteria
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
