### PR TITLE
fix appending of passenger types that have already been defined

### DIFF
--- a/src/pages/api/definePassengerType.ts
+++ b/src/pages/api/definePassengerType.ts
@@ -236,10 +236,8 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
 
                 if (selectedPassengerTypes) {
                     const index = (selectedPassengerTypes as GroupPassengerTypesCollection).passengerTypes.findIndex(
-                        type => type === submittedPassengerType,
+                        type => type === filteredReqBody.groupPassengerType,
                     );
-
-                    (selectedPassengerTypes as GroupPassengerTypesCollection).passengerTypes.splice(index, 1);
 
                     const { ageRangeMin, ageRangeMax, proofDocuments } = filteredReqBody;
                     const { minNumber, maxNumber } = req.body;
@@ -254,23 +252,31 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                         });
                     }
 
-                    companions.push({
+                    const companionToAdd: CompanionInfo = {
                         minNumber,
                         maxNumber,
-                        ageRangeMin,
-                        ageRangeMax,
-                        proofDocuments,
                         passengerType: submittedPassengerType,
-                    });
+                    };
+
+                    if (filteredReqBody.ageRange === 'Yes') {
+                        companionToAdd.ageRangeMax = ageRangeMax;
+                        companionToAdd.ageRangeMin = ageRangeMin;
+                    }
+
+                    if (filteredReqBody.proof === 'Yes') {
+                        companionToAdd.proofDocuments = proofDocuments;
+                    }
+
+                    companions[index] = companionToAdd;
 
                     updateSessionAttribute(req, GROUP_PASSENGER_INFO_ATTRIBUTE, companions);
 
-                    if ((selectedPassengerTypes as GroupPassengerTypesCollection).passengerTypes.length > 0) {
+                    if (index < (selectedPassengerTypes as GroupPassengerTypesCollection).passengerTypes.length - 1) {
                         updateSessionAttribute(req, DEFINE_PASSENGER_TYPE_ERRORS_ATTRIBUTE, undefined);
                         redirectTo(
                             res,
                             `/definePassengerType?groupPassengerType=${
-                                (selectedPassengerTypes as GroupPassengerTypesCollection).passengerTypes[0]
+                                (selectedPassengerTypes as GroupPassengerTypesCollection).passengerTypes[index + 1]
                             }`,
                         );
                     } else {

--- a/tests/pages/api/definePassengerType.test.ts
+++ b/tests/pages/api/definePassengerType.test.ts
@@ -322,7 +322,7 @@ describe('definePassengerType', () => {
     });
 
     it('should set GROUP_PASSENGER_INFO_ATTRIBUTE with the second passenger type in the group, delete the PASSENGER_TYPE_ERRORS_COOKIE and redirect to /timeRestrictions', async () => {
-        const groupPassengerTypesAttribute: GroupPassengerTypesCollection = { passengerTypes: ['child'] };
+        const groupPassengerTypesAttribute: GroupPassengerTypesCollection = { passengerTypes: ['adult', 'child'] };
         const groupSizeAttribute: GroupTicketAttribute = { maxGroupSize: '20' };
         const mockPreviousPassengerTypeDetails: CompanionInfo[] = [
             {


### PR DESCRIPTION
# Description

-   Fix appending of passenger types that have already been defined

# Testing instructions

- Test both the group and single passenger type journeys
- Test going backwards and forwards between group passenger definition pages, passengers should not be appended indefinitely in the matching json / session

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [ ] Able to run pr locally
-   [ ] Followed acceptance criteria
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
