### PR TITLE
feat: allow scheme operators

### DIFF
--- a/src/data/auroradb.ts
+++ b/src/data/auroradb.ts
@@ -416,11 +416,11 @@ export const insertSalesOfferPackage = async (nocCode: string, salesOfferPackage
     }
 };
 
-export const getSearchOperators = async (searchText: string, nocCode: string): Promise<Operator[]> => {
+export const getSearchOperatorsByNocRegion = async (searchText: string, nocCode: string): Promise<Operator[]> => {
     logger.info('', {
         context: 'data.auroradb',
         message: 'retrieving operators for given search text and noc',
-        noc: nocCode,
+        nocCode,
         search: searchText,
     });
 
@@ -433,6 +433,28 @@ export const getSearchOperators = async (searchText: string, nocCode: string): P
 
     try {
         return await executeQuery<Operator[]>(searchQuery, [nocCodeParameter, `%${searchText}%`]);
+    } catch (error) {
+        throw new Error(`Could not retrieve operators from AuroraDB: ${error.stack}`);
+    }
+};
+
+export const getSearchOperatorsBySchemeOpRegion = async (
+    searchText: string,
+    regionCode: string,
+): Promise<Operator[]> => {
+    logger.info('', {
+        context: 'data.auroradb',
+        message: 'retrieving operators for given search text and noc',
+        regionCode,
+        search: searchText,
+    });
+
+    const searchQuery = `SELECT nocCode, operatorPublicName FROM nocTable WHERE nocCode IN (
+        SELECT DISTINCT nocCode FROM tndsOperatorService WHERE regionCode = ?
+        ) AND operatorPublicName LIKE ?`;
+
+    try {
+        return await executeQuery<Operator[]>(searchQuery, [regionCode, `%${searchText}%`]);
     } catch (error) {
         throw new Error(`Could not retrieve operators from AuroraDB: ${error.stack}`);
     }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -79,6 +79,8 @@ export interface CognitoIdToken {
     iat: number;
     email: string;
     'custom:contactable': string;
+    'custom:schemeOperator': string;
+    'custom:schemeRegionCode': string;
 }
 
 export interface Breadcrumb {

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -2,6 +2,14 @@ import { NextApiRequest, NextPageContext } from 'next';
 import { DocumentContext } from 'next/document';
 import { IncomingMessage } from 'http';
 
+export type Ticket =
+    | SingleTicket
+    | ReturnTicket
+    | GeoZoneTicket
+    | PeriodMultipleServicesTicket
+    | FlatFareTicket
+    | SchemeOperatorTicket;
+
 export interface BaseReactElement {
     id: string;
     name: string;
@@ -156,6 +164,30 @@ export interface TimeRestriction {
     endTime?: string;
     validDays?: ('monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday' | 'sunday')[];
 }
+
+export interface SchemeOperatorTicket {
+    schemeOperatorName: string;
+    schemeOperatorRegionCode: string;
+    type: string;
+    passengerType: string;
+    ageRange?: string;
+    ageRangeMin?: string;
+    ageRangeMax?: string;
+    proof?: string;
+    proofDocuments?: string[];
+    email: string;
+    uuid: string;
+    timeRestriction?: TimeRestriction;
+    ticketPeriod: TicketPeriod;
+    products: ProductDetails[];
+    zoneName: string;
+    stops: Stop[];
+    additionalNocs: string[];
+}
+
+export const isSchemeOperatorTicket = (data: Ticket): data is SchemeOperatorTicket =>
+    (data as SchemeOperatorTicket).schemeOperatorName !== undefined &&
+    (data as SchemeOperatorTicket).schemeOperatorRegionCode !== undefined;
 
 export interface BaseTicket {
     nocCode: string;

--- a/src/pages/api/apiUtils/index.ts
+++ b/src/pages/api/apiUtils/index.ts
@@ -135,6 +135,29 @@ export const getAndValidateNoc = (req: NextApiRequest, res: NextApiResponse): st
     throw new Error('invalid noc set');
 };
 
+export const getSchemeOpRegionFromIdToken = (req: NextApiRequest, res: NextApiResponse): string | null =>
+    getAttributeFromIdToken(req, res, 'custom:schemeRegionCode');
+
+export const getAndValidateSchemeOpRegion = (req: NextApiRequest, res: NextApiResponse): string | null => {
+    const idTokenSchemeOpRegion = getSchemeOpRegionFromIdToken(req, res);
+    const operatorCookie = unescapeAndDecodeCookie(new Cookies(req, res), OPERATOR_COOKIE);
+    const cookieSchemeOpRegion = JSON.parse(operatorCookie).region;
+
+    if (!cookieSchemeOpRegion && !idTokenSchemeOpRegion) {
+        return null;
+    }
+
+    if (
+        !cookieSchemeOpRegion ||
+        !idTokenSchemeOpRegion ||
+        (cookieSchemeOpRegion && idTokenSchemeOpRegion && cookieSchemeOpRegion !== idTokenSchemeOpRegion)
+    ) {
+        throw new Error('invalid scheme operator region code set');
+    }
+
+    return cookieSchemeOpRegion;
+};
+
 export const signOutUser = async (username: string | null, req: Req, res: Res): Promise<void> => {
     if (username) {
         await globalSignOut(username);

--- a/src/pages/api/apiUtils/index.ts
+++ b/src/pages/api/apiUtils/index.ts
@@ -158,6 +158,9 @@ export const getAndValidateSchemeOpRegion = (req: NextApiRequest, res: NextApiRe
     return cookieSchemeOpRegion;
 };
 
+export const isSchemeOperator = (req: NextApiRequest, res: NextApiResponse): boolean =>
+    !(!getAndValidateSchemeOpRegion(req, res) && !!getAndValidateNoc(req, res));
+
 export const signOutUser = async (username: string | null, req: Req, res: Res): Promise<void> => {
     if (username) {
         await globalSignOut(username);

--- a/src/pages/api/fareConfirmation.ts
+++ b/src/pages/api/fareConfirmation.ts
@@ -1,5 +1,5 @@
 import { NextApiResponse } from 'next';
-import { redirectToError, redirectOnFareType } from './apiUtils';
+import { redirectToError, redirectOnFareType, isSchemeOperator, redirectTo } from './apiUtils';
 import { isSessionValid } from './apiUtils/validator';
 import { NextApiRequestWithSession } from '../../interfaces';
 
@@ -8,6 +8,12 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
         if (!isSessionValid(req, res)) {
             throw new Error('session is invalid.');
         }
+
+        if (isSchemeOperator(req, res)) {
+            redirectTo(res, '/csvZoneUpload');
+            return;
+        }
+
         redirectOnFareType(req, res);
     } catch (error) {
         const message = 'There was a problem redirecting the user from the fare confirmation page:';

--- a/src/pages/api/salesConfirmation.ts
+++ b/src/pages/api/salesConfirmation.ts
@@ -60,35 +60,32 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
         }
 
         const uuid = getUuidFromCookie(req, res);
-        const schemeOp = isSchemeOperator(req, res);
 
         let userDataJson;
 
         const fareType = isFareType(fareTypeAttribute) && fareTypeAttribute.fareType;
 
-        if (schemeOp) {
+        if (isSchemeOperator(req, res)) {
             userDataJson = await getSchemeOperatorTicketJson(req, res);
-        } else if (!schemeOp) {
-            if (fareType === 'single') {
-                userDataJson = getSingleTicketJson(req, res);
-            } else if (fareType === 'return') {
-                userDataJson = getReturnTicketJson(req, res);
-            } else if (fareType === 'period' || fareType === 'multiOperator') {
-                const ticketRepresentation = getSessionAttribute(req, TICKET_REPRESENTATION_ATTRIBUTE);
-                const ticketType = isTicketRepresentation(ticketRepresentation) ? ticketRepresentation.name : '';
+        } else if (fareType === 'single') {
+            userDataJson = getSingleTicketJson(req, res);
+        } else if (fareType === 'return') {
+            userDataJson = getReturnTicketJson(req, res);
+        } else if (fareType === 'period' || fareType === 'multiOperator') {
+            const ticketRepresentation = getSessionAttribute(req, TICKET_REPRESENTATION_ATTRIBUTE);
+            const ticketType = isTicketRepresentation(ticketRepresentation) ? ticketRepresentation.name : '';
 
-                if (ticketType !== 'geoZone' && ticketType !== 'multipleServices') {
-                    throw new Error('No period type found to generate user data json.');
-                }
-
-                if (ticketType === 'geoZone') {
-                    userDataJson = await getGeoZoneTicketJson(req, res);
-                } else if (ticketType === 'multipleServices') {
-                    userDataJson = getMultipleServicesTicketJson(req, res);
-                }
-            } else if (fareType === 'flatFare') {
-                userDataJson = getFlatFareTicketJson(req, res);
+            if (ticketType !== 'geoZone' && ticketType !== 'multipleServices') {
+                throw new Error('No period type found to generate user data json.');
             }
+
+            if (ticketType === 'geoZone') {
+                userDataJson = await getGeoZoneTicketJson(req, res);
+            } else if (ticketType === 'multipleServices') {
+                userDataJson = getMultipleServicesTicketJson(req, res);
+            }
+        } else if (fareType === 'flatFare') {
+            userDataJson = getFlatFareTicketJson(req, res);
         }
 
         if (userDataJson) {

--- a/src/pages/fareType.tsx
+++ b/src/pages/fareType.tsx
@@ -145,13 +145,13 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Fa
     }
     const operatorInfo = JSON.parse(operatorCookie);
     const operatorName = schemeOp ? operatorInfo.operator : operatorInfo.operator.operatorPublicName;
-    opIdentifier = schemeOp ? `${operatorName}` : opIdentifier;
+    opIdentifier = schemeOp ? operatorName : opIdentifier;
     const uuid = buildUuid(opIdentifier);
     const cookieValue = JSON.stringify({ ...operatorInfo, uuid });
 
     setCookieOnServerSide(ctx, OPERATOR_COOKIE, cookieValue);
 
-    if (schemeOp || (!schemeOp && opIdentifier !== INTERNAL_NOC)) {
+    if (schemeOp || opIdentifier !== INTERNAL_NOC) {
         logger.info('', {
             context: 'pages.fareType',
             message: 'transaction start',

--- a/src/pages/fareType.tsx
+++ b/src/pages/fareType.tsx
@@ -2,15 +2,22 @@ import React, { ReactElement } from 'react';
 import { parseCookies } from 'nookies';
 import { v4 as uuidv4 } from 'uuid';
 import TwoThirdsLayout from '../layout/Layout';
-import { FARE_TYPE_ATTRIBUTE, OPERATOR_COOKIE, INTERNAL_NOC } from '../constants';
+import { FARE_TYPE_ATTRIBUTE, OPERATOR_COOKIE, INTERNAL_NOC, TICKET_REPRESENTATION_ATTRIBUTE } from '../constants';
 import { ErrorInfo, NextPageContextWithSession } from '../interfaces';
 import ErrorSummary from '../components/ErrorSummary';
-import { setCookieOnServerSide, getAndValidateNoc, getCsrfToken } from '../utils/index';
+import {
+    setCookieOnServerSide,
+    getAndValidateNoc,
+    getCsrfToken,
+    getAndValidateSchemeOpRegion,
+    isSchemeOperator,
+} from '../utils/index';
 import FormElementWrapper from '../components/FormElementWrapper';
 import CsrfForm from '../components/CsrfForm';
 import logger from '../utils/logger';
-import { getSessionAttribute } from '../utils/sessions';
+import { getSessionAttribute, updateSessionAttribute } from '../utils/sessions';
 import { isFareTypeAttributeWithErrors } from '../interfaces/typeGuards';
+import { redirectTo } from './api/apiUtils';
 
 const title = 'Fare Type - Create Fares Data Service ';
 const description = 'Fare Type selection page of the Create Fares Data Service';
@@ -18,7 +25,7 @@ const description = 'Fare Type selection page of the Create Fares Data Service';
 const errorId = 'fare-type-single';
 
 type FareTypeProps = {
-    operator: string;
+    operatorName: string;
     errors: ErrorInfo[];
     csrfToken: string;
 };
@@ -29,8 +36,7 @@ export const buildUuid = (noc: string): string => {
     return noc + uuid.substring(0, 8);
 };
 
-const FareTypePage = (props: FareTypeProps): ReactElement => {
-    const { operator, errors = [], csrfToken } = props;
+const FareTypePage = ({ operatorName, errors = [], csrfToken }: FareTypeProps): ReactElement => {
     return (
         <TwoThirdsLayout title={title} description={description} errors={errors}>
             <CsrfForm action="/api/fareType" method="post" csrfToken={csrfToken}>
@@ -44,7 +50,7 @@ const FareTypePage = (props: FareTypeProps): ReactElement => {
                                 </h1>
                             </legend>
                             <span className="govuk-hint" id="fare-type-operator-hint">
-                                {operator}
+                                {operatorName}
                             </span>
                             <FormElementWrapper errors={errors} errorId={errorId} errorClass="govuk-radios--error">
                                 <div className="govuk-radios">
@@ -129,23 +135,33 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Fa
     const cookies = parseCookies(ctx);
     const csrfToken = getCsrfToken(ctx);
 
-    const operatorCookie = cookies[OPERATOR_COOKIE];
-    const noc = getAndValidateNoc(ctx);
+    const schemeOp = isSchemeOperator(ctx);
+    let opIdentifier = getAndValidateSchemeOpRegion(ctx) || getAndValidateNoc(ctx);
 
-    if (!operatorCookie || !noc) {
+    const operatorCookie = cookies[OPERATOR_COOKIE];
+
+    if (!operatorCookie || !opIdentifier) {
         throw new Error('Necessary data not found to show faretype page');
     }
     const operatorInfo = JSON.parse(operatorCookie);
-    const uuid = buildUuid(noc);
+    const operatorName = schemeOp ? operatorInfo.operator : operatorInfo.operator.operatorPublicName;
+    opIdentifier = schemeOp ? `${operatorName}#${opIdentifier}` : opIdentifier;
+    const uuid = buildUuid(opIdentifier);
     const cookieValue = JSON.stringify({ ...operatorInfo, uuid });
 
     setCookieOnServerSide(ctx, OPERATOR_COOKIE, cookieValue);
 
-    if (noc !== INTERNAL_NOC) {
+    if (schemeOp || (!schemeOp && opIdentifier !== INTERNAL_NOC)) {
         logger.info('', {
             context: 'pages.fareType',
             message: 'transaction start',
         });
+    }
+
+    if (schemeOp && ctx.res) {
+        updateSessionAttribute(ctx.req, FARE_TYPE_ATTRIBUTE, { fareType: 'multiOperator' });
+        updateSessionAttribute(ctx.req, TICKET_REPRESENTATION_ATTRIBUTE, { name: 'geoZone' });
+        redirectTo(ctx.res, '/passengerType');
     }
 
     const fareTypeAttribute = getSessionAttribute(ctx.req, FARE_TYPE_ATTRIBUTE);
@@ -153,7 +169,7 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Fa
     const errors: ErrorInfo[] =
         fareTypeAttribute && isFareTypeAttributeWithErrors(fareTypeAttribute) ? fareTypeAttribute.errors : [];
 
-    return { props: { operator: operatorInfo.operator.operatorPublicName, errors, csrfToken } };
+    return { props: { operatorName, errors, csrfToken } };
 };
 
 export default FareTypePage;

--- a/src/pages/fareType.tsx
+++ b/src/pages/fareType.tsx
@@ -145,7 +145,7 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Fa
     }
     const operatorInfo = JSON.parse(operatorCookie);
     const operatorName = schemeOp ? operatorInfo.operator : operatorInfo.operator.operatorPublicName;
-    opIdentifier = schemeOp ? `${operatorName}#${opIdentifier}` : opIdentifier;
+    opIdentifier = schemeOp ? `${operatorName}` : opIdentifier;
     const uuid = buildUuid(opIdentifier);
     const cookieValue = JSON.stringify({ ...operatorInfo, uuid });
 

--- a/src/pages/fareType.tsx
+++ b/src/pages/fareType.tsx
@@ -125,7 +125,7 @@ const FareTypePage = (props: FareTypeProps): ReactElement => {
     );
 };
 
-export const getServerSideProps = (ctx: NextPageContextWithSession): {} => {
+export const getServerSideProps = (ctx: NextPageContextWithSession): { props: FareTypeProps } => {
     const cookies = parseCookies(ctx);
     const csrfToken = getCsrfToken(ctx);
 

--- a/src/pages/multipleProductValidity.tsx
+++ b/src/pages/multipleProductValidity.tsx
@@ -17,7 +17,7 @@ import { isPassengerType } from '../interfaces/typeGuards';
 import { isNumberOfProductsAttribute } from './howManyProducts';
 import { isBaseMultipleProductAttributeWithErrors } from './multipleProducts';
 import { Product } from './api/multipleProductValidity';
-import { getCsrfToken } from '../utils';
+import { getCsrfToken, isSchemeOperator } from '../utils';
 
 const title = 'Multiple Product Validity - Create Fares Data Service';
 const description = 'Multiple Product Validity selection page of the Create Fares Data Service';
@@ -25,7 +25,7 @@ const description = 'Multiple Product Validity selection page of the Create Fare
 const errorId = 'twenty-four-hours-row-0';
 
 interface MultipleProductValidityProps {
-    operator: string;
+    operatorName: string;
     passengerType: string;
     numberOfProducts: string;
     multipleProducts: Product[];
@@ -34,7 +34,7 @@ interface MultipleProductValidityProps {
 }
 
 const MultipleProductValidity = ({
-    operator,
+    operatorName,
     passengerType,
     numberOfProducts,
     multipleProducts,
@@ -55,7 +55,7 @@ const MultipleProductValidity = ({
                         When does the product expire?
                     </h1>
                     <span className="govuk-hint" id="operator-products-hint">
-                        {operator} - {numberOfProducts} products - {upperFirst(passengerType)}
+                        {operatorName} - {numberOfProducts} products - {upperFirst(passengerType)}
                     </span>
                     <span className="govuk-hint" id="multiple-product-validity-page-hint">
                         We need to know the time that this product would be valid until
@@ -167,6 +167,7 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Mu
         throw new Error('Necessary cookies/session not found to display the multiple product validity page');
     }
     const { operator } = JSON.parse(operatorCookie);
+    const operatorName = isSchemeOperator(ctx) ? operator : operator.operatorPublicName;
 
     const multipleProducts: Product[] = multipleProductAttribute.products;
     const numberOfProducts = numberOfProductsAttribute.numberOfProductsInput;
@@ -184,7 +185,7 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Mu
 
     return {
         props: {
-            operator: operator.operatorPublicName,
+            operatorName,
             passengerType: passengerTypeAttribute.passengerType,
             numberOfProducts,
             multipleProducts,

--- a/src/pages/productDetails.tsx
+++ b/src/pages/productDetails.tsx
@@ -17,7 +17,7 @@ import { getSessionAttribute } from '../utils/sessions';
 import { isPassengerType } from '../interfaces/typeGuards';
 import { isFareZoneAttributeWithErrors } from './csvZoneUpload';
 import { isServiceListAttributeWithErrors } from './serviceList';
-import { getCsrfToken } from '../utils';
+import { getCsrfToken, isSchemeOperator } from '../utils';
 
 const title = 'Product Details - Create Fares Data Service';
 const description = 'Product Details entry page of the Create Fares Data Service';
@@ -167,7 +167,7 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Pr
     return {
         props: {
             product: productDetailsAttribute && isProductInfo(productDetailsAttribute) ? productDetailsAttribute : null,
-            operator: operator.operatorPublicName,
+            operator: isSchemeOperator(ctx) ? operator : operator.operatorPublicName,
             passengerType: passengerTypeAttribute.passengerType,
             errors:
                 productDetailsAttribute && isProductInfoWithErrors(productDetailsAttribute)

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -21,13 +21,10 @@ interface RegisterProps {
 
 const Register = ({ errors, regKey, csrfToken }: RegisterProps): ReactElement => {
     let email = '';
-    let nocCode = '';
 
     errors?.forEach((input: ErrorInfo) => {
         if (input.id === 'email') {
             email = input.userInput ?? '';
-        } else if (input.id === 'nocCode') {
-            nocCode = input.userInput ?? '';
         }
     });
 
@@ -109,26 +106,6 @@ const Register = ({ errors, regKey, csrfToken }: RegisterProps): ReactElement =>
                                             spellCheck="false"
                                             autoComplete="new-password"
                                         />
-                                    </div>
-                                    <div className="govuk-form-group">
-                                        <label className="govuk-label" htmlFor="noc-code" id="noc-code-label">
-                                            Enter National Operator Code
-                                        </label>
-                                        <FormElementWrapper
-                                            errors={errors}
-                                            errorId="noc-code"
-                                            errorClass="govuk-input--error"
-                                        >
-                                            <input
-                                                className="govuk-input"
-                                                id="noc-code"
-                                                name="nocCode"
-                                                type="text"
-                                                aria-describedby="noc-code-label"
-                                                spellCheck="false"
-                                                defaultValue={nocCode}
-                                            />
-                                        </FormElementWrapper>
                                     </div>
                                     <p className="govuk-body govuk-!-margin-top-5">
                                         By using this website, you agree to the&nbsp;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -171,6 +171,9 @@ export const getAndValidateSchemeOpRegion = (ctx: NextPageContext): string | nul
     return cookieSchemeOpRegion;
 };
 
+export const isSchemeOperator = (ctx: NextPageContextWithSession): boolean =>
+    !(!getAndValidateSchemeOpRegion(ctx) && !!getAndValidateNoc(ctx));
+
 export const getErrorsByIds = (ids: string[], errors: ErrorInfo[]): ErrorInfo[] => {
     const compactErrors: ErrorInfo[] = [];
     errors.forEach(error => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -149,6 +149,28 @@ export const getAndValidateNoc = (ctx: NextPageContext): string => {
     throw new Error('invalid NOC set');
 };
 
+export const getSchemeOpRegionFromIdToken = (ctx: NextPageContext): string | null =>
+    getAttributeFromIdToken(ctx, 'custom:schemeRegionCode');
+
+export const getAndValidateSchemeOpRegion = (ctx: NextPageContext): string | null => {
+    const idTokenSchemeOpRegion = getSchemeOpRegionFromIdToken(ctx);
+    const cookieSchemeOpRegion = getCookieValue(ctx, OPERATOR_COOKIE, 'region');
+
+    if (!cookieSchemeOpRegion && !idTokenSchemeOpRegion) {
+        return null;
+    }
+
+    if (
+        !cookieSchemeOpRegion ||
+        !idTokenSchemeOpRegion ||
+        (cookieSchemeOpRegion && idTokenSchemeOpRegion && cookieSchemeOpRegion !== idTokenSchemeOpRegion)
+    ) {
+        throw new Error('invalid scheme operator region code set');
+    }
+
+    return cookieSchemeOpRegion;
+};
+
 export const getErrorsByIds = (ids: string[], errors: ErrorInfo[]): ErrorInfo[] => {
     const compactErrors: ErrorInfo[] = [];
     errors.forEach(error => {

--- a/tests/pages/__snapshots__/register.test.tsx.snap
+++ b/tests/pages/__snapshots__/register.test.tsx.snap
@@ -120,32 +120,6 @@ exports[`pages register should render correctly 1`] = `
                 type="password"
               />
             </div>
-            <div
-              className="govuk-form-group"
-            >
-              <label
-                className="govuk-label"
-                htmlFor="noc-code"
-                id="noc-code-label"
-              >
-                Enter National Operator Code
-              </label>
-              <FormElementWrapper
-                errorClass="govuk-input--error"
-                errorId="noc-code"
-                errors={Array []}
-              >
-                <input
-                  aria-describedby="noc-code-label"
-                  className="govuk-input"
-                  defaultValue=""
-                  id="noc-code"
-                  name="nocCode"
-                  spellCheck="false"
-                  type="text"
-                />
-              </FormElementWrapper>
-            </div>
             <p
               className="govuk-body govuk-!-margin-top-5"
             >
@@ -371,39 +345,6 @@ exports[`pages register should render error messaging when errors are passed 1`]
                 type="password"
               />
             </div>
-            <div
-              className="govuk-form-group"
-            >
-              <label
-                className="govuk-label"
-                htmlFor="noc-code"
-                id="noc-code-label"
-              >
-                Enter National Operator Code
-              </label>
-              <FormElementWrapper
-                errorClass="govuk-input--error"
-                errorId="noc-code"
-                errors={
-                  Array [
-                    Object {
-                      "errorMessage": "Enter an email address in the correct format, like name@example.com",
-                      "id": "email",
-                    },
-                  ]
-                }
-              >
-                <input
-                  aria-describedby="noc-code-label"
-                  className="govuk-input"
-                  defaultValue=""
-                  id="noc-code"
-                  name="nocCode"
-                  spellCheck="false"
-                  type="text"
-                />
-              </FormElementWrapper>
-            </div>
             <p
               className="govuk-body govuk-!-margin-top-5"
             >
@@ -487,8 +428,8 @@ exports[`pages register should store email if entered correctly but other fields
   errors={
     Array [
       Object {
-        "errorMessage": "Enter valid nocCode",
-        "id": "nocCode",
+        "errorMessage": "Password must be at least 8 characters long",
+        "id": "password",
       },
       Object {
         "errorMessage": "",
@@ -514,8 +455,8 @@ exports[`pages register should store email if entered correctly but other fields
           errors={
             Array [
               Object {
-                "errorMessage": "Enter valid nocCode",
-                "id": "nocCode",
+                "errorMessage": "Password must be at least 8 characters long",
+                "id": "password",
               },
               Object {
                 "errorMessage": "",
@@ -563,8 +504,8 @@ exports[`pages register should store email if entered correctly but other fields
                 errors={
                   Array [
                     Object {
-                      "errorMessage": "Enter valid nocCode",
-                      "id": "nocCode",
+                      "errorMessage": "Password must be at least 8 characters long",
+                      "id": "password",
                     },
                     Object {
                       "errorMessage": "",
@@ -607,8 +548,8 @@ exports[`pages register should store email if entered correctly but other fields
                 errors={
                   Array [
                     Object {
-                      "errorMessage": "Enter valid nocCode",
-                      "id": "nocCode",
+                      "errorMessage": "Password must be at least 8 characters long",
+                      "id": "password",
                     },
                     Object {
                       "errorMessage": "",
@@ -648,44 +589,6 @@ exports[`pages register should store email if entered correctly but other fields
                 spellCheck="false"
                 type="password"
               />
-            </div>
-            <div
-              className="govuk-form-group"
-            >
-              <label
-                className="govuk-label"
-                htmlFor="noc-code"
-                id="noc-code-label"
-              >
-                Enter National Operator Code
-              </label>
-              <FormElementWrapper
-                errorClass="govuk-input--error"
-                errorId="noc-code"
-                errors={
-                  Array [
-                    Object {
-                      "errorMessage": "Enter valid nocCode",
-                      "id": "nocCode",
-                    },
-                    Object {
-                      "errorMessage": "",
-                      "id": "email",
-                      "userInput": "test@tfn.com",
-                    },
-                  ]
-                }
-              >
-                <input
-                  aria-describedby="noc-code-label"
-                  className="govuk-input"
-                  defaultValue=""
-                  id="noc-code"
-                  name="nocCode"
-                  spellCheck="false"
-                  type="text"
-                />
-              </FormElementWrapper>
             </div>
             <p
               className="govuk-body govuk-!-margin-top-5"

--- a/tests/pages/__snapshots__/selectSalesOfferPackage.test.tsx.snap
+++ b/tests/pages/__snapshots__/selectSalesOfferPackage.test.tsx.snap
@@ -1,5 +1,63 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`pages selectSalesOfferPackage should not render the 'Create New Sales Offer Package' button for a scheme operator user 1`] = `
+<Component
+  description="Sales Offer Package selection page of the Create Fares Data Service"
+  title="Select Sales Offer Package - Create Fares Data Service"
+>
+  <CsrfForm
+    action="/api/selectSalesOfferPackage"
+    csrfToken=""
+    method="post"
+  >
+    <ErrorSummary
+      errors={Array []}
+    />
+    <h1
+      className="govuk-heading-l"
+      id="select-sales-offer-package-page-heading"
+    >
+      How are the tickets sold?
+    </h1>
+    <div>
+      <p
+        className="govuk-body"
+      >
+        To create NeTEx for your fare it needs to contain the following:
+      </p>
+      <ol
+        className="govuk-list govuk-list--number"
+      >
+        <li>
+          Where a ticket can be bought
+        </li>
+        <li>
+          What payment method it can be bought with
+        </li>
+        <li>
+          What format the ticket is provided to the passenger in
+        </li>
+      </ol>
+      <p
+        className="govuk-body"
+      >
+        This combination of information is called a 
+        <strong>
+          sales offer package
+        </strong>
+        . You can choose from one you have already setup or create a new one for these products.
+      </p>
+    </div>
+    <input
+      className="govuk-button"
+      id="continue-button"
+      type="submit"
+      value="Continue"
+    />
+  </CsrfForm>
+</Component>
+`;
+
 exports[`pages selectSalesOfferPackage should render an error when an error message is passed through to props 1`] = `
 <Component
   description="Sales Offer Package selection page of the Create Fares Data Service"

--- a/tests/pages/api/apiUtils/index.test.ts
+++ b/tests/pages/api/apiUtils/index.test.ts
@@ -8,9 +8,10 @@ import {
     validatePassword,
     getSelectedStages,
     getAndValidateSchemeOpRegion,
+    isSchemeOperator,
 } from '../../../../src/pages/api/apiUtils';
 import * as s3 from '../../../../src/data/s3';
-import { getMockRequestAndResponse } from '../../../testData/mockData';
+import { getMockRequestAndResponse, mockSchemOpIdToken } from '../../../testData/mockData';
 import { FARE_TYPE_ATTRIBUTE } from '../../../../src/constants';
 
 describe('apiUtils', () => {
@@ -189,9 +190,6 @@ describe('apiUtils', () => {
     });
 
     describe('getAndValidateSchemeOpRegion', () => {
-        const mockSchemOpIdToken =
-            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206c2NoZW1lT3BlcmF0b3IiOiJTQ0hFTUVfT1BFUkFUT1IiLCJjdXN0b206c2NoZW1lUmVnaW9uQ29kZSI6IlNDSEVNRV9SRUdJT04ifQ.iZ-AJUm34FkHvXQ-zNoaqwAIT_LB708r1zj3xYvT3as';
-
         it('should return the scheme operator region code when the logged in user is a scheme operator', () => {
             const { req, res } = getMockRequestAndResponse({
                 cookieValues: {
@@ -212,6 +210,25 @@ describe('apiUtils', () => {
         it('should throw an error when the idToken and OPERATOR_COOKIE do not match', () => {
             const { req, res } = getMockRequestAndResponse({ cookieValues: { idToken: mockSchemOpIdToken } });
             expect(() => getAndValidateSchemeOpRegion(req, res)).toThrow();
+        });
+    });
+
+    describe('isSchemeOperator', () => {
+        it('should return true when the user logged in is a scheme operator', () => {
+            const { req, res } = getMockRequestAndResponse({
+                cookieValues: {
+                    operator: { operator: 'SCHEME_OPERATOR', region: 'SCHEME_REGION' },
+                    idToken: mockSchemOpIdToken,
+                },
+            });
+            const result = isSchemeOperator(req, res);
+            expect(result).toEqual(true);
+        });
+
+        it('should return false when the user logged in is not a scheme operator', () => {
+            const { req, res } = getMockRequestAndResponse();
+            const result = isSchemeOperator(req, res);
+            expect(result).toEqual(false);
         });
     });
 

--- a/tests/pages/api/apiUtils/index.test.ts
+++ b/tests/pages/api/apiUtils/index.test.ts
@@ -7,6 +7,7 @@ import {
     getAttributeFromIdToken,
     validatePassword,
     getSelectedStages,
+    getAndValidateSchemeOpRegion,
 } from '../../../../src/pages/api/apiUtils';
 import * as s3 from '../../../../src/data/s3';
 import { getMockRequestAndResponse } from '../../../testData/mockData';
@@ -184,6 +185,33 @@ describe('apiUtils', () => {
             const email = getAttributeFromIdToken(req, res, 'custom:noc');
 
             expect(email).toBeNull();
+        });
+    });
+
+    describe('getAndValidateSchemeOpRegion', () => {
+        const mockSchemOpIdToken =
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206c2NoZW1lT3BlcmF0b3IiOiJTQ0hFTUVfT1BFUkFUT1IiLCJjdXN0b206c2NoZW1lUmVnaW9uQ29kZSI6IlNDSEVNRV9SRUdJT04ifQ.iZ-AJUm34FkHvXQ-zNoaqwAIT_LB708r1zj3xYvT3as';
+
+        it('should return the scheme operator region code when the logged in user is a scheme operator', () => {
+            const { req, res } = getMockRequestAndResponse({
+                cookieValues: {
+                    operator: { operator: 'SCHEME_OPERATOR', region: 'SCHEME_REGION' },
+                    idToken: mockSchemOpIdToken,
+                },
+            });
+            const region = getAndValidateSchemeOpRegion(req, res);
+            expect(region).toBe('SCHEME_REGION');
+        });
+
+        it('should return null when the logged in user is not a scheme operator', () => {
+            const { req, res } = getMockRequestAndResponse();
+            const region = getAndValidateSchemeOpRegion(req, res);
+            expect(region).toEqual(null);
+        });
+
+        it('should throw an error when the idToken and OPERATOR_COOKIE do not match', () => {
+            const { req, res } = getMockRequestAndResponse({ cookieValues: { idToken: mockSchemOpIdToken } });
+            expect(() => getAndValidateSchemeOpRegion(req, res)).toThrow();
         });
     });
 

--- a/tests/pages/api/fareConfirmation.test.ts
+++ b/tests/pages/api/fareConfirmation.test.ts
@@ -1,0 +1,32 @@
+import fareConfirmation from '../../../src/pages/api/fareConfirmation';
+import * as apiUtils from '../../../src/pages/api/apiUtils';
+import { getMockRequestAndResponse, mockSchemOpIdToken } from '../../testData/mockData';
+
+describe('fareConfirmation', () => {
+    const writeHeadMock = jest.fn();
+    const redirectOnFareTypeSpy = jest.spyOn(apiUtils, 'redirectOnFareType');
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('should redirect on fareType when the user logged in is not a scheme operator', () => {
+        const { req, res } = getMockRequestAndResponse({
+            mockWriteHeadFn: writeHeadMock,
+        });
+        fareConfirmation(req, res);
+        expect(redirectOnFareTypeSpy).toHaveBeenCalled();
+    });
+
+    it('should redirect to /csvZoneUpload when the user logged in is a scheme operator', () => {
+        const { req, res } = getMockRequestAndResponse({
+            mockWriteHeadFn: writeHeadMock,
+            cookieValues: {
+                operator: { operator: 'SCHEME_OPERATOR', region: 'SCHEME_REGION' },
+                idToken: mockSchemOpIdToken,
+            },
+        });
+        fareConfirmation(req, res);
+        expect(writeHeadMock).toBeCalledWith(302, { Location: '/csvZoneUpload' });
+    });
+});

--- a/tests/pages/api/login.test.ts
+++ b/tests/pages/api/login.test.ts
@@ -17,7 +17,7 @@ const mockBaseOpAuthResponse: CognitoIdentityServiceProvider.AdminInitiateAuthRe
 const mockSchemeOpAuthResponse: CognitoIdentityServiceProvider.AdminInitiateAuthResponse = {
     AuthenticationResult: {
         IdToken:
-            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206c2NoZW1lT3BlcmF0b3IiOiJURVNUX1NDSEVNRSIsImN1c3RvbTpzY2hlbWVSZWdpb25Db2RlIjoiVEVTVF9SRUdJT04ifQ.CIfZetbXZeLRwK64vOFr7yTvNX9LgSk0Np153UGZ56U',
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206c2NoZW1lT3BlcmF0b3IiOiJTQ0hFTUVfT1BFUkFUT1IiLCJjdXN0b206c2NoZW1lUmVnaW9uQ29kZSI6IlNDSEVNRV9SRUdJT04ifQ.iZ-AJUm34FkHvXQ-zNoaqwAIT_LB708r1zj3xYvT3as',
         RefreshToken: 'eyJj',
     },
 };
@@ -109,8 +109,8 @@ describe('login', () => {
     it('should redirect when successfully signed in as a scheme operator', async () => {
         authSignInSpy.mockImplementation(() => Promise.resolve(mockSchemeOpAuthResponse));
         const mockOperatorCookie = {
-            operator: 'TEST_SCHEME',
-            region: 'TEST_REGION',
+            operator: 'SCHEME_OPERATOR',
+            region: 'SCHEME_REGION',
         };
         const { req, res } = getMockRequestAndResponse({
             cookieValues: {},

--- a/tests/pages/api/login.test.ts
+++ b/tests/pages/api/login.test.ts
@@ -6,10 +6,18 @@ import { getMockRequestAndResponse } from '../../testData/mockData';
 import * as apiUtils from '../../../src/pages/api/apiUtils';
 import { OPERATOR_COOKIE } from '../../../src/constants';
 
-const mockAuthResponse: CognitoIdentityServiceProvider.AdminInitiateAuthResponse = {
+const mockBaseOpAuthResponse: CognitoIdentityServiceProvider.AdminInitiateAuthResponse = {
     AuthenticationResult: {
         IdToken:
             'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206bm9jIjoiVEVTVCJ9.yblgxuiLnAHzUUf9d8rH975xO8N62aqR8gUszkw6cHc',
+        RefreshToken: 'eyJj',
+    },
+};
+
+const mockSchemeOpAuthResponse: CognitoIdentityServiceProvider.AdminInitiateAuthResponse = {
+    AuthenticationResult: {
+        IdToken:
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206c2NoZW1lT3BlcmF0b3IiOiJURVNUX1NDSEVNRSIsImN1c3RvbTpzY2hlbWVSZWdpb25Db2RlIjoiVEVTVF9SRUdJT04ifQ.CIfZetbXZeLRwK64vOFr7yTvNX9LgSk0Np153UGZ56U',
         RefreshToken: 'eyJj',
     },
 };
@@ -23,7 +31,7 @@ describe('login', () => {
 
     beforeEach(() => {
         getOperatorNameByNocCodeSpy.mockImplementation(() => Promise.resolve({ operatorPublicName: 'DCCL' }));
-        authSignInSpy.mockImplementation(() => Promise.resolve(mockAuthResponse));
+        authSignInSpy.mockImplementation(() => Promise.resolve(mockBaseOpAuthResponse));
     });
 
     afterEach(() => {
@@ -73,7 +81,12 @@ describe('login', () => {
         expect(setCookieSpy).toHaveBeenCalledWith(OPERATOR_COOKIE, JSON.stringify(expectedCookieValue), req, res);
     });
 
-    it('should redirect when successfully signed in', async () => {
+    it('should redirect when successfully signed in as an ordinary operator', async () => {
+        authSignInSpy.mockImplementation(() => Promise.resolve(mockBaseOpAuthResponse));
+        const mockOperatorCookie = {
+            operator: { operatorPublicName: 'DCCL' },
+            noc: 'TEST',
+        };
         const { req, res } = getMockRequestAndResponse({
             cookieValues: {},
             body: {
@@ -87,6 +100,32 @@ describe('login', () => {
         await login(req, res);
 
         expect(authSignInSpy).toHaveBeenCalledWith('test@test.com', 'abcdefghi');
+        expect(setCookieSpy).toHaveBeenCalledWith(OPERATOR_COOKIE, JSON.stringify(mockOperatorCookie), req, res);
+        expect(writeHeadMock).toBeCalledWith(302, {
+            Location: '/home',
+        });
+    });
+
+    it('should redirect when successfully signed in as a scheme operator', async () => {
+        authSignInSpy.mockImplementation(() => Promise.resolve(mockSchemeOpAuthResponse));
+        const mockOperatorCookie = {
+            operator: 'TEST_SCHEME',
+            region: 'TEST_REGION',
+        };
+        const { req, res } = getMockRequestAndResponse({
+            cookieValues: {},
+            body: {
+                email: 'test@test.com',
+                password: 'abcdefghi',
+            },
+            uuid: '',
+            mockWriteHeadFn: writeHeadMock,
+        });
+
+        await login(req, res);
+
+        expect(authSignInSpy).toHaveBeenCalledWith('test@test.com', 'abcdefghi');
+        expect(setCookieSpy).toHaveBeenCalledWith(OPERATOR_COOKIE, JSON.stringify(mockOperatorCookie), req, res);
         expect(writeHeadMock).toBeCalledWith(302, {
             Location: '/home',
         });

--- a/tests/pages/api/register.test.ts
+++ b/tests/pages/api/register.test.ts
@@ -57,7 +57,6 @@ describe('register', () => {
                 email: '',
                 password: 'chromosoneTelepathyDinosaur',
                 confirmPassword: 'chromosoneTelepathyDinosaur',
-                nocCode: 'DCCL',
                 regKey: 'abcdefg',
                 checkboxUserResearch: 'checkboxUserResearch',
             },
@@ -68,7 +67,6 @@ describe('register', () => {
                         id: 'email',
                         errorMessage: 'Enter an email address in the correct format, like name@example.com',
                     },
-                    { userInput: 'DCCL', id: 'noc-code', errorMessage: '' },
                 ],
             },
         ],
@@ -78,7 +76,6 @@ describe('register', () => {
                 email: 'test@test.com',
                 password: 'abchi',
                 confirmPassword: 'abchi',
-                nocCode: 'DCCL',
                 regKey: 'abcdefg',
                 checkboxUserResearch: 'checkboxUserResearch',
             },
@@ -94,7 +91,6 @@ describe('register', () => {
                         id: 'password',
                         errorMessage: 'Password must be at least 8 characters long',
                     },
-                    { userInput: 'DCCL', id: 'noc-code', errorMessage: '' },
                 ],
             },
         ],
@@ -104,7 +100,6 @@ describe('register', () => {
                 email: 'test@test.com',
                 password: '',
                 confirmPassword: 'chromosoneTelepathyDinosaur',
-                nocCode: 'DCCL',
                 regKey: 'abcdefg',
                 checkboxUserResearch: '',
             },
@@ -120,7 +115,6 @@ describe('register', () => {
                         id: 'password',
                         errorMessage: 'Enter a password',
                     },
-                    { userInput: 'DCCL', id: 'noc-code', errorMessage: '' },
                 ],
             },
         ],
@@ -130,7 +124,6 @@ describe('register', () => {
                 email: 'test@test.com',
                 password: 'chromosoneTelepathyDinosaur',
                 confirmPassword: 'chromosoneTelepathyDinosa',
-                nocCode: 'DCCL',
                 regKey: 'abcdefg',
                 checkboxUserResearch: '',
             },
@@ -142,28 +135,6 @@ describe('register', () => {
                         errorMessage: '',
                     },
                     { userInput: '', id: 'password', errorMessage: 'Passwords do not match' },
-                    { userInput: 'DCCL', id: 'noc-code', errorMessage: '' },
-                ],
-            },
-        ],
-        [
-            'empty NOC field',
-            {
-                email: 'test@test.com',
-                password: 'chromosoneTelepathyDinosaur',
-                confirmPassword: 'chromosoneTelepathyDinosaur',
-                nocCode: '',
-                regKey: 'abcdefg',
-                checkboxUserResearch: 'checkboxUserResearch',
-            },
-            {
-                inputChecks: [
-                    {
-                        userInput: 'test@test.com',
-                        id: 'email',
-                        errorMessage: '',
-                    },
-                    { userInput: '', id: 'noc-code', errorMessage: 'National Operator Code cannot be empty' },
                 ],
             },
         ],
@@ -181,43 +152,6 @@ describe('register', () => {
         expect(setCookieSpy).toHaveBeenCalledWith(USER_COOKIE, JSON.stringify(expectedCookieValue), req, res);
     });
 
-    it('should error when the service noc code is invalid', async () => {
-        getServicesByNocCodeSpy.mockImplementation(() => Promise.resolve([]));
-
-        const { req, res } = getMockRequestAndResponse({
-            cookieValues: {},
-            body: {
-                email: 'test@test.com',
-                password: 'chromosoneTelepathyDinosaur',
-                confirmPassword: 'chromosoneTelepathyDinosaur',
-                nocCode: 'abcd',
-                regKey: 'abcdefg',
-            },
-            uuid: '',
-            mockWriteHeadFn: writeHeadMock,
-        });
-
-        const mockUserCookieValue = {
-            inputChecks: [
-                {
-                    userInput: 'test@test.com',
-                    id: 'email',
-                    errorMessage: '',
-                },
-                { userInput: 'abcd', id: 'noc-code', errorMessage: '' },
-                {
-                    userInput: '',
-                    id: 'email',
-                    errorMessage: 'There was a problem creating your account',
-                },
-            ],
-        };
-
-        await register(req, res);
-
-        expect(setCookieSpy).toHaveBeenCalledWith(USER_COOKIE, JSON.stringify(mockUserCookieValue), req, res);
-    });
-
     it('should redirect when successfully signed in', async () => {
         authSignInSpy.mockImplementation(() => Promise.resolve(mockAuthResponse));
         authCompletePasswordSpy.mockImplementation(() => Promise.resolve());
@@ -230,7 +164,6 @@ describe('register', () => {
                 email: 'test@test.com',
                 password: 'chromosoneTelepathyDinosaur',
                 confirmPassword: 'chromosoneTelepathyDinosaur',
-                nocCode: 'DCCL',
                 regKey: 'abcdefg',
             },
             uuid: '',
@@ -263,7 +196,6 @@ describe('register', () => {
                     id: 'email',
                     errorMessage: '',
                 },
-                { userInput: 'DCCL', id: 'noc-code', errorMessage: '' },
                 {
                     userInput: '',
                     id: 'email',
@@ -278,55 +210,6 @@ describe('register', () => {
                 email: 'test@test.com',
                 password: 'chromosoneTelepathyDinosaur',
                 confirmPassword: 'chromosoneTelepathyDinosaur',
-                nocCode: 'DCCL',
-                regKey: 'abcdefg',
-            },
-            uuid: '',
-            mockWriteHeadFn: writeHeadMock,
-        });
-
-        await register(req, res);
-
-        expect(setCookieSpy).toHaveBeenCalledWith(USER_COOKIE, JSON.stringify(mockUserCookieValue), req, res);
-    });
-
-    it('should error when the NOC does not match what is in Cognito', async () => {
-        authSignInSpy.mockImplementation(() =>
-            Promise.resolve({
-                ChallengeName: 'NEW_PASSWORD_REQUIRED',
-                ChallengeParameters: {
-                    USER_ID_FOR_SRP: 'd3eddd2a-a1c6-4201-82d3-bdab8dcbb586',
-                    userAttributes: JSON.stringify({
-                        'custom:noc': 'FAKE',
-                    }),
-                },
-                Session: 'session',
-            }),
-        );
-
-        const mockUserCookieValue = {
-            inputChecks: [
-                {
-                    userInput: 'test@test.com',
-                    id: 'email',
-                    errorMessage: '',
-                },
-                { userInput: 'DCCL', id: 'noc-code', errorMessage: '' },
-                {
-                    userInput: '',
-                    id: 'email',
-                    errorMessage: 'There was a problem creating your account',
-                },
-            ],
-        };
-
-        const { req, res } = getMockRequestAndResponse({
-            cookieValues: {},
-            body: {
-                email: 'test@test.com',
-                password: 'chromosoneTelepathyDinosaur',
-                confirmPassword: 'chromosoneTelepathyDinosaur',
-                nocCode: 'DCCL',
                 regKey: 'abcdefg',
             },
             uuid: '',
@@ -345,7 +228,6 @@ describe('register', () => {
                 email: 'test@test.com',
                 password: 'chromosoneTelepathyDinosaur',
                 confirmPassword: 'chromosoneTelepathyDinosaur',
-                nocCode: 'DCCL',
                 regKey: 'abcdefg',
                 contactable: 'yes',
             },
@@ -377,7 +259,6 @@ describe('register', () => {
                 email: 'test@test.com',
                 password: 'chromosoneTelepathyDinosaur',
                 confirmPassword: 'chromosoneTelepathyDinosaur',
-                nocCode: 'DCCL',
                 regKey: 'abcdefg',
                 contactable: '',
             },
@@ -400,128 +281,5 @@ describe('register', () => {
         expect(writeHeadMock).toBeCalledWith(302, {
             Location: '/confirmRegistration',
         });
-    });
-});
-
-describe('register pipe split logic', () => {
-    const mockAuthResponse: CognitoIdentityServiceProvider.AdminInitiateAuthResponse = {
-        ChallengeName: 'NEW_PASSWORD_REQUIRED',
-        ChallengeParameters: {
-            USER_ID_FOR_SRP: 'd3eddd2a-a1c6-4201-82d3-bdab8dcbb586',
-            userAttributes: JSON.stringify({
-                'custom:noc': 'DCCL|TEST|1234',
-            }),
-        },
-        Session: 'session',
-    };
-
-    const getServicesByNocCodeSpy = jest.spyOn(auroradb, 'getServicesByNocCode');
-    const authSignInSpy = jest.spyOn(auth, 'initiateAuth');
-    const authCompletePasswordSpy = jest.spyOn(auth, 'respondToNewPasswordChallenge');
-    const authUpdateAttributesSpy = jest.spyOn(auth, 'updateUserAttributes');
-    const authSignOutSpy = jest.spyOn(auth, 'globalSignOut');
-    const setCookieSpy = jest.spyOn(apiUtils, 'setCookieOnResponseObject');
-
-    beforeEach(() => {
-        authSignInSpy.mockImplementation(() => Promise.resolve(mockAuthResponse));
-        authCompletePasswordSpy.mockImplementation(() => Promise.resolve());
-        authSignOutSpy.mockImplementation(() => Promise.resolve());
-        authUpdateAttributesSpy.mockImplementation(() => Promise.resolve());
-        getServicesByNocCodeSpy.mockImplementation(() =>
-            Promise.resolve([
-                {
-                    lineName: '2AC',
-                    startDate: '01012020',
-                    description: 'linename for service ',
-                    serviceCode: 'NW_05_BLAC_2C_1',
-                },
-            ]),
-        );
-    });
-
-    afterEach(() => {
-        jest.resetAllMocks();
-    });
-
-    const writeHeadMock = jest.fn();
-
-    it('should split NOCs into seperate ones if seperated by a pipe, and check if the users matches any', async () => {
-        const { req, res } = getMockRequestAndResponse({
-            cookieValues: {},
-            body: {
-                email: 'test@test.com',
-                password: 'chromosoneTelepathyDinosaur',
-                confirmPassword: 'chromosoneTelepathyDinosaur',
-                nocCode: 'DCCL',
-                regKey: 'abcdefg',
-                contactable: '',
-            },
-            uuid: '',
-            mockWriteHeadFn: writeHeadMock,
-        });
-
-        await register(req, res);
-
-        expect(authUpdateAttributesSpy).toHaveBeenCalledWith('test@test.com', [
-            { Name: 'custom:contactable', Value: 'no' },
-        ]);
-        expect(authSignInSpy).toHaveBeenCalledWith('test@test.com', 'abcdefg');
-        expect(authCompletePasswordSpy).toHaveBeenCalledWith(
-            'd3eddd2a-a1c6-4201-82d3-bdab8dcbb586',
-            'chromosoneTelepathyDinosaur',
-            'session',
-        );
-        expect(authSignOutSpy).toHaveBeenCalled();
-        expect(writeHeadMock).toBeCalledWith(302, {
-            Location: '/confirmRegistration',
-        });
-    });
-
-    it('should error if no NOCs match', async () => {
-        authSignInSpy.mockImplementation(() =>
-            Promise.resolve({
-                ChallengeName: 'NEW_PASSWORD_REQUIRED',
-                ChallengeParameters: {
-                    USER_ID_FOR_SRP: 'd3eddd2a-a1c6-4201-82d3-bdab8dcbb586',
-                    userAttributes: JSON.stringify({
-                        'custom:noc': 'FAKE',
-                    }),
-                },
-                Session: 'session',
-            }),
-        );
-
-        const mockUserCookieValue = {
-            inputChecks: [
-                {
-                    userInput: 'test@test.com',
-                    id: 'email',
-                    errorMessage: '',
-                },
-                { userInput: 'DCCL', id: 'noc-code', errorMessage: '' },
-                {
-                    userInput: '',
-                    id: 'email',
-                    errorMessage: 'There was a problem creating your account',
-                },
-            ],
-        };
-
-        const { req, res } = getMockRequestAndResponse({
-            cookieValues: {},
-            body: {
-                email: 'test@test.com',
-                password: 'chromosoneTelepathyDinosaur',
-                confirmPassword: 'chromosoneTelepathyDinosaur',
-                nocCode: 'DCCL',
-                regKey: 'abcdefg',
-            },
-            uuid: '',
-            mockWriteHeadFn: writeHeadMock,
-        });
-
-        await register(req, res);
-
-        expect(setCookieSpy).toHaveBeenCalledWith(USER_COOKIE, JSON.stringify(mockUserCookieValue), req, res);
     });
 });

--- a/tests/pages/faretype.test.tsx
+++ b/tests/pages/faretype.test.tsx
@@ -1,8 +1,15 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import FareType, { buildUuid } from '../../src/pages/fareType';
+import FareType, { buildUuid, getServerSideProps } from '../../src/pages/fareType';
+import { getMockContext, mockSchemOpIdToken } from '../testData/mockData';
 
 describe('pages', () => {
+    const writeHeadMock = jest.fn();
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
     const mockErrors = [{ errorMessage: 'Choose a fare type from the options', id: 'fare-type-error' }];
 
     describe('fareType', () => {
@@ -14,6 +21,27 @@ describe('pages', () => {
         it('should render error messaging when errors are passed to the page', () => {
             const tree = shallow(<FareType operatorName={' '} errors={mockErrors} csrfToken="" />);
             expect(tree).toMatchSnapshot();
+        });
+
+        describe('getServerSideProps', () => {
+            it('should return expected props when a the user logged in is not a scheme operator', () => {
+                const expectedProps = { props: { operatorName: expect.any(String), errors: [], csrfToken: '' } };
+                const mockContext = getMockContext();
+                const actualProps = getServerSideProps(mockContext);
+                expect(actualProps).toEqual(expectedProps);
+            });
+
+            it('should redirect straight to /passengerType when a the user logged in is a scheme operator', () => {
+                const mockContext = getMockContext({
+                    mockWriteHeadFn: writeHeadMock,
+                    cookies: {
+                        operator: { operator: 'SCHEME_OPERATOR', region: 'SCHEME_REGION' },
+                        idToken: mockSchemOpIdToken,
+                    },
+                });
+                getServerSideProps(mockContext);
+                expect(writeHeadMock).toBeCalledWith(302, { Location: '/passengerType' });
+            });
         });
     });
 

--- a/tests/pages/faretype.test.tsx
+++ b/tests/pages/faretype.test.tsx
@@ -7,12 +7,12 @@ describe('pages', () => {
 
     describe('fareType', () => {
         it('should render correctly', () => {
-            const tree = shallow(<FareType operator={' '} errors={[]} csrfToken="" />);
+            const tree = shallow(<FareType operatorName={' '} errors={[]} csrfToken="" />);
             expect(tree).toMatchSnapshot();
         });
 
         it('should render error messaging when errors are passed to the page', () => {
-            const tree = shallow(<FareType operator={' '} errors={mockErrors} csrfToken="" />);
+            const tree = shallow(<FareType operatorName={' '} errors={mockErrors} csrfToken="" />);
             expect(tree).toMatchSnapshot();
         });
     });

--- a/tests/pages/multipleProductValidity.test.tsx
+++ b/tests/pages/multipleProductValidity.test.tsx
@@ -28,7 +28,7 @@ describe('pages', () => {
         it('should render correctly', () => {
             const wrapper = shallow(
                 <MultiProductValidity
-                    operator="Infinity Line"
+                    operatorName="Infinity Line"
                     passengerType="Adult"
                     numberOfProducts="2"
                     multipleProducts={multipleProducts}
@@ -42,7 +42,7 @@ describe('pages', () => {
         it('should render error messaging when errors are passed', () => {
             const wrapper = shallow(
                 <MultiProductValidity
-                    operator="Infinity Line"
+                    operatorName="Infinity Line"
                     passengerType="Adult"
                     numberOfProducts="2"
                     multipleProducts={multipleProducts}
@@ -61,7 +61,7 @@ describe('pages', () => {
         it('renders 2 radio buttons per product', () => {
             const wrapper = shallow(
                 <MultiProductValidity
-                    operator="Infinity Line"
+                    operatorName="Infinity Line"
                     passengerType="Adult"
                     numberOfProducts="2"
                     multipleProducts={multipleProducts}
@@ -82,7 +82,7 @@ describe('pages', () => {
                 const result = getServerSideProps(ctx);
 
                 expect(result.props.numberOfProducts).toBe('2');
-                expect(result.props.operator).toBe('test');
+                expect(result.props.operatorName).toBe('test');
                 expect(result.props.multipleProducts[0].productName).toBe('Weekly Ticket');
                 expect(result.props.multipleProducts[0].productPrice).toBe('50');
                 expect(result.props.multipleProducts[0].productDuration).toBe('5');

--- a/tests/pages/multipleProducts.test.tsx
+++ b/tests/pages/multipleProducts.test.tsx
@@ -10,7 +10,7 @@ describe('pages', () => {
             const wrapper = shallow(
                 <MultipleProducts
                     numberOfProductsToDisplay="2"
-                    operator="Infinity Line"
+                    operatorName="Infinity Line"
                     passengerType="Adult"
                     errors={[]}
                     userInput={[]}
@@ -43,7 +43,7 @@ describe('pages', () => {
                 const result = getServerSideProps(ctx);
 
                 expect(result.props.numberOfProductsToDisplay).toBe('2');
-                expect(result.props.operator).toBe('BLP');
+                expect(result.props.operatorName).toBe('BLP');
                 expect(result.props.passengerType).toBe('Adult');
             });
 

--- a/tests/pages/register.test.tsx
+++ b/tests/pages/register.test.tsx
@@ -31,8 +31,8 @@ describe('pages', () => {
                     regKey="abcdefg"
                     errors={[
                         {
-                            errorMessage: 'Enter valid nocCode',
-                            id: 'nocCode',
+                            errorMessage: 'Password must be at least 8 characters long',
+                            id: 'password',
                         },
                         { userInput: 'test@tfn.com', errorMessage: '', id: 'email' },
                     ]}

--- a/tests/pages/selectSalesOfferPackage.test.tsx
+++ b/tests/pages/selectSalesOfferPackage.test.tsx
@@ -17,6 +17,7 @@ jest.mock('../../src/data/auroradb');
 
 describe('pages', () => {
     const selectSalesOfferPackagePropsInfoNoError: SelectSalesOfferPackageProps = {
+        schemeOp: false,
         salesOfferPackagesList: [
             defaultSalesOfferPackageOne,
             defaultSalesOfferPackageTwo,
@@ -29,6 +30,7 @@ describe('pages', () => {
     };
 
     const selectSalesOfferPackagePropsInfoWithError: SelectSalesOfferPackageProps = {
+        schemeOp: false,
         productNamesList: [],
         salesOfferPackagesList: [
             defaultSalesOfferPackageOne,
@@ -44,6 +46,7 @@ describe('pages', () => {
         it('should render correctly', () => {
             const tree = shallow(
                 <SelectSalesOfferPackage
+                    schemeOp={selectSalesOfferPackagePropsInfoNoError.schemeOp}
                     salesOfferPackagesList={selectSalesOfferPackagePropsInfoNoError.salesOfferPackagesList}
                     productNamesList={[]}
                     errors={selectSalesOfferPackagePropsInfoNoError.errors}
@@ -56,9 +59,23 @@ describe('pages', () => {
         it('should render an error when an error message is passed through to props', () => {
             const tree = shallow(
                 <SelectSalesOfferPackage
+                    schemeOp={selectSalesOfferPackagePropsInfoWithError.schemeOp}
                     salesOfferPackagesList={selectSalesOfferPackagePropsInfoWithError.salesOfferPackagesList}
                     productNamesList={[]}
                     errors={selectSalesOfferPackagePropsInfoWithError.errors}
+                    csrfToken=""
+                />,
+            );
+            expect(tree).toMatchSnapshot();
+        });
+
+        it("should not render the 'Create New Sales Offer Package' button for a scheme operator user", () => {
+            const tree = shallow(
+                <SelectSalesOfferPackage
+                    schemeOp
+                    salesOfferPackagesList={selectSalesOfferPackagePropsInfoNoError.salesOfferPackagesList}
+                    productNamesList={[]}
+                    errors={selectSalesOfferPackagePropsInfoNoError.errors}
                     csrfToken=""
                 />,
             );
@@ -125,7 +142,7 @@ describe('pages', () => {
                 },
             );
 
-            it('should throw an error when necessary nocCode is invalid', async () => {
+            it('should throw an error when necessary nocCode is invalid, when the user is not a scheme operator', async () => {
                 const ctx = getMockContext({
                     cookies: { operator: null },
                     body: null,

--- a/tests/testData/mockData.ts
+++ b/tests/testData/mockData.ts
@@ -235,6 +235,9 @@ export const getMockContext = ({
     return ctx;
 };
 
+export const mockSchemOpIdToken =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206c2NoZW1lT3BlcmF0b3IiOiJTQ0hFTUVfT1BFUkFUT1IiLCJjdXN0b206c2NoZW1lUmVnaW9uQ29kZSI6IlNDSEVNRV9SRUdJT04ifQ.iZ-AJUm34FkHvXQ-zNoaqwAIT_LB708r1zj3xYvT3as';
+
 export const mockMatchingFaresZones: MatchingFareZones = {
     'Acomb Green Lane': {
         name: 'Acomb Green Lane',

--- a/tests/testData/mockData.ts
+++ b/tests/testData/mockData.ts
@@ -45,6 +45,7 @@ import {
     TimeRestriction,
     MultiOperatorGeoZoneTicket,
     MultiOperatorMultipleServicesTicket,
+    SchemeOperatorTicket,
 } from '../../src/interfaces';
 import { MatchingFareZones } from '../../src/interfaces/matchingInterface';
 import { TextInputFieldset } from '../../src/pages/definePassengerType';
@@ -236,7 +237,7 @@ export const getMockContext = ({
 };
 
 export const mockSchemOpIdToken =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206c2NoZW1lT3BlcmF0b3IiOiJTQ0hFTUVfT1BFUkFUT1IiLCJjdXN0b206c2NoZW1lUmVnaW9uQ29kZSI6IlNDSEVNRV9SRUdJT04ifQ.iZ-AJUm34FkHvXQ-zNoaqwAIT_LB708r1zj3xYvT3as';
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJjdXN0b206c2NoZW1lT3BlcmF0b3IiOiJTQ0hFTUVfT1BFUkFUT1IiLCJjdXN0b206c2NoZW1lUmVnaW9uQ29kZSI6IlNDSEVNRV9SRUdJT04ifQ.TUnqk__NLBCyCLwJjRhkS6KVqnpZB2qYfV85rJ2M0DQ';
 
 export const mockMatchingFaresZones: MatchingFareZones = {
     'Acomb Green Lane': {
@@ -1897,6 +1898,46 @@ export const expectedFlatFareTicket: FlatFareTicket = {
             serviceDescription: 'Infinity Works, Boston - Infinity Works, Berlin',
         },
     ],
+};
+
+export const expectedSchemeOperatorTicket: SchemeOperatorTicket = {
+    schemeOperatorName: expect.any(String),
+    schemeOperatorRegionCode: expect.any(String),
+    type: 'multiOperator',
+    uuid: '1e0459b3-082e-4e70-89db-96e8ae173e10',
+    email: 'test@example.com',
+    zoneName: 'Green Lane Shops',
+    stops: zoneStops,
+    passengerType: 'Adult',
+    timeRestriction: mockTimeRestriction,
+    ticketPeriod: {
+        startDate: '2020-12-17T09:30:46.0Z',
+        endDate: '2020-12-18T09:30:46.0Z',
+    },
+    products: [
+        {
+            productName: 'Weekly Ticket',
+            productPrice: '50',
+            productDuration: '5',
+            productValidity: '24hr',
+            salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+        },
+        {
+            productName: 'Day Ticket',
+            productPrice: '2.50',
+            productDuration: '1',
+            productValidity: '24hr',
+            salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+        },
+        {
+            productName: 'Monthly Ticket',
+            productPrice: '200',
+            productDuration: '28',
+            productValidity: 'endOfCalendarDay',
+            salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+        },
+    ],
+    additionalNocs: ['MCTR', 'WBTR', 'BLAC'],
 };
 
 export const multipleProducts: MultiProduct[] = [

--- a/tests/utils/utils.test.ts
+++ b/tests/utils/utils.test.ts
@@ -8,12 +8,9 @@ import {
     isSchemeOperator,
 } from '../../src/utils';
 import { Stop } from '../../src/data/auroradb';
-import { getMockContext } from '../testData/mockData';
+import { getMockContext, mockSchemOpIdToken } from '../testData/mockData';
 
 describe('utils', () => {
-    const mockSchemOpIdToken =
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206c2NoZW1lT3BlcmF0b3IiOiJTQ0hFTUVfT1BFUkFUT1IiLCJjdXN0b206c2NoZW1lUmVnaW9uQ29kZSI6IlNDSEVNRV9SRUdJT04ifQ.iZ-AJUm34FkHvXQ-zNoaqwAIT_LB708r1zj3xYvT3as';
-
     describe('getHost', () => {
         it('should return http when host is localhost', () => {
             const expected = 'http://localhost';

--- a/tests/utils/utils.test.ts
+++ b/tests/utils/utils.test.ts
@@ -1,10 +1,19 @@
 import MockReq from 'mock-req';
 import { NextPageContext } from 'next';
-import { getHost, formatStopName, getAttributeFromIdToken, getAndValidateSchemeOpRegion } from '../../src/utils';
+import {
+    getHost,
+    formatStopName,
+    getAttributeFromIdToken,
+    getAndValidateSchemeOpRegion,
+    isSchemeOperator,
+} from '../../src/utils';
 import { Stop } from '../../src/data/auroradb';
 import { getMockContext } from '../testData/mockData';
 
 describe('utils', () => {
+    const mockSchemOpIdToken =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206c2NoZW1lT3BlcmF0b3IiOiJTQ0hFTUVfT1BFUkFUT1IiLCJjdXN0b206c2NoZW1lUmVnaW9uQ29kZSI6IlNDSEVNRV9SRUdJT04ifQ.iZ-AJUm34FkHvXQ-zNoaqwAIT_LB708r1zj3xYvT3as';
+
     describe('getHost', () => {
         it('should return http when host is localhost', () => {
             const expected = 'http://localhost';
@@ -108,9 +117,6 @@ describe('utils', () => {
     });
 
     describe('getAndValidateSchemeOpRegion', () => {
-        const mockSchemOpIdToken =
-            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b206c2NoZW1lT3BlcmF0b3IiOiJTQ0hFTUVfT1BFUkFUT1IiLCJjdXN0b206c2NoZW1lUmVnaW9uQ29kZSI6IlNDSEVNRV9SRUdJT04ifQ.iZ-AJUm34FkHvXQ-zNoaqwAIT_LB708r1zj3xYvT3as';
-
         it('should return the scheme operator region code when the logged in user is a scheme operator', () => {
             const ctx = getMockContext({
                 cookies: {
@@ -131,6 +137,25 @@ describe('utils', () => {
         it('should throw an error when the idToken and OPERATOR_COOKIE do not match', () => {
             const ctx = getMockContext({ cookies: { idToken: mockSchemOpIdToken } });
             expect(() => getAndValidateSchemeOpRegion(ctx)).toThrow();
+        });
+    });
+
+    describe('isSchemeOperator', () => {
+        it('should return true when the user logged in is a scheme operator', () => {
+            const ctx = getMockContext({
+                cookies: {
+                    operator: { operator: 'SCHEME_OPERATOR', region: 'SCHEME_REGION' },
+                    idToken: mockSchemOpIdToken,
+                },
+            });
+            const res = isSchemeOperator(ctx);
+            expect(res).toEqual(true);
+        });
+
+        it('should return false when the user logged in is not a scheme operator', () => {
+            const ctx = getMockContext();
+            const res = isSchemeOperator(ctx);
+            expect(res).toEqual(false);
         });
     });
 });


### PR DESCRIPTION
# Description

-   This PR allows scheme operators to use the service to create the necessary matching json. 

# Testing instructions

-   Pull down this branch and run the site locally. You will need to run the site as two different users (i) an ordinary user with a NOC and (ii) a scheme operator user.
-   To set up your user as a scheme operator, follow these instructions: (i) Delete your user using the cognito manager script in the fdbt-aws repo (ii) Set up your user as a scheme operator using the relevant cognito manager script (iii) Complete registration via email and registration url.
-   Validate that the site works as it used to for an ordinary user, and validate that the site works correctly for a scheme operator.

# Type of change

-   [X] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [X] Able to run pr locally
-   [X] Followed acceptance criteria
-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [X] I have made corresponding changes to the documentation if applicable
-   [X] I have added tests that prove my fix is effective or that my feature works
