### PR TITLE
Updated max number of characters for fare stage names

### DIFF
--- a/src/pages/api/stageNames.ts
+++ b/src/pages/api/stageNames.ts
@@ -26,8 +26,8 @@ export const isStageNameValid = (req: NextApiRequestWithSession): InputCheck[] =
         let error;
         if (!stageNameInput[i] || stageNameInput[i].replace(/\s+/g, '').length === 0) {
             error = 'Enter a name for this fare stage';
-        } else if (stageNameInput[i].length > 30) {
-            error = `The name for Fare Stage ${i + 1} needs to be less than 30 characters`;
+        } else if (stageNameInput[i].length > 70) {
+            error = `The name for Fare Stage ${i + 1} needs to be 70 characters or fewer`;
         } else if (stageNameInArrayMultipleTimes(stageNameInput, stageNameInput[i])) {
             error = 'Stage names cannot share exact names';
         } else {

--- a/src/pages/stageNames.tsx
+++ b/src/pages/stageNames.tsx
@@ -97,7 +97,7 @@ const StageNames = ({
                             Enter the names of the fare stages in order from first to last
                         </h1>
                     </legend>
-                    <div className="govuk-hint">Fare stage names are limited to 30 characters</div>
+                    <div className="govuk-hint">Fare stage names are limited to 70 characters</div>
                     <div>{renderInputFields(numberOfFareStages, inputChecks, errors, defaults)}</div>
                 </fieldset>
                 <input type="submit" value="Continue" id="continue-button" className="govuk-button" />

--- a/tests/pages/__snapshots__/stageNames.test.tsx.snap
+++ b/tests/pages/__snapshots__/stageNames.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`pages stageNames should render correctly when a user first visits the p
       <div
         className="govuk-hint"
       >
-        Fare stage names are limited to 30 characters
+        Fare stage names are limited to 70 characters
       </div>
       <div>
         <div
@@ -215,7 +215,7 @@ exports[`pages stageNames should render correctly when a user is redirected to t
       <div
         className="govuk-hint"
       >
-        Fare stage names are limited to 30 characters
+        Fare stage names are limited to 70 characters
       </div>
       <div>
         <div
@@ -383,7 +383,7 @@ exports[`pages stageNames should render correctly when a user is redirected to t
       <div
         className="govuk-hint"
       >
-        Fare stage names are limited to 30 characters
+        Fare stage names are limited to 70 characters
       </div>
       <div>
         <div

--- a/tests/pages/api/stageNames.test.ts
+++ b/tests/pages/api/stageNames.test.ts
@@ -34,7 +34,17 @@ describe('stageNames', () => {
             expect(inputCheck).toEqual(expectedArray);
         });
         it('should return an array of invalid and valid input checks when the user enters incorrect data', () => {
-            const mockBody = { stageNameInput: ['abcde', '   ', 'xyz', '', 'gggg', 'gggg'] };
+            const mockBody = {
+                stageNameInput: [
+                    'abcde',
+                    '   ',
+                    'xyz',
+                    '',
+                    'gggg',
+                    'gggg',
+                    'moreThan70Charactersmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz',
+                ],
+            };
             const { req } = getMockRequestAndResponse({ cookieValues: {}, body: mockBody });
             const expectedArray = [
                 { error: '', id: 'fare-stage-name-1', input: 'abcde' },
@@ -43,6 +53,11 @@ describe('stageNames', () => {
                 { error: 'Enter a name for this fare stage', id: 'fare-stage-name-4', input: '' },
                 { error: 'Stage names cannot share exact names', id: 'fare-stage-name-5', input: 'gggg' },
                 { error: 'Stage names cannot share exact names', id: 'fare-stage-name-6', input: 'gggg' },
+                {
+                    error: 'The name for Fare Stage 7 needs to be 70 characters or fewer',
+                    id: 'fare-stage-name-7',
+                    input: 'moreThan70Charactersmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz',
+                },
             ];
             const inputCheck = isStageNameValid(req);
             expect(inputCheck).toEqual(expectedArray);
@@ -72,7 +87,9 @@ describe('stageNames', () => {
     });
 
     it('should return 302 redirect to /priceEntry when session is valid and request body is present', () => {
-        const mockBody = { stageNameInput: ['a', 'b', 'c', 'd'] };
+        const mockBody = {
+            stageNameInput: ['a', 'b', 'c', '70charactersgaregeargfvfevergergergergergergergergerfsawefwefwewefgerg'],
+        };
         const mockWriteHeadFn = jest.fn();
         const { req, res } = getMockRequestAndResponse({ cookieValues: {}, body: mockBody, uuid: {}, mockWriteHeadFn });
         stageNames(req, res);
@@ -92,13 +109,20 @@ describe('stageNames', () => {
 
     it('should set the STAGE_NAMES_ATTRIBUTE with a value matching the invalid data entered by the user', () => {
         const setUpdateSessionspy = jest.spyOn(sessions, 'updateSessionAttribute');
-        const mockBody = { stageNameInput: [' ', 'abcdefghijklmnopqrstuvwxyzabcdefgh', '   ', 'b'] };
+        const mockBody = {
+            stageNameInput: [
+                ' ',
+                'moreThan70Charactersmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz',
+                '   ',
+                'b',
+            ],
+        };
         const { req, res } = getMockRequestAndResponse({ cookieValues: {}, body: mockBody });
         const mockInputCheck = [
             { input: ' ', error: 'Enter a name for this fare stage', id: 'fare-stage-name-1' },
             {
-                input: 'abcdefghijklmnopqrstuvwxyzabcdefgh',
-                error: 'The name for Fare Stage 2 needs to be less than 30 characters',
+                input: 'moreThan70Charactersmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz',
+                error: 'The name for Fare Stage 2 needs to be 70 characters or fewer',
                 id: 'fare-stage-name-2',
             },
             { input: '   ', error: 'Enter a name for this fare stage', id: 'fare-stage-name-3' },


### PR DESCRIPTION
# Description

-   To allow users enter longer fare stage names, up to 70 characters.

# Testing instructions

-   Use site and add longer fare stage names.

# Type of change

-   [ ] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [x] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [ ] Able to run pr locally
-   [ ] Followed acceptance criteria
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
