### PR TITLE
fix: replace fareType with schoolFareType for school services

### DIFF
--- a/src/pages/api/apiUtils/userData.ts
+++ b/src/pages/api/apiUtils/userData.ts
@@ -47,6 +47,7 @@ import {
     RETURN_VALIDITY_ATTRIBUTE,
     PRODUCT_DATE_ATTRIBUTE,
     MULTIPLE_OPERATOR_ATTRIBUTE,
+    SCHOOL_FARE_TYPE_ATTRIBUTE,
 } from '../../../constants/index';
 
 import {
@@ -148,6 +149,7 @@ export const getBaseTicketAttributes = (
 
     const nocCode = getAndValidateNoc(req, res);
     const fareTypeAttribute = getSessionAttribute(req, FARE_TYPE_ATTRIBUTE);
+    const schoolFareTypeAttribute = getSessionAttribute(req, SCHOOL_FARE_TYPE_ATTRIBUTE);
     const passengerTypeAttribute = getSessionAttribute(req, PASSENGER_TYPE_ATTRIBUTE);
     const uuid = getUuidFromCookie(req, res);
     const fullTimeRestriction = getSessionAttribute(req, FULL_TIME_RESTRICTIONS_ATTRIBUTE);
@@ -156,6 +158,7 @@ export const getBaseTicketAttributes = (
     if (
         !nocCode ||
         !isFareType(fareTypeAttribute) ||
+        (isFareType(fareTypeAttribute) && fareTypeAttribute.fareType === 'schoolService' && !schoolFareTypeAttribute) ||
         !isPassengerType(passengerTypeAttribute) ||
         !idToken ||
         !uuid ||
@@ -169,7 +172,10 @@ export const getBaseTicketAttributes = (
 
     return {
         nocCode,
-        type: fareType,
+        type:
+            fareType === 'schoolService' && schoolFareTypeAttribute?.schoolFareType
+                ? schoolFareTypeAttribute?.schoolFareType
+                : fareType,
         ...passengerTypeAttribute,
         email,
         uuid,

--- a/tests/pages/api/apiUtils/userData.test.ts
+++ b/tests/pages/api/apiUtils/userData.test.ts
@@ -7,6 +7,7 @@ import {
     getFlatFareTicketJson,
     getProductsAndSalesOfferPackages,
     getSchemeOperatorTicketJson,
+    getBaseTicketAttributes,
 } from '../../../../src/pages/api/apiUtils/userData';
 import {
     TERM_TIME_ATTRIBUTE,
@@ -23,6 +24,7 @@ import {
     PRODUCT_DATE_ATTRIBUTE,
     TICKET_REPRESENTATION_ATTRIBUTE,
     MULTIPLE_OPERATOR_ATTRIBUTE,
+    SCHOOL_FARE_TYPE_ATTRIBUTE,
 } from '../../../../src/constants/index';
 
 import {
@@ -58,513 +60,540 @@ import { FareZone } from '../../../../src/pages/api/csvZoneUpload';
 import { MultipleProductAttribute } from '../../../../src/pages/api/multipleProductValidity';
 import { Operator } from '../../../../src/data/auroradb';
 
-describe('getProductsAndSalesOfferPackages', () => {
-    it('should return an array of ProductDetails objects', () => {
-        const multipleProductAttribute: MultipleProductAttribute = {
-            products: [
+describe('userData', () => {
+    describe('isTermTime', () => {
+        it('should return true if term time is true', () => {
+            const { req } = getMockRequestAndResponse({
+                session: {
+                    [TERM_TIME_ATTRIBUTE]: { termTime: true },
+                },
+            });
+            expect(isTermTime(req)).toBeTruthy();
+        });
+        it('should return false if term time is false', () => {
+            const { req } = getMockRequestAndResponse({
+                session: {
+                    [TERM_TIME_ATTRIBUTE]: { termTime: false },
+                },
+            });
+            expect(isTermTime(req)).toBeFalsy();
+        });
+    });
+
+    describe('getProductsAndSalesOfferPackages', () => {
+        it('should return an array of ProductDetails objects', () => {
+            const multipleProductAttribute: MultipleProductAttribute = {
+                products: [
+                    {
+                        productName: 'Product',
+                        productPrice: '2.99',
+                        productDuration: '1',
+                        productDurationUnits: 'week',
+                        productValidity: '24hr',
+                    },
+                    {
+                        productName: 'Product Two',
+                        productPrice: '7.99',
+                        productDuration: '7',
+                        productDurationUnits: 'day',
+                        productValidity: '24hr',
+                    },
+                ],
+            };
+            const productSops = [
                 {
                     productName: 'Product',
-                    productPrice: '2.99',
-                    productDuration: '1',
-                    productDurationUnits: 'week',
-                    productValidity: '24hr',
+                    salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
                 },
                 {
                     productName: 'Product Two',
-                    productPrice: '7.99',
-                    productDuration: '7',
-                    productDurationUnits: 'day',
-                    productValidity: '24hr',
+                    salesOfferPackages: [defaultSalesOfferPackageTwo],
                 },
-            ],
-        };
-        const productSops = [
+            ];
+            const result = getProductsAndSalesOfferPackages(productSops, multipleProductAttribute);
+            expect(result).toEqual(expectedProductDetailsArray);
+        });
+    });
+
+    describe('getBaseTicketAttributes', () => {
+        it('should replace the fareType attribute with the schoolFareType attribute for a schoolService', () => {
+            const { req, res } = getMockRequestAndResponse({
+                session: {
+                    [MATCHING_ATTRIBUTE]: {
+                        service,
+                        userFareStages,
+                        matchingFareZones: mockMatchingFaresZones,
+                    },
+                    [TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE]: mockTimeRestriction,
+                    [FARE_TYPE_ATTRIBUTE]: { fareType: 'schoolService' },
+                    [SCHOOL_FARE_TYPE_ATTRIBUTE]: { schoolFareType: 'single' },
+                    [PRODUCT_DATE_ATTRIBUTE]: {
+                        startDate: '2020-12-17T09:30:46.0Z',
+                        endDate: '2020-12-18T09:30:46.0Z',
+                    },
+                    [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: mockFullTimeRestrictions,
+                    [TERM_TIME_ATTRIBUTE]: { termTime: true },
+                },
+            });
+            const result = getBaseTicketAttributes(req, res, 'single');
+            expect(result.type).toEqual('single');
+        });
+    });
+
+    describe('getSingleTicketJson', () => {
+        it('should return a SingleTicket object', () => {
+            const { req, res } = getMockRequestAndResponse({
+                session: {
+                    [MATCHING_ATTRIBUTE]: {
+                        service,
+                        userFareStages,
+                        matchingFareZones: mockMatchingFaresZones,
+                    },
+                    [TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE]: mockTimeRestriction,
+                    [FARE_TYPE_ATTRIBUTE]: { fareType: 'single' },
+                    [PRODUCT_DATE_ATTRIBUTE]: {
+                        startDate: '2020-12-17T09:30:46.0Z',
+                        endDate: '2020-12-18T09:30:46.0Z',
+                    },
+                    [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: mockFullTimeRestrictions,
+                    [TERM_TIME_ATTRIBUTE]: { termTime: true },
+                },
+            });
+            const result = getSingleTicketJson(req, res);
+            expect(result).toStrictEqual(expectedSingleTicket);
+        });
+    });
+
+    describe('getReturnTicketJson', () => {
+        it('should return a ReturnTicket object for a non circular return journey', () => {
+            const { req, res } = getMockRequestAndResponse({
+                session: {
+                    [MATCHING_ATTRIBUTE]: {
+                        service,
+                        userFareStages,
+                        matchingFareZones: mockOutboundMatchingFaresZones,
+                    },
+                    [INBOUND_MATCHING_ATTRIBUTE]: {
+                        inboundUserFareStages: userFareStages,
+                        inboundMatchingFareZones: mockMatchingFaresZones,
+                    },
+                    [TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE]: mockTimeRestriction,
+                    [FARE_TYPE_ATTRIBUTE]: { fareType: 'return' },
+                    [PRODUCT_DATE_ATTRIBUTE]: {
+                        startDate: '2020-12-17T09:30:46.0Z',
+                        endDate: '2020-12-18T09:30:46.0Z',
+                    },
+                    [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: mockFullTimeRestrictions,
+                },
+            });
+            const result = getReturnTicketJson(req, res);
+            expect(result).toStrictEqual(expectedNonCircularReturnTicket);
+        });
+
+        it('should return a ReturnTicket object for a circular journey', () => {
+            const { req, res } = getMockRequestAndResponse({
+                cookieValues: {},
+                session: {
+                    [MATCHING_ATTRIBUTE]: {
+                        service,
+                        userFareStages,
+                        matchingFareZones: mockMatchingFaresZones,
+                    },
+                    [TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE]: mockTimeRestriction,
+                    [FARE_TYPE_ATTRIBUTE]: { fareType: 'return' },
+                    [PRODUCT_DATE_ATTRIBUTE]: {
+                        startDate: '2020-12-17T09:30:46.0Z',
+                        endDate: '2020-12-18T09:30:46.0Z',
+                    },
+                    [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: mockFullTimeRestrictions,
+                },
+            });
+            const result = getReturnTicketJson(req, res);
+            expect(result).toStrictEqual(expectedCircularReturnTicket);
+        });
+    });
+
+    describe('getGeoZoneTicketJson', () => {
+        afterEach(() => {
+            jest.resetAllMocks();
+        });
+
+        const mockMultiOpSelectedOperators: Operator[] = [
             {
-                productName: 'Product',
-                salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+                nocCode: 'MCTR',
+                operatorPublicName: 'Manchester Community Transport',
             },
             {
-                productName: 'Product Two',
-                salesOfferPackages: [defaultSalesOfferPackageTwo],
+                nocCode: 'WBTR',
+                operatorPublicName: "Warrington's Own Buses",
+            },
+            {
+                nocCode: 'BLAC',
+                operatorPublicName: 'Blackpool Transport',
             },
         ];
-        const result = getProductsAndSalesOfferPackages(productSops, multipleProductAttribute);
-        expect(result).toEqual(expectedProductDetailsArray);
-    });
-});
 
-describe('isTermTime', () => {
-    it('should return true if term time is true', () => {
-        const { req } = getMockRequestAndResponse({
-            session: {
-                [TERM_TIME_ATTRIBUTE]: { termTime: true },
-            },
+        const atcoCodes: string[] = ['13003305E', '13003622B', '13003655B'];
+        let batchGetStopsByAtcoCodeSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            jest.spyOn(s3, 'getCsvZoneUploadData').mockImplementation(() => Promise.resolve(atcoCodes));
+
+            batchGetStopsByAtcoCodeSpy = jest.spyOn(auroradb, 'batchGetStopsByAtcoCode');
         });
-        expect(isTermTime(req)).toBeTruthy();
-    });
-    it('should return false if term time is false', () => {
-        const { req } = getMockRequestAndResponse({
-            session: {
-                [TERM_TIME_ATTRIBUTE]: { termTime: false },
-            },
-        });
-        expect(isTermTime(req)).toBeFalsy();
-    });
-});
 
-describe('getSingleTicketJson', () => {
-    it('should return a SingleTicket object', () => {
-        const { req, res } = getMockRequestAndResponse({
-            session: {
-                [MATCHING_ATTRIBUTE]: {
-                    service,
-                    userFareStages,
-                    matchingFareZones: mockMatchingFaresZones,
-                },
-                [TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE]: mockTimeRestriction,
-                [FARE_TYPE_ATTRIBUTE]: { fareType: 'single' },
-                [PRODUCT_DATE_ATTRIBUTE]: {
-                    startDate: '2020-12-17T09:30:46.0Z',
-                    endDate: '2020-12-18T09:30:46.0Z',
-                },
-                [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: mockFullTimeRestrictions,
-                [TERM_TIME_ATTRIBUTE]: { termTime: true },
-            },
-        });
-        const result = getSingleTicketJson(req, res);
-        expect(result).toStrictEqual(expectedSingleTicket);
-    });
-});
-
-describe('getReturnTicketJson', () => {
-    it('should return a ReturnTicket object for a non circular return journey', () => {
-        const { req, res } = getMockRequestAndResponse({
-            session: {
-                [MATCHING_ATTRIBUTE]: {
-                    service,
-                    userFareStages,
-                    matchingFareZones: mockOutboundMatchingFaresZones,
-                },
-                [INBOUND_MATCHING_ATTRIBUTE]: {
-                    inboundUserFareStages: userFareStages,
-                    inboundMatchingFareZones: mockMatchingFaresZones,
-                },
-                [TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE]: mockTimeRestriction,
-                [FARE_TYPE_ATTRIBUTE]: { fareType: 'return' },
-                [PRODUCT_DATE_ATTRIBUTE]: {
-                    startDate: '2020-12-17T09:30:46.0Z',
-                    endDate: '2020-12-18T09:30:46.0Z',
-                },
-                [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: mockFullTimeRestrictions,
-            },
-        });
-        const result = getReturnTicketJson(req, res);
-        expect(result).toStrictEqual(expectedNonCircularReturnTicket);
-    });
-
-    it('should return a ReturnTicket object for a circular journey', () => {
-        const { req, res } = getMockRequestAndResponse({
-            cookieValues: {},
-            session: {
-                [MATCHING_ATTRIBUTE]: {
-                    service,
-                    userFareStages,
-                    matchingFareZones: mockMatchingFaresZones,
-                },
-                [TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE]: mockTimeRestriction,
-                [FARE_TYPE_ATTRIBUTE]: { fareType: 'return' },
-                [PRODUCT_DATE_ATTRIBUTE]: {
-                    startDate: '2020-12-17T09:30:46.0Z',
-                    endDate: '2020-12-18T09:30:46.0Z',
-                },
-                [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: mockFullTimeRestrictions,
-            },
-        });
-        const result = getReturnTicketJson(req, res);
-        expect(result).toStrictEqual(expectedCircularReturnTicket);
-    });
-});
-
-describe('getGeoZoneTicketJson', () => {
-    afterEach(() => {
-        jest.resetAllMocks();
-    });
-
-    const mockMultiOpSelectedOperators: Operator[] = [
-        {
-            nocCode: 'MCTR',
-            operatorPublicName: 'Manchester Community Transport',
-        },
-        {
-            nocCode: 'WBTR',
-            operatorPublicName: "Warrington's Own Buses",
-        },
-        {
-            nocCode: 'BLAC',
-            operatorPublicName: 'Blackpool Transport',
-        },
-    ];
-
-    const atcoCodes: string[] = ['13003305E', '13003622B', '13003655B'];
-    let batchGetStopsByAtcoCodeSpy: jest.SpyInstance;
-
-    beforeEach(() => {
-        jest.spyOn(s3, 'getCsvZoneUploadData').mockImplementation(() => Promise.resolve(atcoCodes));
-
-        batchGetStopsByAtcoCodeSpy = jest.spyOn(auroradb, 'batchGetStopsByAtcoCode');
-    });
-
-    it.each([
-        ['period', expectedPeriodGeoZoneTicketWithMultipleProducts],
-        ['multiOperator', expectedMultiOperatorGeoZoneTicketWithMultipleProducts],
-    ])('should return a %s geoZoneTicket object', async (fareType, expectedJson) => {
-        const mockFareZoneAttribute: FareZone = { fareZoneName: 'Green Lane Shops' };
-        const { req, res } = getMockRequestAndResponse({
-            cookieValues: {},
-            session: {
-                [TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE]: mockTimeRestriction,
-                [FARE_TYPE_ATTRIBUTE]: { fareType },
-                [FARE_ZONE_ATTRIBUTE]: mockFareZoneAttribute,
-                [MULTIPLE_PRODUCT_ATTRIBUTE]: {
-                    products: [
+        it.each([
+            ['period', expectedPeriodGeoZoneTicketWithMultipleProducts],
+            ['multiOperator', expectedMultiOperatorGeoZoneTicketWithMultipleProducts],
+        ])('should return a %s geoZoneTicket object', async (fareType, expectedJson) => {
+            const mockFareZoneAttribute: FareZone = { fareZoneName: 'Green Lane Shops' };
+            const { req, res } = getMockRequestAndResponse({
+                cookieValues: {},
+                session: {
+                    [TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE]: mockTimeRestriction,
+                    [FARE_TYPE_ATTRIBUTE]: { fareType },
+                    [FARE_ZONE_ATTRIBUTE]: mockFareZoneAttribute,
+                    [MULTIPLE_PRODUCT_ATTRIBUTE]: {
+                        products: [
+                            {
+                                productName: 'Weekly Ticket',
+                                productPrice: '50',
+                                productDuration: '5',
+                                productDurationUnits: 'week',
+                                productValidity: '24hr',
+                                salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+                            },
+                            {
+                                productName: 'Day Ticket',
+                                productPrice: '2.50',
+                                productDuration: '1',
+                                productDurationUnits: 'year',
+                                productValidity: '24hr',
+                                salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+                            },
+                            {
+                                productName: 'Monthly Ticket',
+                                productPrice: '200',
+                                productDuration: '28',
+                                productDurationUnits: 'month',
+                                productValidity: 'endOfCalendarDay',
+                                salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+                            },
+                        ],
+                    },
+                    [SALES_OFFER_PACKAGES_ATTRIBUTE]: [
                         {
                             productName: 'Weekly Ticket',
-                            productPrice: '50',
-                            productDuration: '5',
-                            productDurationUnits: 'week',
-                            productValidity: '24hr',
                             salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
                         },
                         {
                             productName: 'Day Ticket',
-                            productPrice: '2.50',
-                            productDuration: '1',
-                            productDurationUnits: 'year',
-                            productValidity: '24hr',
                             salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
                         },
                         {
                             productName: 'Monthly Ticket',
-                            productPrice: '200',
-                            productDuration: '28',
-                            productDurationUnits: 'month',
-                            productValidity: 'endOfCalendarDay',
                             salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
                         },
                     ],
+                    [PRODUCT_DATE_ATTRIBUTE]: {
+                        startDate: '2020-12-17T09:30:46.0Z',
+                        endDate: '2020-12-18T09:30:46.0Z',
+                    },
+                    ...(fareType === 'multiOperator' && {
+                        [MULTIPLE_OPERATOR_ATTRIBUTE]: { selectedOperators: mockMultiOpSelectedOperators },
+                    }),
+                    [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: mockFullTimeRestrictions,
                 },
-                [SALES_OFFER_PACKAGES_ATTRIBUTE]: [
-                    {
-                        productName: 'Weekly Ticket',
-                        salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+            });
+            batchGetStopsByAtcoCodeSpy.mockImplementation(() => Promise.resolve(zoneStops));
+            const result = await getGeoZoneTicketJson(req, res);
+            expect(result).toStrictEqual(expectedJson);
+        });
+    });
+
+    describe('getPeriodMulipleServicesTicketJson', () => {
+        it('should return a PeriodMultipleServicesTicket object', () => {
+            const { req, res } = getMockRequestAndResponse({
+                cookieValues: {},
+                session: {
+                    [TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE]: mockTimeRestriction,
+                    [FARE_TYPE_ATTRIBUTE]: { fareType: 'period' },
+                    [TICKET_REPRESENTATION_ATTRIBUTE]: { name: 'multipleServices' },
+                    [MULTIPLE_PRODUCT_ATTRIBUTE]: {
+                        products: [
+                            {
+                                productName: 'Weekly Ticket',
+                                productPrice: '50',
+                                productDuration: '5',
+                                productDurationUnits: 'week',
+                                productValidity: '24hr',
+                            },
+                            {
+                                productName: 'Day Ticket',
+                                productPrice: '2.50',
+                                productDuration: '1',
+                                productDurationUnits: 'year',
+                                productValidity: '24hr',
+                            },
+                            {
+                                productName: 'Monthly Ticket',
+                                productPrice: '200',
+                                productDuration: '28',
+                                productDurationUnits: 'month',
+                                productValidity: 'endOfCalendarDay',
+                            },
+                        ],
                     },
-                    {
-                        productName: 'Day Ticket',
-                        salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+                    [SALES_OFFER_PACKAGES_ATTRIBUTE]: [
+                        {
+                            productName: 'Weekly Ticket',
+                            salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+                        },
+                        {
+                            productName: 'Day Ticket',
+                            salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+                        },
+                        {
+                            productName: 'Monthly Ticket',
+                            salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+                        },
+                    ],
+                    [PRODUCT_DATE_ATTRIBUTE]: {
+                        startDate: '2020-12-17T09:30:46.0Z',
+                        endDate: '2020-12-18T09:30:46.0Z',
                     },
-                    {
-                        productName: 'Monthly Ticket',
-                        salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
-                    },
-                ],
-                [PRODUCT_DATE_ATTRIBUTE]: {
-                    startDate: '2020-12-17T09:30:46.0Z',
-                    endDate: '2020-12-18T09:30:46.0Z',
+                    [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: mockFullTimeRestrictions,
                 },
-                ...(fareType === 'multiOperator' && {
+            });
+            const result = getMultipleServicesTicketJson(req, res);
+            expect(result).toStrictEqual(expectedPeriodMultipleServicesTicketWithMultipleProducts);
+        });
+
+        it('should return a MultiOperatorMultipleServicesTicket object if the ticket is multipleOperators', () => {
+            const { req, res } = getMockRequestAndResponse({
+                cookieValues: {},
+                session: {
+                    [TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE]: mockTimeRestriction,
+                    [FARE_TYPE_ATTRIBUTE]: { fareType: 'multiOperator' },
+                    [TICKET_REPRESENTATION_ATTRIBUTE]: { name: 'multipleServices' },
+                    [MULTIPLE_PRODUCT_ATTRIBUTE]: {
+                        products: [
+                            {
+                                productName: 'Weekly Ticket',
+                                productPrice: '50',
+                                productDuration: '5',
+                                productDurationUnits: 'week',
+                                productValidity: '24hr',
+                            },
+                            {
+                                productName: 'Day Ticket',
+                                productPrice: '2.50',
+                                productDuration: '1',
+                                productDurationUnits: 'year',
+                                productValidity: '24hr',
+                            },
+                            {
+                                productName: 'Monthly Ticket',
+                                productPrice: '200',
+                                productDuration: '28',
+                                productDurationUnits: 'month',
+                                productValidity: 'endOfCalendarDay',
+                            },
+                        ],
+                    },
+                    [SALES_OFFER_PACKAGES_ATTRIBUTE]: [
+                        {
+                            productName: 'Weekly Ticket',
+                            salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+                        },
+                        {
+                            productName: 'Day Ticket',
+                            salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+                        },
+                        {
+                            productName: 'Monthly Ticket',
+                            salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+                        },
+                    ],
+                    [PRODUCT_DATE_ATTRIBUTE]: {
+                        startDate: '2020-12-17T09:30:46.0Z',
+                        endDate: '2020-12-18T09:30:46.0Z',
+                    },
+                    [MULTIPLE_OPERATORS_SERVICES_ATTRIBUTE]: [
+                        {
+                            nocCode: 'WBTR',
+                            services: [
+                                '237#11-237-_-y08-1#07/04/2020#Ashton Under Lyne - Glossop',
+                                '391#NW_01_MCT_391_1#23/04/2019#Macclesfield - Bollington - Poynton - Stockport',
+                                '232#NW_04_MCTR_232_1#06/04/2020#Ashton - Hurst Cross - Broadoak Circular',
+                            ],
+                        },
+                        {
+                            nocCode: 'BLAC',
+                            services: [
+                                '343#11-444-_-y08-1#07/04/2020#Test Under Lyne - Glossop',
+                                '444#NW_01_MCT_391_1#23/04/2019#Macclesfield - Bollington - Poynton - Stockport',
+                                '543#NW_04_MCTR_232_1#06/04/2020#Ashton - Hurst Cross - Broadoak Circular',
+                            ],
+                        },
+                        {
+                            nocCode: 'LEDS',
+                            services: [
+                                '342#11-237-_-y08-1#07/04/2020#Another Test Under Lyne - Glossop',
+                                '221#NW_01_MCT_391_1#23/04/2019#Macclesfield - Bollington - Poynton - Stockport',
+                                '247#NW_04_MCTR_232_1#06/04/2020#Ashton - Hurst Cross - Broadoak Circular',
+                            ],
+                        },
+                    ],
+                    [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: mockFullTimeRestrictions,
+                },
+            });
+            const result = getMultipleServicesTicketJson(req, res);
+            expect(result).toStrictEqual(expectedPeriodMultipleServicesTicketWithMultipleProductsAndMultipleOperators);
+        });
+    });
+
+    describe('getFlatFareTicketJson', () => {
+        it('should return a FlatFareTicket object', () => {
+            const { req, res } = getMockRequestAndResponse({
+                session: {
+                    [PRODUCT_DETAILS_ATTRIBUTE]: {
+                        products: [
+                            {
+                                productName: 'Weekly Rider',
+                                productPrice: '7',
+                            },
+                        ],
+                    },
+                    [FARE_TYPE_ATTRIBUTE]: { fareType: 'flatFare' },
+                    [PRODUCT_DATE_ATTRIBUTE]: {
+                        startDate: '2020-12-17T09:30:46.0Z',
+                        endDate: '2020-12-18T09:30:46.0Z',
+                    },
+                },
+            });
+            const result = getFlatFareTicketJson(req, res);
+            expect(result).toEqual(expectedFlatFareTicket);
+        });
+    });
+
+    describe('getSchemeOperatorTicketJson', () => {
+        afterEach(() => {
+            jest.resetAllMocks();
+        });
+
+        const mockMultiOpSelectedOperators: Operator[] = [
+            {
+                nocCode: 'MCTR',
+                operatorPublicName: 'Manchester Community Transport',
+            },
+            {
+                nocCode: 'WBTR',
+                operatorPublicName: "Warrington's Own Buses",
+            },
+            {
+                nocCode: 'BLAC',
+                operatorPublicName: 'Blackpool Transport',
+            },
+        ];
+
+        const atcoCodes: string[] = ['13003305E', '13003622B', '13003655B'];
+        let batchGetStopsByAtcoCodeSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            jest.spyOn(s3, 'getCsvZoneUploadData').mockImplementation(() => Promise.resolve(atcoCodes));
+
+            batchGetStopsByAtcoCodeSpy = jest.spyOn(auroradb, 'batchGetStopsByAtcoCode');
+        });
+
+        it('should return a SchemeOperatorTicket object', async () => {
+            const mockFareZoneAttribute: FareZone = { fareZoneName: 'Green Lane Shops' };
+            const { req, res } = getMockRequestAndResponse({
+                cookieValues: {
+                    operator: { operator: 'SCHEME_OPERATOR', region: 'SCHEME_REGION' },
+                    idToken: mockSchemOpIdToken,
+                },
+                session: {
+                    [TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE]: mockTimeRestriction,
+                    [FARE_TYPE_ATTRIBUTE]: { fareType: 'multiOperator' },
+                    [FARE_ZONE_ATTRIBUTE]: mockFareZoneAttribute,
+                    [MULTIPLE_PRODUCT_ATTRIBUTE]: {
+                        products: [
+                            {
+                                productName: 'Weekly Ticket',
+                                productPrice: '50',
+                                productDuration: '5',
+                                productDurationUnits: 'week',
+                                productValidity: '24hr',
+                                salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+                            },
+                            {
+                                productName: 'Day Ticket',
+                                productPrice: '2.50',
+                                productDuration: '1',
+                                productDurationUnits: 'month',
+                                productValidity: '24hr',
+                                salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+                            },
+                            {
+                                productName: 'Monthly Ticket',
+                                productPrice: '200',
+                                productDuration: '28',
+                                productDurationUnits: 'year',
+                                productValidity: 'endOfCalendarDay',
+                                salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+                            },
+                        ],
+                    },
+                    [SALES_OFFER_PACKAGES_ATTRIBUTE]: [
+                        {
+                            productName: 'Weekly Ticket',
+                            salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+                        },
+                        {
+                            productName: 'Day Ticket',
+                            salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+                        },
+                        {
+                            productName: 'Monthly Ticket',
+                            salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
+                        },
+                    ],
+                    [PRODUCT_DATE_ATTRIBUTE]: {
+                        startDate: '2020-12-17T09:30:46.0Z',
+                        endDate: '2020-12-18T09:30:46.0Z',
+                    },
                     [MULTIPLE_OPERATOR_ATTRIBUTE]: { selectedOperators: mockMultiOpSelectedOperators },
-                }),
-                [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: mockFullTimeRestrictions,
-            },
-        });
-        batchGetStopsByAtcoCodeSpy.mockImplementation(() => Promise.resolve(zoneStops));
-        const result = await getGeoZoneTicketJson(req, res);
-        expect(result).toStrictEqual(expectedJson);
-    });
-});
-
-describe('getPeriodMulipleServicesTicketJson', () => {
-    it('should return a PeriodMultipleServicesTicket object', () => {
-        const { req, res } = getMockRequestAndResponse({
-            cookieValues: {},
-            session: {
-                [TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE]: mockTimeRestriction,
-                [FARE_TYPE_ATTRIBUTE]: { fareType: 'period' },
-                [TICKET_REPRESENTATION_ATTRIBUTE]: { name: 'multipleServices' },
-                [MULTIPLE_PRODUCT_ATTRIBUTE]: {
-                    products: [
-                        {
-                            productName: 'Weekly Ticket',
-                            productPrice: '50',
-                            productDuration: '5',
-                            productDurationUnits: 'week',
-                            productValidity: '24hr',
-                        },
-                        {
-                            productName: 'Day Ticket',
-                            productPrice: '2.50',
-                            productDuration: '1',
-                            productDurationUnits: 'year',
-                            productValidity: '24hr',
-                        },
-                        {
-                            productName: 'Monthly Ticket',
-                            productPrice: '200',
-                            productDuration: '28',
-                            productDurationUnits: 'month',
-                            productValidity: 'endOfCalendarDay',
-                        },
-                    ],
-                },
-                [SALES_OFFER_PACKAGES_ATTRIBUTE]: [
-                    {
-                        productName: 'Weekly Ticket',
-                        salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
-                    },
-                    {
-                        productName: 'Day Ticket',
-                        salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
-                    },
-                    {
-                        productName: 'Monthly Ticket',
-                        salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
-                    },
-                ],
-                [PRODUCT_DATE_ATTRIBUTE]: {
-                    startDate: '2020-12-17T09:30:46.0Z',
-                    endDate: '2020-12-18T09:30:46.0Z',
-                },
-                [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: mockFullTimeRestrictions,
-            },
-        });
-        const result = getMultipleServicesTicketJson(req, res);
-        expect(result).toStrictEqual(expectedPeriodMultipleServicesTicketWithMultipleProducts);
-    });
-
-    it('should return a MultiOperatorMultipleServicesTicket object if the ticket is multipleOperators', () => {
-        const { req, res } = getMockRequestAndResponse({
-            cookieValues: {},
-            session: {
-                [TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE]: mockTimeRestriction,
-                [FARE_TYPE_ATTRIBUTE]: { fareType: 'multiOperator' },
-                [TICKET_REPRESENTATION_ATTRIBUTE]: { name: 'multipleServices' },
-                [MULTIPLE_PRODUCT_ATTRIBUTE]: {
-                    products: [
-                        {
-                            productName: 'Weekly Ticket',
-                            productPrice: '50',
-                            productDuration: '5',
-                            productDurationUnits: 'week',
-                            productValidity: '24hr',
-                        },
-                        {
-                            productName: 'Day Ticket',
-                            productPrice: '2.50',
-                            productDuration: '1',
-                            productDurationUnits: 'year',
-                            productValidity: '24hr',
-                        },
-                        {
-                            productName: 'Monthly Ticket',
-                            productPrice: '200',
-                            productDuration: '28',
-                            productDurationUnits: 'month',
-                            productValidity: 'endOfCalendarDay',
-                        },
-                    ],
-                },
-                [SALES_OFFER_PACKAGES_ATTRIBUTE]: [
-                    {
-                        productName: 'Weekly Ticket',
-                        salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
-                    },
-                    {
-                        productName: 'Day Ticket',
-                        salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
-                    },
-                    {
-                        productName: 'Monthly Ticket',
-                        salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
-                    },
-                ],
-                [PRODUCT_DATE_ATTRIBUTE]: {
-                    startDate: '2020-12-17T09:30:46.0Z',
-                    endDate: '2020-12-18T09:30:46.0Z',
-                },
-                [MULTIPLE_OPERATORS_SERVICES_ATTRIBUTE]: [
-                    {
-                        nocCode: 'WBTR',
-                        services: [
-                            '237#11-237-_-y08-1#07/04/2020#Ashton Under Lyne - Glossop',
-                            '391#NW_01_MCT_391_1#23/04/2019#Macclesfield - Bollington - Poynton - Stockport',
-                            '232#NW_04_MCTR_232_1#06/04/2020#Ashton - Hurst Cross - Broadoak Circular',
+                    [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: {
+                        fullTimeRestrictions: [
+                            {
+                                day: 'monday',
+                                startTime: '0900',
+                                endTime: '',
+                            },
+                            {
+                                day: 'tuesday',
+                                startTime: '',
+                                endTime: '1800',
+                            },
+                            {
+                                day: 'bank holiday',
+                                startTime: '0900',
+                                endTime: '1750',
+                            },
+                            {
+                                day: 'friday',
+                                startTime: '',
+                                endTime: '',
+                            },
                         ],
+                        errors: [],
                     },
-                    {
-                        nocCode: 'BLAC',
-                        services: [
-                            '343#11-444-_-y08-1#07/04/2020#Test Under Lyne - Glossop',
-                            '444#NW_01_MCT_391_1#23/04/2019#Macclesfield - Bollington - Poynton - Stockport',
-                            '543#NW_04_MCTR_232_1#06/04/2020#Ashton - Hurst Cross - Broadoak Circular',
-                        ],
-                    },
-                    {
-                        nocCode: 'LEDS',
-                        services: [
-                            '342#11-237-_-y08-1#07/04/2020#Another Test Under Lyne - Glossop',
-                            '221#NW_01_MCT_391_1#23/04/2019#Macclesfield - Bollington - Poynton - Stockport',
-                            '247#NW_04_MCTR_232_1#06/04/2020#Ashton - Hurst Cross - Broadoak Circular',
-                        ],
-                    },
-                ],
-                [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: mockFullTimeRestrictions,
-            },
+                },
+            });
+            batchGetStopsByAtcoCodeSpy.mockImplementation(() => Promise.resolve(zoneStops));
+            const result = await getSchemeOperatorTicketJson(req, res);
+            expect(result).toEqual(expectedSchemeOperatorTicket);
         });
-        const result = getMultipleServicesTicketJson(req, res);
-        expect(result).toStrictEqual(expectedPeriodMultipleServicesTicketWithMultipleProductsAndMultipleOperators);
-    });
-});
-
-describe('getFlatFareTicketJson', () => {
-    it('should return a FlatFareTicket object', () => {
-        const { req, res } = getMockRequestAndResponse({
-            session: {
-                [PRODUCT_DETAILS_ATTRIBUTE]: {
-                    products: [
-                        {
-                            productName: 'Weekly Rider',
-                            productPrice: '7',
-                        },
-                    ],
-                },
-                [FARE_TYPE_ATTRIBUTE]: { fareType: 'flatFare' },
-                [PRODUCT_DATE_ATTRIBUTE]: {
-                    startDate: '2020-12-17T09:30:46.0Z',
-                    endDate: '2020-12-18T09:30:46.0Z',
-                },
-            },
-        });
-        const result = getFlatFareTicketJson(req, res);
-        expect(result).toEqual(expectedFlatFareTicket);
-    });
-});
-
-describe('getSchemeOperatorTicketJson', () => {
-    afterEach(() => {
-        jest.resetAllMocks();
-    });
-
-    const mockMultiOpSelectedOperators: Operator[] = [
-        {
-            nocCode: 'MCTR',
-            operatorPublicName: 'Manchester Community Transport',
-        },
-        {
-            nocCode: 'WBTR',
-            operatorPublicName: "Warrington's Own Buses",
-        },
-        {
-            nocCode: 'BLAC',
-            operatorPublicName: 'Blackpool Transport',
-        },
-    ];
-
-    const atcoCodes: string[] = ['13003305E', '13003622B', '13003655B'];
-    let batchGetStopsByAtcoCodeSpy: jest.SpyInstance;
-
-    beforeEach(() => {
-        jest.spyOn(s3, 'getCsvZoneUploadData').mockImplementation(() => Promise.resolve(atcoCodes));
-
-        batchGetStopsByAtcoCodeSpy = jest.spyOn(auroradb, 'batchGetStopsByAtcoCode');
-    });
-
-    it('should return a SchemeOperatorTicket object', async () => {
-        const mockFareZoneAttribute: FareZone = { fareZoneName: 'Green Lane Shops' };
-        const { req, res } = getMockRequestAndResponse({
-            cookieValues: {
-                operator: { operator: 'SCHEME_OPERATOR', region: 'SCHEME_REGION' },
-                idToken: mockSchemOpIdToken,
-            },
-            session: {
-                [TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE]: mockTimeRestriction,
-                [FARE_TYPE_ATTRIBUTE]: { fareType: 'multiOperator' },
-                [FARE_ZONE_ATTRIBUTE]: mockFareZoneAttribute,
-                [MULTIPLE_PRODUCT_ATTRIBUTE]: {
-                    products: [
-                        {
-                            productName: 'Weekly Ticket',
-                            productPrice: '50',
-                            productDuration: '5',
-                            productDurationUnits: 'week',
-                            productValidity: '24hr',
-                            salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
-                        },
-                        {
-                            productName: 'Day Ticket',
-                            productPrice: '2.50',
-                            productDuration: '1',
-                            productDurationUnits: 'month',
-                            productValidity: '24hr',
-                            salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
-                        },
-                        {
-                            productName: 'Monthly Ticket',
-                            productPrice: '200',
-                            productDuration: '28',
-                            productDurationUnits: 'year',
-                            productValidity: 'endOfCalendarDay',
-                            salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
-                        },
-                    ],
-                },
-                [SALES_OFFER_PACKAGES_ATTRIBUTE]: [
-                    {
-                        productName: 'Weekly Ticket',
-                        salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
-                    },
-                    {
-                        productName: 'Day Ticket',
-                        salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
-                    },
-                    {
-                        productName: 'Monthly Ticket',
-                        salesOfferPackages: [defaultSalesOfferPackageOne, defaultSalesOfferPackageTwo],
-                    },
-                ],
-                [PRODUCT_DATE_ATTRIBUTE]: {
-                    startDate: '2020-12-17T09:30:46.0Z',
-                    endDate: '2020-12-18T09:30:46.0Z',
-                },
-                [MULTIPLE_OPERATOR_ATTRIBUTE]: { selectedOperators: mockMultiOpSelectedOperators },
-                [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: {
-                    fullTimeRestrictions: [
-                        {
-                            day: 'monday',
-                            startTime: '0900',
-                            endTime: '',
-                        },
-                        {
-                            day: 'tuesday',
-                            startTime: '',
-                            endTime: '1800',
-                        },
-                        {
-                            day: 'bank holiday',
-                            startTime: '0900',
-                            endTime: '1750',
-                        },
-                        {
-                            day: 'friday',
-                            startTime: '',
-                            endTime: '',
-                        },
-                    ],
-                    errors: [],
-                },
-            },
-        });
-        batchGetStopsByAtcoCodeSpy.mockImplementation(() => Promise.resolve(zoneStops));
-        const result = await getSchemeOperatorTicketJson(req, res);
-        expect(result).toEqual(expectedSchemeOperatorTicket);
     });
 });


### PR DESCRIPTION
# Description

-   This PR ensures that the matching json produced for a school ticket contains a 'type' attribute which matches the actual ticket type (rather than `type = 'schoolService')`.

# Testing instructions

-   Pull down this branch and run the site locally. Validate that the type attribute is representative of the actual ticket type for each school service ticket type. 

# Type of change

-   [ ] feat - A new feature
-   [X] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [X] Able to run pr locally
-   [X] Followed acceptance criteria
-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [X] I have added tests that prove my fix is effective or that my feature works
