### PR TITLE
fix: users will be told about incorrect ATCO/NaPTAN codes immediately

### DIFF
--- a/src/data/auroradb.ts
+++ b/src/data/auroradb.ts
@@ -241,6 +241,9 @@ export const batchGetStopsByAtcoCode = async (atcoCodes: string[]): Promise<Stop
         `;
 
         const queryResults = await executeQuery<NaptanInfo[]>(batchQuery, atcoCodes);
+        if (queryResults.length !== atcoCodes.length) {
+            throw new Error('Not all ATCO codes returned stops, some must be invalid.');
+        }
 
         return queryResults.map(item => ({
             stopName: item.commonName,

--- a/tests/pages/api/csvZoneUpload.test.ts
+++ b/tests/pages/api/csvZoneUpload.test.ts
@@ -9,6 +9,7 @@ import * as dynamo from '../../../src/data/auroradb';
 import { FARE_ZONE_ATTRIBUTE, FARE_TYPE_ATTRIBUTE } from '../../../src/constants';
 
 const putStringInS3Spy = jest.spyOn(s3, 'putStringInS3');
+jest.mock('../../../src/data/auroradb');
 
 describe('csvZoneUpload', () => {
     const writeHeadMock = jest.fn();

--- a/tests/pages/returnDirection.test.tsx
+++ b/tests/pages/returnDirection.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { mount, shallow } from 'enzyme';
-
 import { getServiceByNocCodeAndLineName, batchGetStopsByAtcoCode } from '../../src/data/auroradb';
 import { getMockContext, mockRawService, mockRawServiceWithDuplicates, mockService } from '../testData/mockData';
 import ReturnDirection, { getServerSideProps } from '../../src/pages/returnDirection';


### PR DESCRIPTION
# Description

-   Users were getting through to the end of their journey before finding out their ATCO/NaPTAN codes were incorrect. This change means they are checked immediately, and renders and error message on the page if they are.

# Testing instructions

-   Run site locally and attempt to upload a 
# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
