### PR TITLE
Fixed confirmation page so it doesnt say days  on end of duration

### DIFF
--- a/src/pages/ticketConfirmation.tsx
+++ b/src/pages/ticketConfirmation.tsx
@@ -308,9 +308,7 @@ export const buildTicketConfirmationElements = (
                 },
                 {
                     name: `Product - ${fareTypeProps.products.productName}`,
-                    content: `Duration - ${fareTypeProps.products.productDuration} ${
-                        fareTypeProps.products.productDuration === '1' ? 'day' : 'days'
-                    }`,
+                    content: `Duration - ${fareTypeProps.products.productDuration}`,
                     href: fareTypeProps.numberOfProducts > 1 ? 'multipleProducts' : 'chooseValidity',
                 },
                 {


### PR DESCRIPTION
# Description

-   We were saying the users product duration was 3 weeks days or 4 days days. This is to lop off the last 'days'.

# Testing instructions

-   Use site to create a single product period ticket, and observe on ticketConfirmation page.

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [ ] Able to run pr locally
-   [ ] Followed acceptance criteria
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
