### PR TITLE
feat: removed undefined nocCode from createdFiles page

### DIFF
--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -128,7 +128,7 @@ export interface Stop {
 
 export interface S3NetexFile {
     name: string;
-    noc: string;
+    noc: string | undefined;
     reference: string;
     fareType: string;
     productNames?: string;

--- a/src/pages/createdFiles.tsx
+++ b/src/pages/createdFiles.tsx
@@ -149,9 +149,15 @@ const CreatedFiles = ({ files, numberOfResults, currentPage, numberPerPage }: Cr
                                 <span className="govuk-body govuk-!-font-weight-bold">Reference: </span>{' '}
                                 {file.reference}
                                 <br />
-                                <span className="govuk-body govuk-!-font-weight-bold">National Operator Code: </span>
-                                {file.noc}
-                                <br />
+                                {file.noc && (
+                                    <>
+                                        <span className="govuk-body govuk-!-font-weight-bold">
+                                            National Operator Code:{' '}
+                                        </span>
+                                        {file.noc}
+                                        <br />
+                                    </>
+                                )}
                                 <span className="govuk-body govuk-!-font-weight-bold">Fare Type: </span>{' '}
                                 {startCase(file.fareType)}
                                 <br />

--- a/tests/pages/__snapshots__/createdFiles.test.tsx.snap
+++ b/tests/pages/__snapshots__/createdFiles.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`pages createdFiles should render correctly 1`] = `
+exports[`pages createdFiles should render correctly for a classic operator 1`] = `
 <Component
   description="Created Files page for the Create Fares Data Service"
   title="Created Files - Create Fares Data Service"
@@ -58,7 +58,8 @@ exports[`pages createdFiles should render correctly 1`] = `
           <span
             className="govuk-body govuk-!-font-weight-bold"
           >
-            National Operator Code: 
+            National Operator Code:
+             
           </span>
           TEST
           <br />
@@ -150,9 +151,219 @@ exports[`pages createdFiles should render correctly 1`] = `
           <span
             className="govuk-body govuk-!-font-weight-bold"
           >
-            National Operator Code: 
+            National Operator Code:
+             
           </span>
           TEST2
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Fare Type: 
+          </span>
+           
+          Flat Fare
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Passenger Type: 
+          </span>
+           
+          Child
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Sales Offer Package(s): 
+          </span>
+          Test SOP Name 2
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Service(s): 
+          </span>
+           
+          1, 56, X02
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Product(s): 
+          </span>
+           
+          Product 1, Product 2
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Date of Creation: 
+          </span>
+           
+          Wed, 02 Sep 2020 14:46:58 GMT
+          <br />
+          <br />
+          <a
+            className="govuk-button"
+            download={true}
+            href="https://test.example.com/gfnhgddd"
+          >
+            Download - File Type XML - File Size 
+            456B
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <Pagination
+    currentPage={1}
+    link="/createdFiles"
+    numberOfResults={10}
+    numberPerPage={5}
+  />
+</Component>
+`;
+
+exports[`pages createdFiles should render correctly for a scheme operator 1`] = `
+<Component
+  description="Created Files page for the Create Fares Data Service"
+  title="Created Files - Create Fares Data Service"
+>
+  <h1
+    className="govuk-heading-l"
+  >
+    Previously created files
+  </h1>
+  <span
+    className="govuk-hint"
+    id="fare-type-operator-hint"
+  >
+    This page will show any NeTEx files created in the last 60 days
+  </span>
+  <div
+    className="govuk-accordion"
+    data-module="govuk-accordion"
+    id="accordion-default"
+  >
+    <div
+      className="govuk-accordion__section"
+      key="TEST12345Test Name"
+    >
+      <div
+        className="govuk-accordion__section-header"
+      >
+        <h2
+          className="govuk-accordion__section-heading"
+        >
+          <span
+            className="govuk-accordion__section-button"
+            id="accordion-default-heading-0"
+          >
+            Test Name
+          </span>
+        </h2>
+      </div>
+      <div
+        aria-labelledby="accordion-default-heading-0"
+        className="govuk-accordion__section-content"
+        id="accordion-default-content-0"
+      >
+        <div
+          className="govuk-body"
+        >
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Reference: 
+          </span>
+           
+          TEST12345
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Fare Type: 
+          </span>
+           
+          Single
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Passenger Type: 
+          </span>
+           
+          Adult
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Sales Offer Package(s): 
+          </span>
+          Test SOP Name, Test SOP Name 2
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Line Name: 
+          </span>
+           
+          X01
+          <br />
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Date of Creation: 
+          </span>
+           
+          Tue, 01 Sep 2020 14:46:58 GMT
+          <br />
+          <br />
+          <a
+            className="govuk-button"
+            download={true}
+            href="https://test.example.com/dscsdcd"
+          >
+            Download - File Type XML - File Size 
+            123B
+          </a>
+        </div>
+      </div>
+    </div>
+    <div
+      className="govuk-accordion__section"
+      key="TEST54321Test Name 2"
+    >
+      <div
+        className="govuk-accordion__section-header"
+      >
+        <h2
+          className="govuk-accordion__section-heading"
+        >
+          <span
+            className="govuk-accordion__section-button"
+            id="accordion-default-heading-1"
+          >
+            Test Name 2
+          </span>
+        </h2>
+      </div>
+      <div
+        aria-labelledby="accordion-default-heading-1"
+        className="govuk-accordion__section-content"
+        id="accordion-default-content-1"
+      >
+        <div
+          className="govuk-body"
+        >
+          <span
+            className="govuk-body govuk-!-font-weight-bold"
+          >
+            Reference: 
+          </span>
+           
+          TEST54321
           <br />
           <span
             className="govuk-body govuk-!-font-weight-bold"

--- a/tests/pages/createdFiles.test.tsx
+++ b/tests/pages/createdFiles.test.tsx
@@ -7,7 +7,7 @@ import { getMockContext, expectedSingleTicket } from '../testData/mockData';
 
 jest.mock('../../src/data/s3.ts');
 
-const netexFiles: S3NetexFile[] = [
+const classicOperatorNetexFiles: S3NetexFile[] = [
     {
         name: 'Test Name',
         fareType: 'single',
@@ -24,6 +24,34 @@ const netexFiles: S3NetexFile[] = [
         name: 'Test Name 2',
         fareType: 'flatFare',
         noc: 'TEST2',
+        passengerType: 'child',
+        reference: 'TEST54321',
+        date: 'Wed, 02 Sep 2020 14:46:58 GMT',
+        signedUrl: 'https://test.example.com/gfnhgddd',
+        sopNames: 'Test SOP Name 2',
+        serviceNames: '1, 56, X02',
+        productNames: 'Product 1, Product 2',
+        fileSize: 456,
+    },
+];
+
+const schemeOperatorNetexFiles: S3NetexFile[] = [
+    {
+        name: 'Test Name',
+        fareType: 'single',
+        noc: undefined,
+        passengerType: 'adult',
+        reference: 'TEST12345',
+        date: 'Tue, 01 Sep 2020 14:46:58 GMT',
+        signedUrl: 'https://test.example.com/dscsdcd',
+        sopNames: 'Test SOP Name, Test SOP Name 2',
+        lineName: 'X01',
+        fileSize: 123,
+    },
+    {
+        name: 'Test Name 2',
+        fareType: 'flatFare',
+        noc: undefined,
         passengerType: 'child',
         reference: 'TEST54321',
         date: 'Wed, 02 Sep 2020 14:46:58 GMT',
@@ -75,23 +103,50 @@ describe('pages', () => {
             jest.resetAllMocks();
         });
 
-        it('should render correctly', () => {
+        it('should render correctly for a classic operator', () => {
             const tree = shallow(
-                <CreatedFiles files={netexFiles} numberOfResults={10} currentPage={1} numberPerPage={5} />,
+                <CreatedFiles
+                    files={classicOperatorNetexFiles}
+                    numberOfResults={10}
+                    currentPage={1}
+                    numberPerPage={5}
+                />,
+            );
+            expect(tree).toMatchSnapshot();
+        });
+
+        it('should render correctly for a scheme operator', () => {
+            const tree = shallow(
+                <CreatedFiles
+                    files={schemeOperatorNetexFiles}
+                    numberOfResults={10}
+                    currentPage={1}
+                    numberPerPage={5}
+                />,
             );
             expect(tree).toMatchSnapshot();
         });
 
         it('should render pagination if number of results more than number per page', () => {
             const tree = shallow(
-                <CreatedFiles files={netexFiles} numberOfResults={10} currentPage={1} numberPerPage={5} />,
+                <CreatedFiles
+                    files={classicOperatorNetexFiles}
+                    numberOfResults={10}
+                    currentPage={1}
+                    numberPerPage={5}
+                />,
             );
             expect(tree.find('Pagination')).toHaveLength(1);
         });
 
         it('should not render pagination if number of results less than number per page', () => {
             const tree = shallow(
-                <CreatedFiles files={netexFiles} numberOfResults={2} currentPage={1} numberPerPage={5} />,
+                <CreatedFiles
+                    files={classicOperatorNetexFiles}
+                    numberOfResults={2}
+                    currentPage={1}
+                    numberPerPage={5}
+                />,
             );
             expect(tree.find('Pagination')).toHaveLength(0);
         });


### PR DESCRIPTION
# Description

-   This PR removes a field from the createdFiles page that displays the user's NOC when the NOC doesn't exist (i.e. when the user is a scheme operator)

# Type of change

-   [ ] feat - A new feature
-   [X] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [X] Able to run pr locally
-   [X] Followed acceptance criteria
-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [X] I have added tests that prove my fix is effective or that my feature works
