### PR TITLE
fix: styling on static error page

### DIFF
--- a/error/error/index.html
+++ b/error/error/index.html
@@ -89,8 +89,8 @@
                             <li class="govuk-footer__inline-list-item">
                                 <a class="govuk-footer__link" href="/contact">Contact</a>
                             </li>
-                            <li className="govuk-footer__inline-list-item">
-                                <a className="govuk-footer__link" href="/accessibility">
+                            <li class="govuk-footer__inline-list-item">
+                                <a class="govuk-footer__link" href="/accessibility">
                                     Accessibility
                                 </a>
                             </li>    
@@ -99,8 +99,8 @@
                                     >Terms and conditions</a
                                 >
                             </li>
-                            <li className="govuk-footer__inline-list-item">
-                                <a className="govuk-footer__link" href="/privacy">
+                            <li class="govuk-footer__inline-list-item">
+                                <a class="govuk-footer__link" href="/privacy">
                                     Privacy
                                 </a>
                             </li>    


### PR DESCRIPTION
# Description

-   This PR fixes the styling on the static error page

# Testing instructions

-   Pull down this branch and run the site locally. Check the styling in the footer on `localhost:5555/error/index.html`.

# Type of change

-   [ ] feat - A new feature
-   [X] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [X] Able to run pr locally
-   [X] Followed acceptance criteria
-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
