### PR TITLE
fix: default checks added for different types of RadioConditionalInput

### DIFF
--- a/src/components/RadioConditionalInput.tsx
+++ b/src/components/RadioConditionalInput.tsx
@@ -310,6 +310,19 @@ const renderConditionalDateInputs = (radio: RadioWithConditionalInputs): ReactEl
     );
 };
 
+export const conditionalRadioInputDefaultExists = (radio: RadioWithConditionalInputs): boolean => {
+    if (radio.inputType === 'text' || radio.inputType === 'textWithUnits') {
+        return radio.inputs.some(input => input.defaultValue !== '');
+    }
+    if (radio.inputType === 'date') {
+        return radio.inputs.some(input => input.defaultValue !== '##');
+    }
+    if (radio.inputType === 'checkbox') {
+        return radio.inputs.some(input => input.defaultChecked);
+    }
+    return false;
+};
+
 const renderConditionalRadioButton = (
     radio: RadioWithConditionalInputs,
     radioLabel: ReactElement,
@@ -347,12 +360,7 @@ const renderConditionalRadioButton = (
     return (
         <div key={radio.id}>
             <div className="govuk-radios__item">
-                {radio.inputErrors.length > 0 ||
-                radio.inputs.some(
-                    input =>
-                        (input.defaultChecked === undefined && input.defaultValue !== '') ||
-                        (input.defaultValue === undefined && input.defaultChecked),
-                )
+                {radio.inputErrors.length > 0 || conditionalRadioInputDefaultExists(radio)
                     ? checkedRadioInput
                     : uncheckedRadioInput}
                 {radioLabel}

--- a/tests/components/RadioConditionalInput.test.tsx
+++ b/tests/components/RadioConditionalInput.test.tsx
@@ -235,36 +235,17 @@ describe('RadioConditionalInput', () => {
     });
 
     describe('conditionalRadioInputDefaultExists', () => {
-        it('should return true when text input has default value', () => {
-            expect(conditionalRadioInputDefaultExists(conditionalRadioWithTextInput)).toBeTruthy();
-        });
-
-        it('should return false when text input has no default value', () => {
-            expect(conditionalRadioInputDefaultExists(conditionalRadioWithEmptyTextInput)).toBeFalsy();
-        });
-
-        it('should return true when textWithUnits input has default value', () => {
-            expect(conditionalRadioInputDefaultExists(conditionalRadioWithTextWithUnitsInput)).toBeTruthy();
-        });
-
-        it('should return false when textWithUnits input has no default value', () => {
-            expect(conditionalRadioInputDefaultExists(conditionalRadioWithEmptyTextWithUnitsInput)).toBeFalsy();
-        });
-
-        it('should return true when date input has default value', () => {
-            expect(conditionalRadioInputDefaultExists(conditionalRadioWithDateInput)).toBeTruthy();
-        });
-
-        it('should return false when date input has no default value', () => {
-            expect(conditionalRadioInputDefaultExists(conditionalRadioWithEmptyDateInput)).toBeFalsy();
-        });
-
-        it('should return true when checkbox input is checked', () => {
-            expect(conditionalRadioInputDefaultExists(conditionalRadioWithCheckedCheckboxInput)).toBeTruthy();
-        });
-
-        it('should return false when checkbox input is unchecked', () => {
-            expect(conditionalRadioInputDefaultExists(conditionalRadioWithUncheckedCheckboxInput)).toBeFalsy();
+        it.each([
+            [true, 'text input has default value', conditionalRadioWithTextInput],
+            [false, 'text input has no default value', conditionalRadioWithEmptyTextInput],
+            [true, 'textWithUnits input has default value', conditionalRadioWithTextWithUnitsInput],
+            [false, 'textWithUnits input has no default value', conditionalRadioWithEmptyTextWithUnitsInput],
+            [true, 'date input has default value', conditionalRadioWithDateInput],
+            [false, 'date input has no default value', conditionalRadioWithEmptyDateInput],
+            [true, 'checkbox input is checked', conditionalRadioWithCheckedCheckboxInput],
+            [false, 'checkbox input is unchecked', conditionalRadioWithUncheckedCheckboxInput],
+        ])('should return %s when %s', (defaultExists, _case, conditionalRadioWithInput) => {
+            expect(conditionalRadioInputDefaultExists(conditionalRadioWithInput)).toBe(defaultExists);
         });
     });
 });

--- a/tests/components/RadioConditionalInput.test.tsx
+++ b/tests/components/RadioConditionalInput.test.tsx
@@ -1,11 +1,22 @@
 import { shallow } from 'enzyme';
 import React, { ReactElement } from 'react';
+import {
+    conditionalRadioWithCheckedCheckboxInput,
+    conditionalRadioWithDateInput,
+    conditionalRadioWithEmptyDateInput,
+    conditionalRadioWithEmptyTextInput,
+    conditionalRadioWithEmptyTextWithUnitsInput,
+    conditionalRadioWithTextInput,
+    conditionalRadioWithTextWithUnitsInput,
+    conditionalRadioWithUncheckedCheckboxInput,
+} from '../testData/mockData';
 import { ErrorInfo } from '../../src/interfaces';
 import RadioConditionalInput, {
     RadioConditionalInputFieldset,
     renderConditionalTextInput,
     RadioWithConditionalInputs,
     renderConditionalTextWithUnitsInput,
+    conditionalRadioInputDefaultExists,
 } from '../../src/components/RadioConditionalInput';
 
 describe('RadioConditionalInput', () => {
@@ -220,6 +231,40 @@ describe('RadioConditionalInput', () => {
             expect(selectInputFormGroup.props.className).toEqual('govuk-form-group govuk-form-group--error');
             expect(textInputFormElementWrapper.props.errors).toBe(inputErrors);
             expect(selectInputFormElementWrapper.props.errors).toBe(inputErrors);
+        });
+    });
+
+    describe('conditionalRadioInputDefaultExists', () => {
+        it('should return true when text input has default value', () => {
+            expect(conditionalRadioInputDefaultExists(conditionalRadioWithTextInput)).toBeTruthy();
+        });
+
+        it('should return false when text input has no default value', () => {
+            expect(conditionalRadioInputDefaultExists(conditionalRadioWithEmptyTextInput)).toBeFalsy();
+        });
+
+        it('should return true when textWithUnits input has default value', () => {
+            expect(conditionalRadioInputDefaultExists(conditionalRadioWithTextWithUnitsInput)).toBeTruthy();
+        });
+
+        it('should return false when textWithUnits input has no default value', () => {
+            expect(conditionalRadioInputDefaultExists(conditionalRadioWithEmptyTextWithUnitsInput)).toBeFalsy();
+        });
+
+        it('should return true when date input has default value', () => {
+            expect(conditionalRadioInputDefaultExists(conditionalRadioWithDateInput)).toBeTruthy();
+        });
+
+        it('should return false when date input has no default value', () => {
+            expect(conditionalRadioInputDefaultExists(conditionalRadioWithEmptyDateInput)).toBeFalsy();
+        });
+
+        it('should return true when checkbox input is checked', () => {
+            expect(conditionalRadioInputDefaultExists(conditionalRadioWithCheckedCheckboxInput)).toBeTruthy();
+        });
+
+        it('should return false when checkbox input is unchecked', () => {
+            expect(conditionalRadioInputDefaultExists(conditionalRadioWithUncheckedCheckboxInput)).toBeFalsy();
         });
     });
 });

--- a/tests/testData/mockData.ts
+++ b/tests/testData/mockData.ts
@@ -46,7 +46,7 @@ import { RawService, Service } from '../../src/data/auroradb';
 import { UserFareStages } from '../../src/data/s3';
 
 import { MultiProduct, MultiProductWithErrors } from '../../src/pages/api/multipleProducts';
-import { RadioConditionalInputFieldset } from '../../src/components/RadioConditionalInput';
+import { RadioConditionalInputFieldset, RadioWithConditionalInputs } from '../../src/components/RadioConditionalInput';
 
 import { MatchingFareZones } from '../../src/interfaces/matchingInterface';
 import { TextInputFieldset } from '../../src/pages/definePassengerType';
@@ -2314,6 +2314,170 @@ export const mockProductRadioErrors: ErrorInfo[] = [
     },
 ];
 
+export const conditionalRadioWithTextInput: RadioWithConditionalInputs = {
+    id: 'text-input',
+    name: 'textInput',
+    value: 'Yes',
+    label: 'Yes',
+    dataAriaControls: 'text-input-conditional',
+    inputHint: { id: 'text-input-hint', content: 'Hint.' },
+    inputType: 'text',
+    inputs: [
+        {
+            id: 'text',
+            name: 'text',
+            label: 'Text',
+            defaultValue: 'Default text',
+        },
+    ],
+    inputErrors: [],
+};
+
+export const conditionalRadioWithEmptyTextInput: RadioWithConditionalInputs = {
+    id: 'text-input',
+    name: 'textInput',
+    value: 'Yes',
+    label: 'Yes',
+    dataAriaControls: 'text-input-conditional',
+    inputHint: { id: 'text-input-hint', content: 'Hint.' },
+    inputType: 'text',
+    inputs: [
+        {
+            id: 'text',
+            name: 'text',
+            label: 'Text',
+            defaultValue: '',
+        },
+    ],
+    inputErrors: [],
+};
+
+export const conditionalRadioWithTextWithUnitsInput: RadioWithConditionalInputs = {
+    id: 'text-units-input',
+    name: 'textUnitsInput',
+    value: 'Yes',
+    label: 'Yes',
+    dataAriaControls: 'text-units-input-conditional',
+    inputHint: { id: 'text-units-input-hint', content: 'Hint.' },
+    inputType: 'textWithUnits',
+    inputs: [
+        {
+            id: 'text',
+            name: 'text',
+            label: 'Text',
+            defaultValue: '',
+        },
+        {
+            id: 'units',
+            name: 'units',
+            label: 'Units',
+            defaultValue: '10',
+        },
+    ],
+    inputErrors: [],
+};
+
+export const conditionalRadioWithEmptyTextWithUnitsInput: RadioWithConditionalInputs = {
+    id: 'text-units-input',
+    name: 'textUnitsInput',
+    value: 'Yes',
+    label: 'Yes',
+    dataAriaControls: 'text-units-input-conditional',
+    inputHint: { id: 'text-units-input-hint', content: 'Hint.' },
+    inputType: 'textWithUnits',
+    inputs: [
+        {
+            id: 'text',
+            name: 'text',
+            label: 'Text',
+            defaultValue: '',
+        },
+        {
+            id: 'units',
+            name: 'units',
+            label: 'Units',
+            defaultValue: '',
+        },
+    ],
+    inputErrors: [],
+};
+
+export const conditionalRadioWithDateInput: RadioWithConditionalInputs = {
+    id: 'date-input',
+    name: 'dateInput',
+    value: 'Yes',
+    label: 'Yes',
+    dataAriaControls: 'date-input-conditional',
+    inputHint: { id: 'date-input-hint', content: 'Hint.' },
+    inputType: 'date',
+    inputs: [
+        {
+            id: 'date',
+            name: 'date',
+            label: 'Date',
+            defaultValue: '12#12#2020',
+        },
+    ],
+    inputErrors: [],
+};
+
+export const conditionalRadioWithEmptyDateInput: RadioWithConditionalInputs = {
+    id: 'date-input',
+    name: 'dateInput',
+    value: 'Yes',
+    label: 'Yes',
+    dataAriaControls: 'date-input-conditional',
+    inputHint: { id: 'date-input-hint', content: 'Hint.' },
+    inputType: 'date',
+    inputs: [
+        {
+            id: 'date',
+            name: 'date',
+            label: 'Date',
+            defaultValue: '##',
+        },
+    ],
+    inputErrors: [],
+};
+
+export const conditionalRadioWithCheckedCheckboxInput: RadioWithConditionalInputs = {
+    id: 'checkbox-input',
+    name: 'checkboxInput',
+    value: 'Yes',
+    label: 'Yes',
+    dataAriaControls: 'checkbox-input-conditional',
+    inputHint: { id: 'checkbox-input-hint', content: 'Hint.' },
+    inputType: 'checkbox',
+    inputs: [
+        {
+            id: 'checkbox',
+            name: 'checkbox',
+            label: 'Checkbox',
+            defaultChecked: true,
+        },
+    ],
+    inputErrors: [],
+};
+
+export const conditionalRadioWithUncheckedCheckboxInput: RadioWithConditionalInputs = {
+    id: 'checkbox-input',
+    name: 'checkboxInput',
+    value: 'Yes',
+    label: 'Yes',
+    dataAriaControls: 'checkbox-input-conditional',
+    inputHint: { id: 'checkbox-input-hint', content: 'Hint.' },
+    inputType: 'checkbox',
+    inputs: [
+        {
+            id: 'checkbox',
+            name: 'checkbox',
+            label: 'Checkbox',
+            defaultChecked: false,
+        },
+    ],
+    inputErrors: [],
+};
+
 export const mockProductDateInformationFieldsets: RadioConditionalInputFieldset = {
     heading: {
         id: 'product-dates-information',
@@ -2457,6 +2621,7 @@ export const mockProductDateInformationFieldsetsWithErrors: RadioConditionalInpu
         },
     ],
 };
+
 export const mockPeriodValidityFieldset: RadioConditionalInputFieldset = {
     heading: {
         id: 'period-validity',


### PR DESCRIPTION
# Description

-   Adds input-type-specific checks for whether a default input value exists for conditional radio inputs. This now catches the case where a date input has no default, and therefore has a value of '##'.

# Testing instructions

-   Pull down this branch and navigate through the flat fare journey, up to the `/productDateInformation` page. Check that the conditional radio input is not expanded by default.

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
