### PR TITLE
Altered single product page to take a number and type of duration

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -40,7 +40,7 @@ export const FARE_STAGES_ATTRIBUTE = 'fdbt-fare-stages';
 
 export const STAGE_NAMES_ATTRIBUTE = 'fdbt-stage-names';
 
-export const TIME_PERIOD_VALID_ATTRIBUTE = 'fdbt-time-period-valid';
+export const DURATION_VALID_ATTRIBUTE = 'fdbt-duration-valid';
 
 export const PRODUCT_DETAILS_ATTRIBUTE = 'fdbt-product-details';
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -40,7 +40,7 @@ export const FARE_STAGES_ATTRIBUTE = 'fdbt-fare-stages';
 
 export const STAGE_NAMES_ATTRIBUTE = 'fdbt-stage-names';
 
-export const DAYS_VALID_ATTRIBUTE = 'fdbt-days-valid';
+export const TIME_PERIOD_VALID_ATTRIBUTE = 'fdbt-time-period-valid';
 
 export const PRODUCT_DETAILS_ATTRIBUTE = 'fdbt-product-details';
 

--- a/src/design/Layout.scss
+++ b/src/design/Layout.scss
@@ -309,3 +309,7 @@ svg:not(:root) {
         display: none;
     }
 }
+
+.text-input-margin {
+    margin-right: 10px;
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -15,8 +15,9 @@ export interface ProductInfo {
     productPrice: string;
 }
 
-export interface DaysValidInfo {
-    daysValid: string;
+export interface TimePeriodValidInfo {
+    amount: string;
+    timePeriodType: string;
     errors: ErrorInfo[];
 }
 

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -23,9 +23,9 @@ export interface ProductInfo {
     productPrice: string;
 }
 
-export interface TimePeriodValidInfo {
+export interface DurationValidInfo {
     amount: string;
-    timePeriodType: string;
+    duration: string;
     errors: ErrorInfo[];
 }
 

--- a/src/pages/api/chooseValidity.ts
+++ b/src/pages/api/chooseValidity.ts
@@ -28,6 +28,9 @@ export const isInvalidInput = (validityInput: string): boolean => {
     return false;
 };
 
+export const isValidInputDuration = (durationInput: string): boolean =>
+    ['day', 'week', 'month', 'year'].includes(durationInput);
+
 export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
     try {
         if (!isSessionValid(req, res)) {
@@ -45,7 +48,7 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
             });
         }
 
-        if (!duration || duration !== ('day' || 'week' || 'month' || 'year')) {
+        if (!duration || !isValidInputDuration(duration)) {
             errorInfo.push({
                 errorMessage: 'The type of duration is needed. Choose one of the options.',
                 id: 'validity-units',

--- a/src/pages/api/chooseValidity.ts
+++ b/src/pages/api/chooseValidity.ts
@@ -51,21 +51,16 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
                 id: 'validity-units',
             });
         }
+        updateSessionAttribute(req, DURATION_VALID_ATTRIBUTE, {
+            amount: validityInput ?? '',
+            duration: duration ?? '',
+            errors: errorInfo,
+        });
         if (errorInfo.length > 0) {
-            updateSessionAttribute(req, DURATION_VALID_ATTRIBUTE, {
-                amount: validityInput ?? '',
-                duration: duration ?? '',
-                errors: errorInfo,
-            });
             redirectTo(res, '/chooseValidity');
             return;
         }
 
-        updateSessionAttribute(req, DURATION_VALID_ATTRIBUTE, {
-            amount: validityInput ?? '',
-            duration: duration ?? '',
-            errors: [],
-        });
         redirectTo(res, '/periodValidity');
     } catch (error) {
         const message = 'There was a problem inputting the amount of time the product is valid for:';

--- a/src/pages/api/chooseValidity.ts
+++ b/src/pages/api/chooseValidity.ts
@@ -1,13 +1,11 @@
 import { NextApiResponse } from 'next';
 import { NextApiRequestWithSession, ErrorInfo } from '../../interfaces/index';
 import { updateSessionAttribute } from '../../utils/sessions';
-import { DAYS_VALID_ATTRIBUTE } from '../../constants/index';
+import { TIME_PERIOD_VALID_ATTRIBUTE } from '../../constants/index';
 import { redirectToError, redirectTo } from './apiUtils';
 import { isSessionValid } from './apiUtils/validator';
 
-export const isInvalidValidityNumber = (req: NextApiRequestWithSession): boolean => {
-    const { validityInput } = req.body;
-
+export const isInvalidValidityNumber = (validityInput: number): boolean => {
     if (Number.isNaN(validityInput)) {
         return true;
     }
@@ -16,28 +14,57 @@ export const isInvalidValidityNumber = (req: NextApiRequestWithSession): boolean
         return true;
     }
 
-    if (validityInput > 366 || validityInput < 1) {
+    if (validityInput > 1000 || validityInput < 1) {
         return true;
     }
 
     return false;
 };
 
-export const setSession = (req: NextApiRequestWithSession, res: NextApiResponse, error = ''): void => {
-    const daysValid = req.body.validityInput;
-
-    if (error) {
-        const errorInfo: ErrorInfo[] = [
-            {
-                errorMessage: error,
-                id: 'validity',
-            },
-        ];
-        updateSessionAttribute(req, DAYS_VALID_ATTRIBUTE, { daysValid, errors: errorInfo });
-        redirectTo(res, '/chooseValidity');
-        return;
+export const validityInputErrorCheck = (errorInfo: ErrorInfo[], validityInput: string): ErrorInfo[] => {
+    if (!validityInput) {
+        errorInfo.push({
+            errorMessage: 'The amount of time your product is valid for cannot be empty.',
+            id: 'validity',
+        });
+        return errorInfo;
     }
-    updateSessionAttribute(req, DAYS_VALID_ATTRIBUTE, { daysValid, errors: [] });
+
+    if (validityInput === '0') {
+        errorInfo.push({
+            errorMessage: 'The amount of time your product is valid for cannot be 0.',
+            id: 'validity',
+        });
+        return errorInfo;
+    }
+
+    if (isInvalidValidityNumber(Number(validityInput))) {
+        errorInfo.push({
+            errorMessage:
+                'The amount of time your your product is valid for has to be a whole number between 1 and 1000.',
+            id: 'validity',
+        });
+        return errorInfo;
+    }
+
+    return errorInfo;
+};
+
+export const errorArrayCheckAndRedirect = (
+    errorInfo: ErrorInfo[],
+    validityInput: string,
+    duration: string,
+    req: NextApiRequestWithSession,
+    res: NextApiResponse,
+): void => {
+    if (errorInfo.length > 0) {
+        updateSessionAttribute(req, TIME_PERIOD_VALID_ATTRIBUTE, {
+            amount: validityInput ?? '',
+            timePeriodType: duration ?? '',
+            errors: errorInfo,
+        });
+        redirectTo(res, '/chooseValidity');
+    }
 };
 
 export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
@@ -46,29 +73,27 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
             throw new Error('session is invalid.');
         }
 
-        if (req.body.validityInput === '0') {
-            setSession(req, res, 'The value of days your product is valid for cannot be 0.');
-            return;
-        }
+        const { validityInput, duration } = req.body;
+        const errorInfo: ErrorInfo[] = [];
 
-        if (!req.body.validityInput) {
-            setSession(req, res, 'The value of days your product is valid for cannot be empty.');
-            return;
-        }
+        errorInfo.concat(validityInputErrorCheck(errorInfo, validityInput));
 
-        if (isInvalidValidityNumber(req)) {
-            setSession(
-                req,
-                res,
-                'The value of days your product is valid for has to be a whole number between 1 and 366.',
-            );
-            return;
+        if (!duration || duration !== ('day' || 'week' || 'month' || 'year')) {
+            errorInfo.push({
+                errorMessage: 'The type of duration is needed. Choose one of the options.',
+                id: 'validity-units',
+            });
         }
+        errorArrayCheckAndRedirect(errorInfo, validityInput, duration, req, res);
 
-        setSession(req, res);
+        updateSessionAttribute(req, TIME_PERIOD_VALID_ATTRIBUTE, {
+            amount: validityInput ?? '',
+            timePeriodType: duration ?? '',
+            errors: [],
+        });
         redirectTo(res, '/periodValidity');
     } catch (error) {
-        const message = 'There was a problem inputting the number of days the product is valid for:';
+        const message = 'There was a problem inputting the amount of time the product is valid for:';
         redirectToError(res, message, 'api.chooseValidity', error);
     }
 };

--- a/src/pages/api/periodValidity.ts
+++ b/src/pages/api/periodValidity.ts
@@ -1,6 +1,6 @@
 import { NextApiResponse } from 'next';
 import { getSessionAttribute, updateSessionAttribute } from '../../utils/sessions';
-import { PRODUCT_DETAILS_ATTRIBUTE, PERIOD_EXPIRY_ATTRIBUTE, DAYS_VALID_ATTRIBUTE } from '../../constants';
+import { PRODUCT_DETAILS_ATTRIBUTE, PERIOD_EXPIRY_ATTRIBUTE, TIME_PERIOD_VALID_ATTRIBUTE } from '../../constants';
 import { redirectToError, redirectTo } from './apiUtils';
 import { isSessionValid } from './apiUtils/validator';
 import { NextApiRequestWithSession, ProductData } from '../../interfaces';
@@ -19,7 +19,7 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
         if (req.body.periodValid) {
             const { periodValid } = req.body;
 
-            const daysValidInfo = getSessionAttribute(req, DAYS_VALID_ATTRIBUTE);
+            const daysValidInfo = getSessionAttribute(req, TIME_PERIOD_VALID_ATTRIBUTE);
             const productDetailsAttribute = getSessionAttribute(req, PRODUCT_DETAILS_ATTRIBUTE);
 
             if (!isProductInfo(productDetailsAttribute) || !daysValidInfo) {
@@ -27,14 +27,16 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
             }
 
             const { productName, productPrice } = productDetailsAttribute;
-            const { daysValid } = daysValidInfo;
+            const timePeriodValid = `${daysValidInfo.amount} ${daysValidInfo.timePeriodType}${
+                daysValidInfo.amount === '1' ? '' : 's'
+            }`;
 
             const periodExpiryAttributeValue: ProductData = {
                 products: [
                     {
                         productName,
                         productPrice,
-                        productDuration: daysValid,
+                        productDuration: timePeriodValid,
                         productValidity: periodValid,
                     },
                 ],

--- a/src/pages/api/periodValidity.ts
+++ b/src/pages/api/periodValidity.ts
@@ -1,6 +1,6 @@
 import { NextApiResponse } from 'next';
 import { getSessionAttribute, updateSessionAttribute } from '../../utils/sessions';
-import { PRODUCT_DETAILS_ATTRIBUTE, PERIOD_EXPIRY_ATTRIBUTE, TIME_PERIOD_VALID_ATTRIBUTE } from '../../constants';
+import { PRODUCT_DETAILS_ATTRIBUTE, PERIOD_EXPIRY_ATTRIBUTE, DURATION_VALID_ATTRIBUTE } from '../../constants';
 import { redirectToError, redirectTo } from './apiUtils';
 import { isSessionValid } from './apiUtils/validator';
 import { NextApiRequestWithSession, ProductData } from '../../interfaces';
@@ -19,7 +19,7 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
         if (req.body.periodValid) {
             const { periodValid } = req.body;
 
-            const daysValidInfo = getSessionAttribute(req, TIME_PERIOD_VALID_ATTRIBUTE);
+            const daysValidInfo = getSessionAttribute(req, DURATION_VALID_ATTRIBUTE);
             const productDetailsAttribute = getSessionAttribute(req, PRODUCT_DETAILS_ATTRIBUTE);
 
             if (!isProductInfo(productDetailsAttribute) || !daysValidInfo) {
@@ -27,7 +27,7 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
             }
 
             const { productName, productPrice } = productDetailsAttribute;
-            const timePeriodValid = `${daysValidInfo.amount} ${daysValidInfo.timePeriodType}${
+            const timePeriodValid = `${daysValidInfo.amount} ${daysValidInfo.duration}${
                 daysValidInfo.amount === '1' ? '' : 's'
             }`;
 

--- a/src/pages/chooseValidity.tsx
+++ b/src/pages/chooseValidity.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import upperFirst from 'lodash/upperFirst';
 import TwoThirdsLayout from '../layout/Layout';
-import { PRODUCT_DETAILS_ATTRIBUTE, TIME_PERIOD_VALID_ATTRIBUTE, PASSENGER_TYPE_ATTRIBUTE } from '../constants';
+import { PRODUCT_DETAILS_ATTRIBUTE, DURATION_VALID_ATTRIBUTE, PASSENGER_TYPE_ATTRIBUTE } from '../constants';
 import CsrfForm from '../components/CsrfForm';
 import { ErrorInfo, NextPageContextWithSession } from '../interfaces';
 import FormElementWrapper, { FormGroupWrapper } from '../components/FormElementWrapper';
@@ -21,7 +21,7 @@ interface ValidityProps {
     amount: string;
     errors: ErrorInfo[];
     csrfToken: string;
-    timePeriodType: string;
+    duration: string;
 }
 
 const ChooseValidity = ({
@@ -30,7 +30,7 @@ const ChooseValidity = ({
     passengerType,
     amount,
     errors,
-    timePeriodType,
+    duration,
     csrfToken,
 }: ValidityProps): ReactElement => (
     <TwoThirdsLayout title={title} description={description}>
@@ -78,7 +78,7 @@ const ChooseValidity = ({
                                     className="govuk-select"
                                     id="validity-units"
                                     name="duration"
-                                    defaultValue={timePeriodType}
+                                    defaultValue={duration}
                                 >
                                     <option selected value="" disabled>
                                         Select a duration
@@ -100,7 +100,7 @@ const ChooseValidity = ({
 
 export const getServerSideProps = (ctx: NextPageContextWithSession): { props: ValidityProps } => {
     const csrfToken = getCsrfToken(ctx);
-    const validityInfo = getSessionAttribute(ctx.req, TIME_PERIOD_VALID_ATTRIBUTE);
+    const validityInfo = getSessionAttribute(ctx.req, DURATION_VALID_ATTRIBUTE);
     const passengerTypeAttribute = getSessionAttribute(ctx.req, PASSENGER_TYPE_ATTRIBUTE);
     const productAttribute = getSessionAttribute(ctx.req, PRODUCT_DETAILS_ATTRIBUTE);
 
@@ -113,15 +113,15 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Va
     }
 
     let amount;
-    let timePeriodType;
+    let duration;
 
     if (validityInfo) {
         if (validityInfo.amount) {
             amount = validityInfo.amount;
         }
 
-        if (validityInfo.timePeriodType) {
-            timePeriodType = validityInfo.timePeriodType;
+        if (validityInfo.duration) {
+            duration = validityInfo.duration;
         }
     }
 
@@ -132,7 +132,7 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Va
             passengerType: passengerTypeAttribute.passengerType,
             amount: amount ?? '',
             errors: validityInfo?.errors ?? [],
-            timePeriodType: timePeriodType ?? '',
+            duration: duration ?? '',
             csrfToken,
         },
     };

--- a/src/pages/chooseValidity.tsx
+++ b/src/pages/chooseValidity.tsx
@@ -1,10 +1,10 @@
 import React, { ReactElement } from 'react';
 import upperFirst from 'lodash/upperFirst';
 import TwoThirdsLayout from '../layout/Layout';
-import { PRODUCT_DETAILS_ATTRIBUTE, DAYS_VALID_ATTRIBUTE, PASSENGER_TYPE_ATTRIBUTE } from '../constants';
+import { PRODUCT_DETAILS_ATTRIBUTE, TIME_PERIOD_VALID_ATTRIBUTE, PASSENGER_TYPE_ATTRIBUTE } from '../constants';
 import CsrfForm from '../components/CsrfForm';
 import { ErrorInfo, NextPageContextWithSession } from '../interfaces';
-import FormElementWrapper from '../components/FormElementWrapper';
+import FormElementWrapper, { FormGroupWrapper } from '../components/FormElementWrapper';
 import ErrorSummary from '../components/ErrorSummary';
 import { isPassengerType } from '../interfaces/typeGuards';
 import { getSessionAttribute } from '../utils/sessions';
@@ -18,47 +18,81 @@ interface ValidityProps {
     productName: string;
     productPrice: string;
     passengerType: string;
-    daysValid: string;
+    amount: string;
     errors: ErrorInfo[];
     csrfToken: string;
+    timePeriodType: string;
 }
 
 const ChooseValidity = ({
     productName,
     productPrice,
     passengerType,
-    daysValid,
+    amount,
     errors,
+    timePeriodType,
     csrfToken,
 }: ValidityProps): ReactElement => (
     <TwoThirdsLayout title={title} description={description}>
         <CsrfForm action="/api/chooseValidity" method="post" csrfToken={csrfToken}>
             <>
                 <ErrorSummary errors={errors} />
-                <div className={`govuk-form-group ${errors.length ? 'govuk-form-group--error' : ''}`}>
-                    <label htmlFor="validity">
-                        <h1 className="govuk-heading-l" id="choose-validity-page-heading">
-                            How many days is your product valid for?
-                        </h1>
-                    </label>
+                <fieldset className="govuk-fieldset">
+                    <legend className="govuk-fieldset__legend govuk-fieldset__legend--l">
+                        <h1 className="govuk-fieldset__heading">How long is your product valid for?</h1>
+                    </legend>
                     <div className="govuk-hint">
                         Product: {productName} - £{productPrice} - {upperFirst(passengerType)}
                     </div>
                     <div className="govuk-hint" id="choose-validity-page-hint">
-                        Enter a whole number. For example: a day ticket would be 1 and two weeks would be 14
+                        Enter a whole number, and select a duration type. For example, 7 months.
                     </div>
-                    <FormElementWrapper errors={errors} errorId="validity" errorClass="govuk-input--error">
-                        <input
-                            className="govuk-input govuk-input--width-2"
-                            id="validity"
-                            name="validityInput"
-                            type="text"
-                            defaultValue={daysValid}
-                            aria-describedby="choose-validity-page-hint"
-                        />
-                    </FormElementWrapper>
-                </div>
-                <input type="submit" value="Continue" id="continue-button" className="govuk-button" />
+                    <FormGroupWrapper errorId="validity" errors={errors}>
+                        <>
+                            <label className="govuk-label" htmlFor="validity">
+                                Number
+                            </label>
+                            <FormElementWrapper errors={errors} errorId="validity" errorClass="govuk-input--error">
+                                <input
+                                    className="govuk-input govuk-input--width-2"
+                                    id="validity"
+                                    name="validityInput"
+                                    type="text"
+                                    defaultValue={amount}
+                                    aria-describedby="choose-validity-page-hint"
+                                />
+                            </FormElementWrapper>
+                        </>
+                    </FormGroupWrapper>
+                    <FormGroupWrapper errorId="validity-units" errors={errors}>
+                        <>
+                            <label className="govuk-label" htmlFor="validity-units">
+                                Duration
+                            </label>
+                            <FormElementWrapper
+                                errors={errors}
+                                errorId="validity-units"
+                                errorClass="govuk-select--error"
+                            >
+                                <select
+                                    className="govuk-select"
+                                    id="validity-units"
+                                    name="duration"
+                                    defaultValue={timePeriodType}
+                                >
+                                    <option selected value="" disabled>
+                                        Select a duration
+                                    </option>
+                                    <option value="day">Days</option>
+                                    <option value="week">Weeks</option>
+                                    <option value="month">Months</option>
+                                    <option value="year">Years</option>
+                                </select>
+                            </FormElementWrapper>
+                        </>
+                    </FormGroupWrapper>
+                    <input type="submit" value="Continue" id="continue-button" className="govuk-button" />
+                </fieldset>
             </>
         </CsrfForm>
     </TwoThirdsLayout>
@@ -66,7 +100,7 @@ const ChooseValidity = ({
 
 export const getServerSideProps = (ctx: NextPageContextWithSession): { props: ValidityProps } => {
     const csrfToken = getCsrfToken(ctx);
-    const validityInfo = getSessionAttribute(ctx.req, DAYS_VALID_ATTRIBUTE);
+    const validityInfo = getSessionAttribute(ctx.req, TIME_PERIOD_VALID_ATTRIBUTE);
     const passengerTypeAttribute = getSessionAttribute(ctx.req, PASSENGER_TYPE_ATTRIBUTE);
     const productAttribute = getSessionAttribute(ctx.req, PRODUCT_DETAILS_ATTRIBUTE);
 
@@ -78,10 +112,17 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Va
         throw new Error('Failed to retrieve passenger type session info for choose validity page.');
     }
 
-    let validity;
+    let amount;
+    let timePeriodType;
 
     if (validityInfo) {
-        validity = validityInfo.daysValid;
+        if (validityInfo.amount) {
+            amount = validityInfo.amount;
+        }
+
+        if (validityInfo.timePeriodType) {
+            timePeriodType = validityInfo.timePeriodType;
+        }
     }
 
     return {
@@ -89,8 +130,9 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Va
             productName: productAttribute.productName,
             productPrice: productAttribute.productPrice,
             passengerType: passengerTypeAttribute.passengerType,
-            daysValid: validity ?? '',
+            amount: amount ?? '',
             errors: validityInfo?.errors ?? [],
+            timePeriodType: timePeriodType ?? '',
             csrfToken,
         },
     };

--- a/src/utils/sessions.ts
+++ b/src/utils/sessions.ts
@@ -9,7 +9,7 @@ import {
     GroupDefinition,
     TimeRestriction,
     CompanionInfo,
-    TimePeriodValidInfo,
+    DurationValidInfo,
     Journey,
     JourneyWithErrors,
     TicketRepresentationAttribute,
@@ -22,7 +22,7 @@ import {
 } from '../interfaces/index';
 import { FaresInformation } from '../pages/api/priceEntry';
 import {
-    TIME_PERIOD_VALID_ATTRIBUTE,
+    DURATION_VALID_ATTRIBUTE,
     PRICE_ENTRY_ATTRIBUTE,
     TIME_RESTRICTIONS_ATTRIBUTE,
     SALES_OFFER_PACKAGES_ATTRIBUTE,
@@ -90,7 +90,7 @@ import { MultipleOperatorsAttribute, MultipleOperatorsAttributeWithErrors } from
 
 type SessionAttributeTypes = {
     [STAGE_NAMES_ATTRIBUTE]: string[] | InputCheck[];
-    [TIME_PERIOD_VALID_ATTRIBUTE]: TimePeriodValidInfo;
+    [DURATION_VALID_ATTRIBUTE]: DurationValidInfo;
     [INPUT_METHOD_ATTRIBUTE]: InputMethodInfo | ErrorInfo;
     [SOP_ATTRIBUTE]: SalesOfferPackageWithErrors;
     [SOP_INFO_ATTRIBUTE]: SalesOfferPackageInfo | SalesOfferPackageInfoWithErrors;

--- a/src/utils/sessions.ts
+++ b/src/utils/sessions.ts
@@ -9,7 +9,7 @@ import {
     GroupDefinition,
     TimeRestriction,
     CompanionInfo,
-    DaysValidInfo,
+    TimePeriodValidInfo,
     Journey,
     JourneyWithErrors,
     TicketRepresentationAttribute,
@@ -22,7 +22,7 @@ import {
 } from '../interfaces/index';
 import { FaresInformation } from '../pages/api/priceEntry';
 import {
-    DAYS_VALID_ATTRIBUTE,
+    TIME_PERIOD_VALID_ATTRIBUTE,
     PRICE_ENTRY_ATTRIBUTE,
     TIME_RESTRICTIONS_ATTRIBUTE,
     SALES_OFFER_PACKAGES_ATTRIBUTE,
@@ -90,7 +90,7 @@ import { MultipleOperatorsAttribute, MultipleOperatorsAttributeWithErrors } from
 
 type SessionAttributeTypes = {
     [STAGE_NAMES_ATTRIBUTE]: string[] | InputCheck[];
-    [DAYS_VALID_ATTRIBUTE]: DaysValidInfo;
+    [TIME_PERIOD_VALID_ATTRIBUTE]: TimePeriodValidInfo;
     [INPUT_METHOD_ATTRIBUTE]: InputMethodInfo | ErrorInfo;
     [SOP_ATTRIBUTE]: SalesOfferPackageWithErrors;
     [SOP_INFO_ATTRIBUTE]: SalesOfferPackageInfo | SalesOfferPackageInfoWithErrors;

--- a/tests/pages/__snapshots__/chooseValidity.test.tsx.snap
+++ b/tests/pages/__snapshots__/chooseValidity.test.tsx.snap
@@ -13,19 +13,18 @@ exports[`Choose Validity Page should render correctly 1`] = `
     <ErrorSummary
       errors={Array []}
     />
-    <div
-      className="govuk-form-group "
+    <fieldset
+      className="govuk-fieldset"
     >
-      <label
-        htmlFor="validity"
+      <legend
+        className="govuk-fieldset__legend govuk-fieldset__legend--l"
       >
         <h1
-          className="govuk-heading-l"
-          id="choose-validity-page-heading"
+          className="govuk-fieldset__heading"
         >
-          How many days is your product valid for?
+          How long is your product valid for?
         </h1>
-      </label>
+      </legend>
       <div
         className="govuk-hint"
       >
@@ -40,29 +39,219 @@ exports[`Choose Validity Page should render correctly 1`] = `
         className="govuk-hint"
         id="choose-validity-page-hint"
       >
-        Enter a whole number. For example: a day ticket would be 1 and two weeks would be 14
+        Enter a whole number, and select a duration type. For example, 7 months.
       </div>
-      <FormElementWrapper
-        errorClass="govuk-input--error"
+      <Component
         errorId="validity"
         errors={Array []}
       >
-        <input
-          aria-describedby="choose-validity-page-hint"
-          className="govuk-input govuk-input--width-2"
-          defaultValue=""
-          id="validity"
-          name="validityInput"
-          type="text"
-        />
-      </FormElementWrapper>
-    </div>
-    <input
-      className="govuk-button"
-      id="continue-button"
-      type="submit"
-      value="Continue"
+        <label
+          className="govuk-label"
+          htmlFor="validity"
+        >
+          Number
+        </label>
+        <FormElementWrapper
+          errorClass="govuk-input--error"
+          errorId="validity"
+          errors={Array []}
+        >
+          <input
+            aria-describedby="choose-validity-page-hint"
+            className="govuk-input govuk-input--width-2"
+            defaultValue=""
+            id="validity"
+            name="validityInput"
+            type="text"
+          />
+        </FormElementWrapper>
+      </Component>
+      <Component
+        errorId="validity-units"
+        errors={Array []}
+      >
+        <label
+          className="govuk-label"
+          htmlFor="validity-units"
+        >
+          Duration
+        </label>
+        <FormElementWrapper
+          errorClass="govuk-select--error"
+          errorId="validity-units"
+          errors={Array []}
+        >
+          <select
+            className="govuk-select"
+            defaultValue=""
+            id="validity-units"
+            name="duration"
+          >
+            <option
+              disabled={true}
+              selected={true}
+              value=""
+            >
+              Select a duration
+            </option>
+            <option
+              value="day"
+            >
+              Days
+            </option>
+            <option
+              value="week"
+            >
+              Weeks
+            </option>
+            <option
+              value="month"
+            >
+              Months
+            </option>
+            <option
+              value="year"
+            >
+              Years
+            </option>
+          </select>
+        </FormElementWrapper>
+      </Component>
+      <input
+        className="govuk-button"
+        id="continue-button"
+        type="submit"
+        value="Continue"
+      />
+    </fieldset>
+  </CsrfForm>
+</Component>
+`;
+
+exports[`Choose Validity Page should render correctly with defaults when provided 1`] = `
+<Component
+  description="Choose Validity page of the Create Fares Data Service"
+  title="Choose Validity - Create Fares Data Service"
+>
+  <CsrfForm
+    action="/api/chooseValidity"
+    csrfToken=""
+    method="post"
+  >
+    <ErrorSummary
+      errors={Array []}
     />
+    <fieldset
+      className="govuk-fieldset"
+    >
+      <legend
+        className="govuk-fieldset__legend govuk-fieldset__legend--l"
+      >
+        <h1
+          className="govuk-fieldset__heading"
+        >
+          How long is your product valid for?
+        </h1>
+      </legend>
+      <div
+        className="govuk-hint"
+      >
+        Product: 
+        bus company
+         - £
+        £3.00
+         - 
+        Adult
+      </div>
+      <div
+        className="govuk-hint"
+        id="choose-validity-page-hint"
+      >
+        Enter a whole number, and select a duration type. For example, 7 months.
+      </div>
+      <Component
+        errorId="validity"
+        errors={Array []}
+      >
+        <label
+          className="govuk-label"
+          htmlFor="validity"
+        >
+          Number
+        </label>
+        <FormElementWrapper
+          errorClass="govuk-input--error"
+          errorId="validity"
+          errors={Array []}
+        >
+          <input
+            aria-describedby="choose-validity-page-hint"
+            className="govuk-input govuk-input--width-2"
+            defaultValue="2"
+            id="validity"
+            name="validityInput"
+            type="text"
+          />
+        </FormElementWrapper>
+      </Component>
+      <Component
+        errorId="validity-units"
+        errors={Array []}
+      >
+        <label
+          className="govuk-label"
+          htmlFor="validity-units"
+        >
+          Duration
+        </label>
+        <FormElementWrapper
+          errorClass="govuk-select--error"
+          errorId="validity-units"
+          errors={Array []}
+        >
+          <select
+            className="govuk-select"
+            defaultValue="day"
+            id="validity-units"
+            name="duration"
+          >
+            <option
+              disabled={true}
+              selected={true}
+              value=""
+            >
+              Select a duration
+            </option>
+            <option
+              value="day"
+            >
+              Days
+            </option>
+            <option
+              value="week"
+            >
+              Weeks
+            </option>
+            <option
+              value="month"
+            >
+              Months
+            </option>
+            <option
+              value="year"
+            >
+              Years
+            </option>
+          </select>
+        </FormElementWrapper>
+      </Component>
+      <input
+        className="govuk-button"
+        id="continue-button"
+        type="submit"
+        value="Continue"
+      />
+    </fieldset>
   </CsrfForm>
 </Component>
 `;

--- a/tests/pages/api/chooseValidity.test.ts
+++ b/tests/pages/api/chooseValidity.test.ts
@@ -1,7 +1,7 @@
 import chooseValidity from '../../../src/pages/api/chooseValidity';
 import { getMockRequestAndResponse } from '../../testData/mockData';
 import * as sessions from '../../../src/utils/sessions';
-import { TIME_PERIOD_VALID_ATTRIBUTE } from '../../../src/constants';
+import { DURATION_VALID_ATTRIBUTE } from '../../../src/constants';
 
 describe('chooseValidity', () => {
     const updateSessionAttributeSpy = jest.spyOn(sessions, 'updateSessionAttribute');
@@ -43,9 +43,9 @@ describe('chooseValidity', () => {
         chooseValidity(req, res);
 
         expect(updateSessionAttributeSpy).toBeCalledTimes(1);
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, TIME_PERIOD_VALID_ATTRIBUTE, {
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, DURATION_VALID_ATTRIBUTE, {
             amount: '6',
-            timePeriodType: 'day',
+            duration: 'day',
             errors: [],
         });
     });

--- a/tests/pages/api/chooseValidity.test.ts
+++ b/tests/pages/api/chooseValidity.test.ts
@@ -1,14 +1,17 @@
-import { updateSessionAttribute } from '../../../src/utils/sessions';
 import chooseValidity from '../../../src/pages/api/chooseValidity';
 import { getMockRequestAndResponse } from '../../testData/mockData';
+import * as sessions from '../../../src/utils/sessions';
+import { TIME_PERIOD_VALID_ATTRIBUTE } from '../../../src/constants';
 
 describe('chooseValidity', () => {
+    const updateSessionAttributeSpy = jest.spyOn(sessions, 'updateSessionAttribute');
     beforeEach(() => {
         jest.resetAllMocks();
     });
     const cases: {}[] = [
         [{}, { Location: '/chooseValidity' }],
-        [{ validityInput: 'abcdefghijk' }, { Location: '/chooseValidity' }],
+        [{ validityInput: 'abcdefghijk', duration: 'day' }, { Location: '/chooseValidity' }],
+        [{ duration: 'day' }, { Location: '/chooseValidity' }],
         [{ validityInput: '1.2' }, { Location: '/chooseValidity' }],
         [{ validityInput: 1.2 }, { Location: '/chooseValidity' }],
         [{ validityInput: '367' }, { Location: '/chooseValidity' }],
@@ -17,6 +20,8 @@ describe('chooseValidity', () => {
         [{ validityInput: 0 }, { Location: '/chooseValidity' }],
         [{ validityInput: "[]'l..33" }, { Location: '/chooseValidity' }],
         [{ validityInput: '-1' }, { Location: '/chooseValidity' }],
+        [{ validityInput: '2', duration: 'day' }, { Location: '/periodValidity' }],
+        [{ validityInput: '2', duration: 'fortnights' }, { Location: '/chooseValidity' }],
     ];
 
     test.each(cases)('given %p as request, redirects to %p', (testData, expectedLocation) => {
@@ -30,16 +35,18 @@ describe('chooseValidity', () => {
     });
 
     it('should set the validity stages session according to the specified number of fare stages', () => {
-        const { req, res } = getMockRequestAndResponse({ cookieValues: {}, body: { validityInput: '6' } });
-
-        const mockSetSession = jest.fn();
-
-        (updateSessionAttribute as {}) = jest.fn().mockImplementation(() => {
-            mockSetSession();
+        const { req, res } = getMockRequestAndResponse({
+            cookieValues: {},
+            body: { validityInput: '6', duration: 'day' },
         });
 
         chooseValidity(req, res);
 
-        expect(mockSetSession).toBeCalledTimes(1);
+        expect(updateSessionAttributeSpy).toBeCalledTimes(1);
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, TIME_PERIOD_VALID_ATTRIBUTE, {
+            amount: '6',
+            timePeriodType: 'day',
+            errors: [],
+        });
     });
 });

--- a/tests/pages/api/periodValidity.test.ts
+++ b/tests/pages/api/periodValidity.test.ts
@@ -18,7 +18,7 @@ describe('periodValidity', () => {
                 {
                     productName: 'Product A',
                     productPrice: '1234',
-                    productDuration: '2',
+                    productDuration: '2 days',
                     productValidity: '24hr',
                 },
             ],

--- a/tests/pages/api/productDateInformation.test.ts
+++ b/tests/pages/api/productDateInformation.test.ts
@@ -193,7 +193,7 @@ describe('productDataInformation', () => {
                 startDateYear: '',
                 endDateDay: '04',
                 endDateMonth: '11',
-                endDateYear: '2020',
+                endDateYear: '4020',
                 productDates: 'Yes',
             },
             mockWriteHeadFn: writeHeadMock,

--- a/tests/pages/chooseValidity.test.tsx
+++ b/tests/pages/chooseValidity.test.tsx
@@ -9,7 +9,22 @@ describe('Choose Validity Page', () => {
                 productName="bus company"
                 productPrice="£3.00"
                 passengerType="Adult"
-                daysValid=""
+                amount=""
+                timePeriodType=""
+                errors={[]}
+                csrfToken=""
+            />,
+        );
+        expect(tree).toMatchSnapshot();
+    });
+    it('should render correctly with defaults when provided', () => {
+        const tree = shallow(
+            <ChooseValidity
+                productName="bus company"
+                productPrice="£3.00"
+                passengerType="Adult"
+                amount="2"
+                timePeriodType="day"
                 errors={[]}
                 csrfToken=""
             />,

--- a/tests/pages/chooseValidity.test.tsx
+++ b/tests/pages/chooseValidity.test.tsx
@@ -10,7 +10,7 @@ describe('Choose Validity Page', () => {
                 productPrice="£3.00"
                 passengerType="Adult"
                 amount=""
-                timePeriodType=""
+                duration=""
                 errors={[]}
                 csrfToken=""
             />,
@@ -24,7 +24,7 @@ describe('Choose Validity Page', () => {
                 productPrice="£3.00"
                 passengerType="Adult"
                 amount="2"
-                timePeriodType="day"
+                duration="day"
                 errors={[]}
                 csrfToken=""
             />,

--- a/tests/testData/mockData.ts
+++ b/tests/testData/mockData.ts
@@ -6,7 +6,7 @@ import { defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo } from '../../
 import {
     SALES_OFFER_PACKAGES_ATTRIBUTE,
     STAGE_NAMES_ATTRIBUTE,
-    DAYS_VALID_ATTRIBUTE,
+    TIME_PERIOD_VALID_ATTRIBUTE,
     SERVICE_ATTRIBUTE,
     INPUT_METHOD_ATTRIBUTE,
     TICKET_REPRESENTATION_ATTRIBUTE,
@@ -109,7 +109,7 @@ export const getMockRequestAndResponse = ({
         [INPUT_METHOD_ATTRIBUTE]: { inputMethod: 'csv' },
         [PASSENGER_TYPE_ATTRIBUTE]: { passengerType: 'Adult' },
         [DEFINE_PASSENGER_TYPE_ERRORS_ATTRIBUTE]: { passengerType: 'Adult' },
-        [DAYS_VALID_ATTRIBUTE]: { daysValid: '2', errors: [] },
+        [TIME_PERIOD_VALID_ATTRIBUTE]: { amount: '2', timePeriodType: 'day', errors: [] },
         [TICKET_REPRESENTATION_ATTRIBUTE]: { name: 'geoZone' },
         [FARE_STAGES_ATTRIBUTE]: { fareStages: 6 },
         [STAGE_NAMES_ATTRIBUTE]: ['Stage name one', 'Stage name two', 'Stage name three'],

--- a/tests/testData/mockData.ts
+++ b/tests/testData/mockData.ts
@@ -6,7 +6,7 @@ import { defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo } from '../../
 import {
     SALES_OFFER_PACKAGES_ATTRIBUTE,
     STAGE_NAMES_ATTRIBUTE,
-    TIME_PERIOD_VALID_ATTRIBUTE,
+    DURATION_VALID_ATTRIBUTE,
     SERVICE_ATTRIBUTE,
     INPUT_METHOD_ATTRIBUTE,
     TICKET_REPRESENTATION_ATTRIBUTE,
@@ -110,7 +110,7 @@ export const getMockRequestAndResponse = ({
         [INPUT_METHOD_ATTRIBUTE]: { inputMethod: 'csv' },
         [PASSENGER_TYPE_ATTRIBUTE]: { passengerType: 'Adult' },
         [DEFINE_PASSENGER_TYPE_ERRORS_ATTRIBUTE]: { passengerType: 'Adult' },
-        [TIME_PERIOD_VALID_ATTRIBUTE]: { amount: '2', timePeriodType: 'day', errors: [] },
+        [DURATION_VALID_ATTRIBUTE]: { amount: '2', duration: 'day', errors: [] },
         [TICKET_REPRESENTATION_ATTRIBUTE]: { name: 'geoZone' },
         [FARE_STAGES_ATTRIBUTE]: { fareStages: 6 },
         [STAGE_NAMES_ATTRIBUTE]: ['Stage name one', 'Stage name two', 'Stage name three'],


### PR DESCRIPTION
# Description

-   To allow the user to say their product lasts for 3 weeks or 2 months etc, instead of just using days.

# Testing instructions

-   Run site locally, and progress to single product period page.

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
