### PR TITLE
Content/cfd 59 update format of direction dropdown

### DIFF
--- a/src/components/DirectionDropdown.tsx
+++ b/src/components/DirectionDropdown.tsx
@@ -56,7 +56,7 @@ const DirectionDropdown = ({
                                 value={`${journeyPattern.startPoint.Id}#${journeyPattern.endPoint.Id}`}
                                 className="journey-option"
                             >
-                                {journeyPattern.startPoint.Display} TO {journeyPattern.endPoint.Display}
+                                {journeyPattern.startPoint.Display} - {journeyPattern.endPoint.Display}
                             </option>
                         );
                     })}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -126,6 +126,11 @@ export interface Stop {
     street?: string;
 }
 
+export interface StopPoint {
+    stopPointRef: string;
+    commonName: string;
+}
+
 export interface S3NetexFile {
     name: string;
     noc: string | undefined;

--- a/src/utils/dataTransform.ts
+++ b/src/utils/dataTransform.ts
@@ -1,7 +1,7 @@
 import { Stop, StopPoint } from '../interfaces';
 import { batchGetStopsByAtcoCode, JourneyPattern, RawJourneyPattern, RawService } from '../data/auroradb';
 
-export const formatStopPoint = (stopPoint: StopPoint, stop: Stop): string =>
+export const formatStopPoint = (stop: Stop, stopPoint: StopPoint): string =>
     stop?.localityName ? `${stop.localityName} (${stopPoint.commonName})` : `${stopPoint.commonName}`;
 
 export const enrichJourneyPatternsWithNaptanInfo = async (
@@ -20,11 +20,11 @@ export const enrichJourneyPatternsWithNaptanInfo = async (
 
                 return {
                     startPoint: {
-                        Display: formatStopPoint(startPoint, startPointStop),
+                        Display: formatStopPoint(startPointStop, startPoint),
                         Id: startPoint.stopPointRef,
                     },
                     endPoint: {
-                        Display: formatStopPoint(endPoint, endPointStop),
+                        Display: formatStopPoint(endPointStop, endPoint),
                         Id: endPoint.stopPointRef,
                     },
                     stopList,

--- a/src/utils/dataTransform.ts
+++ b/src/utils/dataTransform.ts
@@ -1,4 +1,8 @@
+import { Stop, StopPoint } from '../interfaces';
 import { batchGetStopsByAtcoCode, JourneyPattern, RawJourneyPattern, RawService } from '../data/auroradb';
+
+export const formatStopPoint = (stopPoint: StopPoint, stop: Stop): string =>
+    stop?.localityName ? `${stop.localityName} (${stopPoint.commonName})` : `${stopPoint.commonName}`;
 
 export const enrichJourneyPatternsWithNaptanInfo = async (
     journeyPatterns: RawJourneyPattern[],
@@ -6,25 +10,21 @@ export const enrichJourneyPatternsWithNaptanInfo = async (
     Promise.all(
         journeyPatterns.map(
             async (item: RawJourneyPattern): Promise<JourneyPattern> => {
-                const stopList = item.orderedStopPoints.flatMap(stopPoint => stopPoint.stopPointRef);
+                const stopList = item.orderedStopPoints.flatMap((stopPoint: StopPoint) => stopPoint.stopPointRef);
 
-                const startPoint = item.orderedStopPoints[0];
-                const [startPointStopLocality] = await batchGetStopsByAtcoCode([startPoint.stopPointRef]);
+                const startPoint: StopPoint = item.orderedStopPoints[0];
+                const [startPointStop] = await batchGetStopsByAtcoCode([startPoint.stopPointRef]);
 
-                const endPoint = item.orderedStopPoints.slice(-1)[0];
-                const [endPointStopLocality] = await batchGetStopsByAtcoCode([endPoint.stopPointRef]);
+                const endPoint: StopPoint = item.orderedStopPoints.slice(-1)[0];
+                const [endPointStop] = await batchGetStopsByAtcoCode([endPoint.stopPointRef]);
 
                 return {
                     startPoint: {
-                        Display: `${startPoint.commonName}${
-                            startPointStopLocality?.localityName ? `, ${startPointStopLocality.localityName}` : ''
-                        }`,
+                        Display: formatStopPoint(startPoint, startPointStop),
                         Id: startPoint.stopPointRef,
                     },
                     endPoint: {
-                        Display: `${endPoint.commonName}${
-                            endPointStopLocality?.localityName ? `, ${endPointStopLocality.localityName}` : ''
-                        }`,
+                        Display: formatStopPoint(endPoint, endPointStop),
                         Id: endPoint.stopPointRef,
                     },
                     stopList,

--- a/tests/components/__snapshots__/DirectionDropDown.test.tsx.snap
+++ b/tests/components/__snapshots__/DirectionDropDown.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`DirectionDropdown should render the dropdown with options 1`] = `
         value="13003921A#13003655B"
       >
         Estate (Hail and Ride) N/B
-         TO 
+         - 
         Interchange Stand B
       </option>
       <option
@@ -40,7 +40,7 @@ exports[`DirectionDropdown should render the dropdown with options 1`] = `
         value="13003655B#13003921A"
       >
         Interchange Stand B
-         TO 
+         - 
         Estate (Hail and Ride) N/B
       </option>
     </select>

--- a/tests/pages/returnDirection.test.tsx
+++ b/tests/pages/returnDirection.test.tsx
@@ -51,8 +51,8 @@ describe('pages', () => {
             const serviceJourney = wrapper.find('.journey-option');
 
             expect(serviceJourney).toHaveLength(4);
-            expect(serviceJourney.first().text()).toBe('Estate (Hail and Ride) N/B TO Interchange Stand B');
-            expect(serviceJourney.at(1).text()).toBe('Interchange Stand B TO Estate (Hail and Ride) N/B');
+            expect(serviceJourney.first().text()).toBe('Estate (Hail and Ride) N/B - Interchange Stand B');
+            expect(serviceJourney.at(1).text()).toBe('Interchange Stand B - Estate (Hail and Ride) N/B');
         });
 
         describe('getServerSideProps', () => {

--- a/tests/pages/singleDirection.test.tsx
+++ b/tests/pages/singleDirection.test.tsx
@@ -60,8 +60,8 @@ describe('pages', () => {
             const serviceJourney = wrapper.find('.journey-option');
 
             expect(serviceJourney).toHaveLength(2);
-            expect(serviceJourney.first().text()).toBe('Estate (Hail and Ride) N/B TO Interchange Stand B');
-            expect(serviceJourney.at(1).text()).toBe('Interchange Stand B TO Estate (Hail and Ride) N/B');
+            expect(serviceJourney.first().text()).toBe('Estate (Hail and Ride) N/B - Interchange Stand B');
+            expect(serviceJourney.at(1).text()).toBe('Interchange Stand B - Estate (Hail and Ride) N/B');
         });
 
         describe('getServerSideProps', () => {

--- a/tests/utils/dataTransform.test.ts
+++ b/tests/utils/dataTransform.test.ts
@@ -4,14 +4,14 @@ import { Stop, StopPoint } from '../../src/interfaces';
 describe('dataTransform', () => {
     describe('formatStopPoint', () => {
         const stopPoint: StopPoint = {
-            stopPointRef: '13003921A',
-            commonName: 'Estate (Hail and Ride) N/B',
+            stopPointRef: '12345678A',
+            commonName: 'Test Stop',
         };
 
-        it('should format stop point with locality name and common name', () => {
-            const expected = 'Test Town (Estate (Hail and Ride) N/B)';
+        it('should format stop point with locality name and common name if both are provided', () => {
+            const expected = 'Test Town (Test Stop)';
             const allFieldsStop: Stop = {
-                stopName: 'Test Stop',
+                stopName: 'Stop 1',
                 naptanCode: '12345',
                 atcoCode: 'gvgvxgasvx',
                 localityCode: 'GHS167',
@@ -20,14 +20,14 @@ describe('dataTransform', () => {
                 street: 'Test Street',
                 parentLocalityName: 'Another town',
             };
-            const stopPointDisplay: string = formatStopPoint(stopPoint, allFieldsStop);
+            const stopPointDisplay: string = formatStopPoint(allFieldsStop, stopPoint);
             expect(stopPointDisplay).toEqual(expected);
         });
 
-        it('should format stop point with common name but no locality name', () => {
-            const expected = 'Estate (Hail and Ride) N/B';
+        it('should format stop point with common name only when locality name not provided', () => {
+            const expected = 'Test Stop';
             const noLocalityNameStop: Stop = {
-                stopName: 'Test Stop',
+                stopName: 'Stop 1',
                 naptanCode: '12345',
                 atcoCode: 'gvgvxgasvx',
                 localityCode: 'GHS167',
@@ -36,7 +36,7 @@ describe('dataTransform', () => {
                 street: 'Test Street',
                 parentLocalityName: 'Another town',
             };
-            const stopPointDisplay: string = formatStopPoint(stopPoint, noLocalityNameStop);
+            const stopPointDisplay: string = formatStopPoint(noLocalityNameStop, stopPoint);
             expect(stopPointDisplay).toEqual(expected);
         });
     });

--- a/tests/utils/dataTransform.test.ts
+++ b/tests/utils/dataTransform.test.ts
@@ -1,0 +1,43 @@
+import { formatStopPoint } from '../../src/utils/dataTransform';
+import { Stop, StopPoint } from '../../src/interfaces';
+
+describe('dataTransform', () => {
+    describe('formatStopPoint', () => {
+        const stopPoint: StopPoint = {
+            stopPointRef: '13003921A',
+            commonName: 'Estate (Hail and Ride) N/B',
+        };
+
+        it('should format stop point with locality name and common name', () => {
+            const expected = 'Test Town (Estate (Hail and Ride) N/B)';
+            const allFieldsStop: Stop = {
+                stopName: 'Test Stop',
+                naptanCode: '12345',
+                atcoCode: 'gvgvxgasvx',
+                localityCode: 'GHS167',
+                localityName: 'Test Town',
+                indicator: 'SE',
+                street: 'Test Street',
+                parentLocalityName: 'Another town',
+            };
+            const stopPointDisplay: string = formatStopPoint(stopPoint, allFieldsStop);
+            expect(stopPointDisplay).toEqual(expected);
+        });
+
+        it('should format stop point with common name but no locality name', () => {
+            const expected = 'Estate (Hail and Ride) N/B';
+            const noLocalityNameStop: Stop = {
+                stopName: 'Test Stop',
+                naptanCode: '12345',
+                atcoCode: 'gvgvxgasvx',
+                localityCode: 'GHS167',
+                localityName: '',
+                indicator: 'SE',
+                street: 'Test Street',
+                parentLocalityName: 'Another town',
+            };
+            const stopPointDisplay: string = formatStopPoint(stopPoint, noLocalityNameStop);
+            expect(stopPointDisplay).toEqual(expected);
+        });
+    });
+});

--- a/tests/utils/index.test.ts
+++ b/tests/utils/index.test.ts
@@ -10,7 +10,7 @@ import {
 import { Stop } from '../../src/data/auroradb';
 import { getMockContext, mockSchemOpIdToken } from '../testData/mockData';
 
-describe('utils', () => {
+describe('index', () => {
     describe('getHost', () => {
         it('should return http when host is localhost', () => {
             const expected = 'http://localhost';


### PR DESCRIPTION
# Description

- Refactors the Direction Dropdown such that it displays as follows:
`Locality Name (Common Name) - Locality Name (Common Name)`

- If locality name is not provided for a stop, just the common name should be displayed without brackets, e.g.:
`Common Name - Locality Name (Common Name)`

# Testing instructions

- Pull down this branch and run site locally
- Navigate to the `/singleDirection` and `/returnDirection` pages and confirm the dropdowns display correctly 

# Type of change

-   [ ] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [x] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
