### PR TITLE
fix: scheme operators created netex page showing undefined

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -31,6 +31,7 @@ const unauthenticatedGetRoutes = [
     '/cookies',
     '/cookieDetails',
     '/accessibility',
+    '/privacy',
 ];
 
 const unauthenticatedPostRoutes = [

--- a/src/pages/createdFiles.tsx
+++ b/src/pages/createdFiles.tsx
@@ -25,8 +25,8 @@ interface CreateFilesProps {
     numberPerPage: number;
 }
 
-const buildName = (file: PointToPointTicket | PeriodTicket): string => {
-    let name = `${file.nocCode} - ${startCase(file.type)} - ${startCase(file.passengerType)}`;
+export const buildName = (file: PointToPointTicket | PeriodTicket): string => {
+    let name = `${file.nocCode ? `${file.nocCode} - ` : ''}${startCase(file.type)} - ${startCase(file.passengerType)}`;
 
     if (isPointToPointTicket(file)) {
         name += ` - Line ${file.lineName}`;

--- a/tests/pages/createdFiles.test.tsx
+++ b/tests/pages/createdFiles.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import CreatedFiles, { getServerSideProps } from '../../src/pages/createdFiles';
+import CreatedFiles, { getServerSideProps, buildName } from '../../src/pages/createdFiles';
 import { S3NetexFile } from '../../src/interfaces';
 import * as s3 from '../../src/data/s3';
 import { getMockContext, expectedSingleTicket } from '../testData/mockData';
@@ -94,6 +94,47 @@ describe('pages', () => {
                 <CreatedFiles files={netexFiles} numberOfResults={2} currentPage={1} numberPerPage={5} />,
             );
             expect(tree.find('Pagination')).toHaveLength(0);
+        });
+
+        describe('buildName', () => {
+            it('includes the NOC if its there', () => {
+                const file = {
+                    operatorName: '',
+                    products: [],
+                    nocCode: 'NOC',
+                    type: 'Single',
+                    passengerType: 'Child',
+                    email: '',
+                    uuid: '',
+                    timeRestriction: [],
+                    ticketPeriod: {
+                        startDate: '',
+                        endDate: '',
+                    },
+                    zoneName: 'The Test Zone',
+                    stops: [],
+                };
+                expect(buildName(file)).toBe('NOC - Single - Child - The Test Zone');
+            });
+            it('does not include the NOC if its not there', () => {
+                const file = {
+                    operatorName: '',
+                    products: [],
+                    nocCode: '',
+                    type: 'Single',
+                    passengerType: 'Child',
+                    email: '',
+                    uuid: '',
+                    timeRestriction: [],
+                    ticketPeriod: {
+                        startDate: '',
+                        endDate: '',
+                    },
+                    zoneName: 'The Test Zone',
+                    stops: [],
+                };
+                expect(buildName(file)).toBe('Single - Child - The Test Zone');
+            });
         });
 
         describe('getServerSideProps', () => {


### PR DESCRIPTION
# Description

-   Previously, scheme operators were seeing undefined as their created netex file names. They no longer show this.

# Testing instructions

-   Observe unit test which sets name.

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
