### PR TITLE
feat: Refactored page structure on how SOPs are displayed

### DIFF
--- a/src/pages/api/describeSalesOfferPackage.ts
+++ b/src/pages/api/describeSalesOfferPackage.ts
@@ -31,7 +31,7 @@ export const sopInfoSchema = yup.object({
     description: yup
         .string()
         .min(0, noInputError('description'))
-        .max(50, inputTooLongError('description', 50))
+        .max(150, inputTooLongError('description', 150))
         .required(noInputError('description')),
 });
 

--- a/src/pages/selectSalesOfferPackage.tsx
+++ b/src/pages/selectSalesOfferPackage.tsx
@@ -65,13 +65,7 @@ export interface SelectSalesOfferPackageProps {
     csrfToken: string;
 }
 
-export const formatSOPArray = (stringArray: string[]): string => {
-    let stringToReturn = '';
-    stringArray.forEach(string => {
-        stringToReturn = `${stringToReturn}${stringToReturn.length > 0 ? ',' : ''} ${startCase(string)}`;
-    });
-    return stringToReturn;
-};
+const formatSOPArray = (stringArray: string[]): string => stringArray.map(string => startCase(string)).join(', ');
 
 const generateCheckbox = (
     salesOfferPackagesList: SalesOfferPackage[],
@@ -80,10 +74,6 @@ const generateCheckbox = (
 ): ReactElement[] => {
     return salesOfferPackagesList.map((offer, index) => {
         const { name, description, purchaseLocations, paymentMethods, ticketFormats } = offer;
-        let modifiedDescription = description;
-        if (modifiedDescription.length > 200) {
-            modifiedDescription = `${description.substr(0, description.length - 10)}...`;
-        }
 
         const productNameIds = removeAllWhiteSpace(productName);
 
@@ -112,7 +102,7 @@ const generateCheckbox = (
                     defaultChecked={isSelectedOffer}
                 />
                 <label className="govuk-label govuk-checkboxes__label" htmlFor={`${productNameIds}-checkbox-${index}`}>
-                    <b>{name}</b> {description.length > 0 ? '-' : ''} {modifiedDescription}
+                    <b>{name}</b> {description.length > 0 ? '-' : ''} {description}
                 </label>
                 <span className="govuk-hint govuk-!-margin-left-3" id="sales-offer-package-hint">
                     Purchase locations: {formatSOPArray(purchaseLocations)}

--- a/src/pages/selectSalesOfferPackage.tsx
+++ b/src/pages/selectSalesOfferPackage.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import startCase from 'lodash/startCase';
 import { isSalesOfferPackageWithErrors, isFareType } from '../interfaces/typeGuards';
 import ErrorSummary from '../components/ErrorSummary';
 import FormElementWrapper, { FormGroupWrapper } from '../components/FormElementWrapper';
@@ -25,7 +26,7 @@ const pageDescription = 'Sales Offer Package selection page of the Create Fares 
 
 export const defaultSalesOfferPackageOne: SalesOfferPackage = {
     name: 'Onboard (cash)',
-    description: 'Purchasable on board the bus, with cash, as a paper ticket.',
+    description: '',
     purchaseLocations: ['onBoard'],
     paymentMethods: ['cash'],
     ticketFormats: ['paperTicket'],
@@ -33,7 +34,7 @@ export const defaultSalesOfferPackageOne: SalesOfferPackage = {
 
 export const defaultSalesOfferPackageTwo: SalesOfferPackage = {
     name: 'Onboard (contactless)',
-    description: 'Purchasable on board the bus, with a contactless card or device, as a paper ticket.',
+    description: '',
     purchaseLocations: ['onBoard'],
     paymentMethods: ['contactlessPaymentCard'],
     ticketFormats: ['paperTicket'],
@@ -41,8 +42,7 @@ export const defaultSalesOfferPackageTwo: SalesOfferPackage = {
 
 export const defaultSalesOfferPackageThree: SalesOfferPackage = {
     name: 'Online (smart card)',
-    description:
-        'Purchasable online, with a debit/credit card or direct debit transaction, on a smart card or similar.',
+    description: '',
     purchaseLocations: ['online'],
     paymentMethods: ['directDebit', 'creditCard', 'debitCard'],
     ticketFormats: ['smartCard'],
@@ -50,8 +50,7 @@ export const defaultSalesOfferPackageThree: SalesOfferPackage = {
 
 export const defaultSalesOfferPackageFour: SalesOfferPackage = {
     name: 'Mobile App',
-    description:
-        'Purchasable on a mobile device application, with a debit/credit card or direct debit transaction, stored on the mobile application.',
+    description: '',
     purchaseLocations: ['mobileDevice'],
     paymentMethods: ['debitCard', 'creditCard', 'mobilePhone', 'directDebit'],
     ticketFormats: ['mobileApp'],
@@ -66,17 +65,24 @@ export interface SelectSalesOfferPackageProps {
     csrfToken: string;
 }
 
+export const formatSOPArray = (stringArray: string[]): string => {
+    let stringToReturn = '';
+    stringArray.forEach(string => {
+        stringToReturn = `${stringToReturn}${stringToReturn.length > 0 ? ',' : ''} ${startCase(string)}`;
+    });
+    return stringToReturn;
+};
+
 const generateCheckbox = (
     salesOfferPackagesList: SalesOfferPackage[],
     productName: string,
     selected?: { [key: string]: string[] },
 ): ReactElement[] => {
     return salesOfferPackagesList.map((offer, index) => {
-        const { name, description } = offer;
-        let checkboxTitles = `${name} - ${description}`;
-
-        if (checkboxTitles.length > 200) {
-            checkboxTitles = `${checkboxTitles.substr(0, checkboxTitles.length - 10)}...`;
+        const { name, description, purchaseLocations, paymentMethods, ticketFormats } = offer;
+        let modifiedDescription = description;
+        if (modifiedDescription.length > 200) {
+            modifiedDescription = `${description.substr(0, description.length - 10)}...`;
         }
 
         const productNameIds = removeAllWhiteSpace(productName);
@@ -106,8 +112,17 @@ const generateCheckbox = (
                     defaultChecked={isSelectedOffer}
                 />
                 <label className="govuk-label govuk-checkboxes__label" htmlFor={`${productNameIds}-checkbox-${index}`}>
-                    {checkboxTitles}
+                    <b>{name}</b> {description.length > 0 ? '-' : ''} {modifiedDescription}
                 </label>
+                <span className="govuk-hint govuk-!-margin-left-3" id="sales-offer-package-hint">
+                    Purchase locations: {formatSOPArray(purchaseLocations)}
+                </span>
+                <span className="govuk-hint govuk-!-margin-left-3" id="sales-offer-package-hint">
+                    Payment methods: {formatSOPArray(paymentMethods)}
+                </span>
+                <span className="govuk-hint govuk-!-margin-left-3" id="sales-offer-package-hint">
+                    Ticket formats: {formatSOPArray(ticketFormats)}
+                </span>
             </div>
         );
     });


### PR DESCRIPTION
# Description

-   To change the select SOP page so that the contents of the SOP can be seen, meaning the user can choose a description which means something to them, instead of just the contents.

# Testing instructions

-   Run site locally and use page

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [ ] Able to run pr locally
-   [ ] Followed acceptance criteria
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
