### PR TITLE
feat: allow users to upload xls and xlsx files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2799,6 +2799,14 @@
             "integrity": "sha512-PUdqTZVrNYTNcIhLHkiaYzoOIaUi5LFg/XLerAdgvwQrUCx+oSbtoBze1AMyvYbcwzUSNC+Isl58SM4Sm/6COw==",
             "dev": true
         },
+        "@types/xlsx": {
+            "version": "0.0.36",
+            "resolved": "https://registry.npmjs.org/@types/xlsx/-/xlsx-0.0.36.tgz",
+            "integrity": "sha512-mvfrKiKKMErQzLMF8ElYEH21qxWCZtN59pHhWGmWCWFJStYdMWjkDSAy6mGowFxHXaXZWe5/TW7pBUiWclIVOw==",
+            "requires": {
+                "xlsx": "*"
+            }
+        },
         "@types/yargs": {
             "version": "15.0.4",
             "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
@@ -3163,6 +3171,15 @@
                 "object-path": {
                     "version": "^0.11.5"
                 }
+            }
+        },
+        "adler-32": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.2.0.tgz",
+            "integrity": "sha1-aj5r8KY5ALoVZSgIyxXGgT0aXyU=",
+            "requires": {
+                "exit-on-epipe": "~1.0.1",
+                "printj": "~1.1.0"
             }
         },
         "aggregate-error": {
@@ -4285,6 +4302,16 @@
             "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
             "dev": true
         },
+        "cfb": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.0.tgz",
+            "integrity": "sha512-sXMvHsKCICVR3Naq+J556K+ExBo9n50iKl6LGarlnvuA2035uMlGA/qVrc0wQtow5P1vJEw9UyrKLCbtIKz+TQ==",
+            "requires": {
+                "adler-32": "~1.2.0",
+                "crc-32": "~1.2.0",
+                "printj": "~1.1.2"
+            }
+        },
         "chalk": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -4636,6 +4663,22 @@
                 "q": "^1.1.2"
             }
         },
+        "codepage": {
+            "version": "1.14.0",
+            "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.14.0.tgz",
+            "integrity": "sha1-jL4lSBMjVZ19MHVxsP/5HnodL5k=",
+            "requires": {
+                "commander": "~2.14.1",
+                "exit-on-epipe": "~1.0.1"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.14.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+                    "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+                }
+            }
+        },
         "collect-v8-coverage": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
@@ -4952,6 +4995,15 @@
                 "is-directory": "^0.3.1",
                 "js-yaml": "^3.13.1",
                 "parse-json": "^4.0.0"
+            }
+        },
+        "crc-32": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
+            "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
+            "requires": {
+                "exit-on-epipe": "~1.0.1",
+                "printj": "~1.1.0"
             }
         },
         "create-ecdh": {
@@ -6457,6 +6509,11 @@
             "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
             "dev": true
         },
+        "exit-on-epipe": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+            "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
+        },
         "expand-brackets": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -6864,6 +6921,11 @@
             "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
             "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg=="
         },
+        "fflate": {
+            "version": "0.3.10",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.3.10.tgz",
+            "integrity": "sha512-s5j69APkUPPbzdI20Ix4pPtQP+1Qi58YcFRpE7aO/P1kEywUYjbl2RjZRVEMdnySO9pr4MB0BHPbxkiahrtD/Q=="
+        },
         "figgy-pudding": {
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -7204,6 +7266,11 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
             "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+        },
+        "frac": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+            "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA=="
         },
         "fragment-cache": {
             "version": "0.2.1",
@@ -13908,6 +13975,11 @@
                 }
             }
         },
+        "printj": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+            "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
+        },
         "private": {
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -15303,6 +15375,14 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.2.tgz",
             "integrity": "sha512-vF4ZbYdKS8OnoJAWBmMxCQDkiEBkGQYU7UZPtL8flbDRSNkhaXvRJ279ZtI6M+zDaQovVU4tuRgzK5fVhvFAhg=="
+        },
+        "ssf": {
+            "version": "0.11.2",
+            "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+            "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+            "requires": {
+                "frac": "~1.1.2"
+            }
         },
         "sshpk": {
             "version": "1.16.1",
@@ -17060,6 +17140,16 @@
                 }
             }
         },
+        "wmf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+            "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw=="
+        },
+        "word": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+            "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA=="
+        },
         "word-wrap": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -17156,6 +17246,30 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/x-xss-protection/-/x-xss-protection-1.3.0.tgz",
             "integrity": "sha512-kpyBI9TlVipZO4diReZMAHWtS0MMa/7Kgx8hwG/EuZLiA6sg4Ah/4TRdASHhRRN3boobzcYgFRUFSgHRge6Qhg=="
+        },
+        "xlsx": {
+            "version": "0.16.9",
+            "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.16.9.tgz",
+            "integrity": "sha512-gxi1I3EasYvgCX1vN9pGyq920Ron4NO8PNfhuoA3Hpq6Y8f0ECXiy4OLrK4QZBnj1jx3QD+8Fq5YZ/3mPZ5iXw==",
+            "requires": {
+                "adler-32": "~1.2.0",
+                "cfb": "^1.1.4",
+                "codepage": "~1.14.0",
+                "commander": "~2.17.1",
+                "crc-32": "~1.2.0",
+                "exit-on-epipe": "~1.0.1",
+                "fflate": "^0.3.8",
+                "ssf": "~0.11.2",
+                "wmf": "~1.0.1",
+                "word": "~0.3.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.17.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+                    "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+                }
+            }
         },
         "xml-name-validator": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "license": "ISC",
     "dependencies": {
         "@types/nodemailer": "^6.4.0",
+        "@types/xlsx": "0.0.36",
         "@types/zxcvbn": "^4.4.0",
         "aws-param-store": "^3.2.0",
         "aws-sdk": "^2.675.0",
@@ -70,6 +71,7 @@
         "universal-cookie": "^4.0.4",
         "uuid": "^7.0.2",
         "winston": "^3.3.3",
+        "xlsx": "^0.16.9",
         "yup": "^0.29.0",
         "zxcvbn": "^4.4.2"
     },

--- a/src/components/UserDataUploads.tsx
+++ b/src/components/UserDataUploads.tsx
@@ -61,7 +61,7 @@ const UserDataUploadComponent = ({
                                     id="csv-upload"
                                     name="csv-upload"
                                     type="file"
-                                    accept=".csv"
+                                    accept=".csv,.xlsx,.xls"
                                     aria-describedby="csv-upload-hint"
                                 />
                             </FormElementWrapper>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -102,9 +102,8 @@ export const SCHOOL_FARE_TYPE_ATTRIBUTE = 'fdbt-school-fare-type';
 
 export const oneYearInSeconds = 31556952;
 
-export const ALLOWED_XSLX_FILE_TYPES = [
+export const ALLOWED_XLSX_FILE_TYPES = [
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    'application/vnd.ms-excel',
     'application/vnd.ms-excel',
 ];
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -102,10 +102,15 @@ export const SCHOOL_FARE_TYPE_ATTRIBUTE = 'fdbt-school-fare-type';
 
 export const oneYearInSeconds = 31556952;
 
+export const ALLOWED_XSLX_FILE_TYPES = [
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/vnd.ms-excel',
+    'application/vnd.ms-excel',
+];
+
 export const ALLOWED_CSV_FILE_TYPES = [
     'text/plain',
     'text/x-csv',
-    'application/vnd.ms-excel',
     'application/csv',
     'application/x-csv',
     'application/octet-stream',

--- a/src/pages/api/apiUtils/fileUpload.ts
+++ b/src/pages/api/apiUtils/fileUpload.ts
@@ -5,7 +5,7 @@ import { NextApiRequest } from 'next';
 import fs from 'fs';
 import NodeClam from 'clamscan';
 import XLSX from 'xlsx';
-import { ALLOWED_XSLX_FILE_TYPES, ALLOWED_CSV_FILE_TYPES } from '../../../constants/index';
+import { ALLOWED_XLSX_FILE_TYPES, ALLOWED_CSV_FILE_TYPES } from '../../../constants/index';
 import logger from '../../../utils/logger';
 
 interface FileData {
@@ -39,7 +39,7 @@ export const getFormData = async (req: NextApiRequest): Promise<FileData> => {
 
     if (ALLOWED_CSV_FILE_TYPES.includes(type)) {
         fileContents = await fs.promises.readFile(files['csv-upload'].path, 'utf-8');
-    } else if (ALLOWED_XSLX_FILE_TYPES.includes(type)) {
+    } else if (ALLOWED_XLSX_FILE_TYPES.includes(type)) {
         const workBook = XLSX.readFile(files['csv-upload'].path);
         const sheetName = workBook.SheetNames[0];
         fileContents = XLSX.utils.sheet_to_csv(workBook.Sheets[sheetName]);
@@ -77,7 +77,7 @@ export const validateFile = (fileData: formidable.File, fileContents: string): s
         return `The selected file must be smaller than 5MB`;
     }
 
-    if (!ALLOWED_CSV_FILE_TYPES.includes(type) && !ALLOWED_XSLX_FILE_TYPES.includes(type)) {
+    if (!ALLOWED_CSV_FILE_TYPES.includes(type) && !ALLOWED_XLSX_FILE_TYPES.includes(type)) {
         logger.warn('', { context: 'api.utils.validateFile', message: 'file not of allowed type', type });
 
         return 'The selected file must be a .csv or .xlsx';

--- a/src/pages/api/apiUtils/fileUpload.ts
+++ b/src/pages/api/apiUtils/fileUpload.ts
@@ -4,7 +4,8 @@ import formidable, { Files } from 'formidable';
 import { NextApiRequest } from 'next';
 import fs from 'fs';
 import NodeClam from 'clamscan';
-import { ALLOWED_CSV_FILE_TYPES } from '../../../constants';
+import XLSX from 'xlsx';
+import { ALLOWED_XSLX_FILE_TYPES, ALLOWED_CSV_FILE_TYPES } from '../../../constants/index';
 import logger from '../../../utils/logger';
 
 interface FileData {
@@ -33,7 +34,16 @@ export const formParse = async (req: NextApiRequest): Promise<Files> => {
 
 export const getFormData = async (req: NextApiRequest): Promise<FileData> => {
     const files = await formParse(req);
-    const fileContents = await fs.promises.readFile(files['csv-upload'].path, 'utf-8');
+    const { type } = files['csv-upload'];
+    let fileContents = '';
+
+    if (ALLOWED_CSV_FILE_TYPES.includes(type)) {
+        fileContents = await fs.promises.readFile(files['csv-upload'].path, 'utf-8');
+    } else if (ALLOWED_XSLX_FILE_TYPES.includes(type)) {
+        const workBook = XLSX.readFile(files['csv-upload'].path);
+        const sheetName = workBook.SheetNames[0];
+        fileContents = XLSX.utils.sheet_to_csv(workBook.Sheets[sheetName]);
+    }
 
     return {
         files,
@@ -67,10 +77,10 @@ export const validateFile = (fileData: formidable.File, fileContents: string): s
         return `The selected file must be smaller than 5MB`;
     }
 
-    if (!ALLOWED_CSV_FILE_TYPES.includes(type)) {
+    if (!ALLOWED_CSV_FILE_TYPES.includes(type) && !ALLOWED_XSLX_FILE_TYPES.includes(type)) {
         logger.warn('', { context: 'api.utils.validateFile', message: 'file not of allowed type', type });
 
-        return 'The selected file must be a CSV';
+        return 'The selected file must be a .csv or .xlsx';
     }
 
     return '';

--- a/src/pages/api/csvZoneUpload.ts
+++ b/src/pages/api/csvZoneUpload.ts
@@ -101,7 +101,7 @@ export const processCsv = async (
                     logger.warn('', {
                         context: 'api.csvZoneUpload',
                         message:
-                            'the uploaded CSV was not of the correct format, one of the required columns of information is missing or misnamed',
+                            'the uploaded fare zone was not of the correct format, one of the required columns of information is missing or misnamed',
                     });
                     csvValid = false;
                 }
@@ -113,7 +113,7 @@ export const processCsv = async (
         if (rawUserFareZones.length === 0) {
             logger.warn('', {
                 context: 'api.csvZoneUpload',
-                message: 'the uploaded CSV contained no Naptan Codes or Atco Codes',
+                message: 'the uploaded fare zone contained no Naptan Codes or Atco Codes',
             });
             csvValid = false;
         }

--- a/src/pages/csvUpload.tsx
+++ b/src/pages/csvUpload.tsx
@@ -18,7 +18,7 @@ const CsvUpload = (uploadProps: UserDataUploadsProps): ReactElement => (
             {...uploadProps}
             detailBody={
                 <>
-                    <p>Some common issues with CSV uploads include:</p>
+                    <p>Some common issues with fares triangle uploads include:</p>
                     <ul className="govuk-list govuk-list--bullet">
                         <li>Commas in fare stage names</li>
                         <li>Not providing a price in every cell</li>
@@ -26,7 +26,7 @@ const CsvUpload = (uploadProps: UserDataUploadsProps): ReactElement => (
                     </ul>
                     <p>
                         Use the help file for a more detailed guide on constructing a fares triangle in the required
-                        format or download the CSV template to create a new file.
+                        format or download the fares triangle template to create a new file.
                     </p>
                 </>
             }
@@ -40,9 +40,9 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Us
     return {
         props: {
             csvUploadApiRoute: '/api/csvUpload',
-            csvUploadTitle: 'Upload fares triangle as CSV',
+            csvUploadTitle: 'Upload fares triangle',
             csvUploadHintText:
-                'Upload a fares triangle as a CSV file. Refer to the help documents section to download a help file or a fares triangle template.',
+                'Upload a fares triangle as a .csv or MS Excel file. Refer to the help documents section to download a help file or a fares triangle template.',
             guidanceDocDisplayName: 'Download Help File - File Type PDF - File Size 1.2MB',
             guidanceDocAttachmentUrl: HowToUploadFaresTriangle,
             guidanceDocSize: '1.2MB',
@@ -50,7 +50,7 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Us
             csvTemplateAttachmentUrl: FaresTriangleExampleCsv,
             csvTemplateSize: '255B',
             errors,
-            detailSummary: "My CSV won't upload",
+            detailSummary: "My fare triangle won't upload",
             csrfToken: getCsrfToken(ctx),
         },
     };

--- a/src/pages/csvZoneUpload.tsx
+++ b/src/pages/csvZoneUpload.tsx
@@ -19,13 +19,13 @@ const CsvZoneUpload = (uploadProps: UserDataUploadsProps): ReactElement => (
             {...uploadProps}
             detailBody={
                 <>
-                    <p>Some common issues with CSV uploads include:</p>
+                    <p>Some common issues with fare zone uploads include:</p>
                     <ul className="govuk-list govuk-list--bullet">
                         <li>Commas in fare zone names</li>
                     </ul>
                     <p>
                         Use the help file document for a more detailed help on constructing a fare zone CSV in the
-                        required format or download the CSV template to create a new file.
+                        required format or download the .csv template to create a new file.
                     </p>
                 </>
             }
@@ -45,9 +45,9 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Us
     return {
         props: {
             csvUploadApiRoute: '/api/csvZoneUpload',
-            csvUploadTitle: 'Upload fare zone as CSV',
+            csvUploadTitle: 'Upload fare zone',
             csvUploadHintText:
-                'Upload a fare zone as a CSV file. A fare zone is made up of all the relevant NaPTAN or ATCO codes within a geographical area. Refer to the help documents section to download a help file or a template.',
+                'Upload a fare zone as a .csv or MS Excel file. A fare zone is made up of all the relevant NaPTAN or ATCO codes within a geographical area. Refer to the help documents section to download a help file or a template.',
             guidanceDocDisplayName: 'Download Help File - File Type PDF - File Size 967KB',
             guidanceDocAttachmentUrl: HowToUploadFareZone,
             guidanceDocSize: '967KB',
@@ -55,7 +55,7 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Us
             csvTemplateAttachmentUrl: FareZoneExampleCsv,
             csvTemplateSize: '673B',
             errors,
-            detailSummary: "My CSV won't upload",
+            detailSummary: "My fare zone won't upload",
             csrfToken: getCsrfToken(ctx),
         },
     };

--- a/src/pages/inputMethod.tsx
+++ b/src/pages/inputMethod.tsx
@@ -46,7 +46,7 @@ const InputMethod = ({ errors = [], csrfToken }: InputMethodProps): ReactElement
                                                 value="csv"
                                             />
                                             <label className="govuk-label govuk-radios__label" htmlFor="csv-upload">
-                                                Upload (.csv)
+                                                Upload a fares triangle (CSV)
                                             </label>
                                         </div>
                                         <div className="govuk-radios__item">
@@ -60,7 +60,7 @@ const InputMethod = ({ errors = [], csrfToken }: InputMethodProps): ReactElement
                                                 value="manual"
                                             />
                                             <label className="govuk-label govuk-radios__label" htmlFor="manual-entry">
-                                                Manual Fares Triangle input
+                                                Manual fares triangle input
                                             </label>
                                         </div>
                                         <div className="govuk-radios__item">
@@ -95,8 +95,9 @@ const InputMethod = ({ errors = [], csrfToken }: InputMethodProps): ReactElement
                 <p className="govuk-body">
                     CSV stands for Comma Separated Values. A CSV file is a popular format for publishing data on the
                     web. They are plain text files which means they can contain numbers and letters only. Most
-                    spreadsheet software (Microsoft Excel, Google Sheets etc.) will have a &apos;.csv&apos; option when
-                    saving your data. This is the easiest way to turn your spreadsheet into a CSV file.
+                    spreadsheet software (Microsoft Excel, Google Sheets etc.) will have a <b>.csv</b>, <b>.xlsx</b> or{' '}
+                    <b>.xls</b> option when saving your data. This is the easiest way to turn your spreadsheet into a
+                    CSV file.
                 </p>
             </div>
         </div>

--- a/tests/pages/__snapshots__/csvUpload.test.tsx.snap
+++ b/tests/pages/__snapshots__/csvUpload.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`pages csvUpload should render correctly 1`] = `
                     className="govuk-label govuk-radios__label"
                     htmlFor="csv-upload"
                   >
-                    Upload (.csv)
+                    Upload a fares triangle (CSV)
                   </label>
                 </div>
                 <div
@@ -77,7 +77,7 @@ exports[`pages csvUpload should render correctly 1`] = `
                     className="govuk-label govuk-radios__label"
                     htmlFor="manual-entry"
                   >
-                    Manual Fares Triangle input
+                    Manual fares triangle input
                   </label>
                 </div>
                 <div
@@ -122,7 +122,20 @@ exports[`pages csvUpload should render correctly 1`] = `
       <p
         className="govuk-body"
       >
-        CSV stands for Comma Separated Values. A CSV file is a popular format for publishing data on the web. They are plain text files which means they can contain numbers and letters only. Most spreadsheet software (Microsoft Excel, Google Sheets etc.) will have a '.csv' option when saving your data. This is the easiest way to turn your spreadsheet into a CSV file.
+        CSV stands for Comma Separated Values. A CSV file is a popular format for publishing data on the web. They are plain text files which means they can contain numbers and letters only. Most spreadsheet software (Microsoft Excel, Google Sheets etc.) will have a 
+        <b>
+          .csv
+        </b>
+        , 
+        <b>
+          .xlsx
+        </b>
+         or
+         
+        <b>
+          .xls
+        </b>
+         option when saving your data. This is the easiest way to turn your spreadsheet into a CSV file.
       </p>
     </div>
   </div>

--- a/tests/pages/__snapshots__/csvZoneUpload.test.tsx.snap
+++ b/tests/pages/__snapshots__/csvZoneUpload.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`pages csvzoneupload should render correctly 1`] = `
     detailBody={
       <React.Fragment>
         <p>
-          Some common issues with CSV uploads include:
+          Some common issues with fare zone uploads include:
         </p>
         <ul
           className="govuk-list govuk-list--bullet"
@@ -27,7 +27,7 @@ exports[`pages csvzoneupload should render correctly 1`] = `
           </li>
         </ul>
         <p>
-          Use the help file document for a more detailed help on constructing a fare zone CSV in the required format or download the CSV template to create a new file.
+          Use the help file document for a more detailed help on constructing a fare zone CSV in the required format or download the .csv template to create a new file.
         </p>
       </React.Fragment>
     }

--- a/tests/pages/__snapshots__/inputMethod.test.tsx.snap
+++ b/tests/pages/__snapshots__/inputMethod.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`pages inputMethod should render correctly 1`] = `
                     className="govuk-label govuk-radios__label"
                     htmlFor="csv-upload"
                   >
-                    Upload (.csv)
+                    Upload a fares triangle (CSV)
                   </label>
                 </div>
                 <div
@@ -77,7 +77,7 @@ exports[`pages inputMethod should render correctly 1`] = `
                     className="govuk-label govuk-radios__label"
                     htmlFor="manual-entry"
                   >
-                    Manual Fares Triangle input
+                    Manual fares triangle input
                   </label>
                 </div>
                 <div
@@ -122,7 +122,20 @@ exports[`pages inputMethod should render correctly 1`] = `
       <p
         className="govuk-body"
       >
-        CSV stands for Comma Separated Values. A CSV file is a popular format for publishing data on the web. They are plain text files which means they can contain numbers and letters only. Most spreadsheet software (Microsoft Excel, Google Sheets etc.) will have a '.csv' option when saving your data. This is the easiest way to turn your spreadsheet into a CSV file.
+        CSV stands for Comma Separated Values. A CSV file is a popular format for publishing data on the web. They are plain text files which means they can contain numbers and letters only. Most spreadsheet software (Microsoft Excel, Google Sheets etc.) will have a 
+        <b>
+          .csv
+        </b>
+        , 
+        <b>
+          .xlsx
+        </b>
+         or
+         
+        <b>
+          .xls
+        </b>
+         option when saving your data. This is the easiest way to turn your spreadsheet into a CSV file.
       </p>
     </div>
   </div>

--- a/tests/pages/api/csvUpload.test.ts
+++ b/tests/pages/api/csvUpload.test.ts
@@ -138,7 +138,9 @@ describe('csvUpload', () => {
     });
 
     it('should return 302 redirect to /csvUpload with an error message when the attached file is not a csv', async () => {
-        const mockError: ErrorInfo[] = [{ id: 'csv-upload', errorMessage: 'The selected file must be a CSV' }];
+        const mockError: ErrorInfo[] = [
+            { id: 'csv-upload', errorMessage: 'The selected file must be a .csv or .xlsx' },
+        ];
         const { req, res } = getMockRequestAndResponse({
             cookieValues: {},
             body: null,

--- a/tests/pages/api/csvZoneUpload.test.ts
+++ b/tests/pages/api/csvZoneUpload.test.ts
@@ -309,7 +309,7 @@ describe('csvZoneUpload', () => {
             expect(updateSessionAttributeSpy).toBeCalledWith(req, FARE_ZONE_ATTRIBUTE, {
                 errors: [
                     {
-                        errorMessage: 'The selected file must be a CSV',
+                        errorMessage: 'The selected file must be a .csv or .xlsx',
                         id: 'csv-upload',
                     },
                 ],


### PR DESCRIPTION
# Description

-   As per title, to allow users to upload MS excel created CSV files (xls and xlsx).

# Testing instructions

-   Use site, and upload xls or xlsx file.

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [ ] Able to run pr locally
-   [ ] Followed acceptance criteria
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
