### PR TITLE
feat: warn users about lack of TNDS during registration

### DIFF
--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -82,10 +82,6 @@ export type WithErrors<T> = {
 
 // Miscellaneous
 
-export interface TndsCheckResult {
-    nocsWithNoTnds: string[];
-}
-
 export type PassengerAttributes = {
     passengerTypeDisplay: string;
     passengerTypeValue: string;

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -82,6 +82,10 @@ export type WithErrors<T> = {
 
 // Miscellaneous
 
+export interface TndsCheckResult {
+    nocsWithNoTnds: string[];
+}
+
 export type PassengerAttributes = {
     passengerTypeDisplay: string;
     passengerTypeValue: string;

--- a/src/pages/api/register.ts
+++ b/src/pages/api/register.ts
@@ -74,19 +74,7 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
                 const nocsWithNoTnds = await operatorHasTndsData(cognitoNocs);
 
                 if (!(nocsWithNoTnds.length < cognitoNocs.length)) {
-                    const lengthCheck = cognitoNocs.length > 0;
-                    inputChecks.push({
-                        userInput: '',
-                        id: '',
-                        errorMessage: `There is no service data available for your National Operator Code${
-                            lengthCheck ? 's' : ''
-                        } (NOC).
-                            This service utilises the Traveline National Dataset (TNDS) to obtain operators' service data in order to help them create fares data. It appears there is no service data for your NOC${
-                                lengthCheck ? 's' : ''
-                            } in the Traveline National Dataset. You will not be able to continue creating fares data without this.
-                            Use the contact link in the footer if you have any questions.`,
-                    });
-                    setErrorsCookieAndRedirect(inputChecks, regKey);
+                    redirectTo(res, '/noServices');
                     return;
                 }
 

--- a/src/pages/confirmRegistration.tsx
+++ b/src/pages/confirmRegistration.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
-import { NextPage, NextPageContext } from 'next';
+import { NextPageContext } from 'next';
+import isArray from 'lodash/isArray';
 import TwoThirdsLayout from '../layout/Layout';
 import { deleteCookieOnServerSide } from '../utils';
 import { USER_COOKIE } from '../constants';
@@ -7,9 +8,31 @@ import { USER_COOKIE } from '../constants';
 const title = 'Registration Successful - Create Fares Data Service';
 const description = 'Confirm Registration page for the Create Fares Data Service';
 
-const ConfirmRegistration: NextPage = (): ReactElement => (
+interface ConfirmRegistrationProps {
+    tndslessNocs: string[];
+}
+
+const ConfirmRegistration = ({ tndslessNocs }: ConfirmRegistrationProps): ReactElement => (
     <TwoThirdsLayout title={title} description={description}>
         <h1 className="govuk-heading-l">Your account has been successfully created</h1>
+        {tndslessNocs.length > 0 && (
+            <>
+                <p className="govuk-body-m">
+                    This service utilises the Traveline National Dataset (TNDS) to obtain operators&apos; service data
+                    in order to help them create fares data.
+                </p>
+                <p className="govuk-body-m">
+                    The following National Operator Codes have no service data in TNDS and so cannot be used to create
+                    NeTex:
+                </p>
+                <p className="govuk-body-m">
+                    <b>{tndslessNocs.join(',')}</b>
+                </p>
+                <p className="govuk-body-m">
+                    <a href="/contact">Contact</a> us if you have further questions.
+                </p>
+            </>
+        )}
         <p className="govuk-body-l">Click continue to go to the homepage.</p>
         <a
             href="/"
@@ -24,9 +47,18 @@ const ConfirmRegistration: NextPage = (): ReactElement => (
     </TwoThirdsLayout>
 );
 
-export const getServerSideProps = (ctx: NextPageContext): {} => {
+export const getServerSideProps = (ctx: NextPageContext): { props: ConfirmRegistrationProps } => {
     deleteCookieOnServerSide(ctx, USER_COOKIE);
-    return { props: {} };
+    const { nocs } = ctx.query;
+    let nocsToDisplay: string[] = [];
+    if (nocs && !isArray(nocs)) {
+        nocsToDisplay = nocsToDisplay.concat(nocs.split('|'));
+    }
+    return {
+        props: {
+            tndslessNocs: nocsToDisplay,
+        },
+    };
 };
 
 export default ConfirmRegistration;

--- a/tests/pages/__snapshots__/confirmRegistration.test.tsx.snap
+++ b/tests/pages/__snapshots__/confirmRegistration.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`pages confirmRegistration should render correctly 1`] = `
+exports[`pages confirmRegistration should render correctly with no tndsless nocs 1`] = `
 <Component
   description="Confirm Registration page for the Create Fares Data Service"
   title="Registration Successful - Create Fares Data Service"
@@ -10,6 +10,61 @@ exports[`pages confirmRegistration should render correctly 1`] = `
   >
     Your account has been successfully created
   </h1>
+  <p
+    className="govuk-body-l"
+  >
+    Click continue to go to the homepage.
+  </p>
+  <a
+    className="govuk-button"
+    data-module="govuk-button"
+    draggable="false"
+    href="/"
+    id="continue-button"
+    role="button"
+  >
+    Continue
+  </a>
+</Component>
+`;
+
+exports[`pages confirmRegistration should render correctly with tndsless nocs 1`] = `
+<Component
+  description="Confirm Registration page for the Create Fares Data Service"
+  title="Registration Successful - Create Fares Data Service"
+>
+  <h1
+    className="govuk-heading-l"
+  >
+    Your account has been successfully created
+  </h1>
+  <p
+    className="govuk-body-m"
+  >
+    This service utilises the Traveline National Dataset (TNDS) to obtain operators' service data in order to help them create fares data.
+  </p>
+  <p
+    className="govuk-body-m"
+  >
+    The following National Operator Codes have no service data in TNDS and so cannot be used to create NeTex:
+  </p>
+  <p
+    className="govuk-body-m"
+  >
+    <b>
+      AAAA,ZZZZ
+    </b>
+  </p>
+  <p
+    className="govuk-body-m"
+  >
+    <a
+      href="/contact"
+    >
+      Contact
+    </a>
+     us if you have further questions.
+  </p>
   <p
     className="govuk-body-l"
   >

--- a/tests/pages/api/register.test.ts
+++ b/tests/pages/api/register.test.ts
@@ -5,6 +5,7 @@ import * as auroradb from '../../../src/data/auroradb';
 import { getMockRequestAndResponse } from '../../testData/mockData';
 import * as apiUtils from '../../../src/pages/api/apiUtils';
 import { USER_COOKIE } from '../../../src/constants';
+import { getServicesByNocCode } from '../../../src/data/auroradb';
 
 jest.mock('../../../src/data/auroradb.ts');
 
@@ -181,6 +182,28 @@ describe('register', () => {
         expect(authSignOutSpy).toHaveBeenCalled();
         expect(writeHeadMock).toBeCalledWith(302, {
             Location: '/confirmRegistration',
+        });
+    });
+
+    it('should redirect when there are no services for the noc code', async () => {
+        (getServicesByNocCode as jest.Mock).mockImplementation(() => []);
+
+        const { req, res } = getMockRequestAndResponse({
+            cookieValues: {},
+            body: {
+                email: 'test@test.com',
+                password: 'chromosoneTelepathyDinosaur',
+                confirmPassword: 'chromosoneTelepathyDinosaur',
+                regKey: 'abcdefg',
+            },
+            uuid: '',
+            mockWriteHeadFn: writeHeadMock,
+        });
+
+        await register(req, res);
+
+        expect(writeHeadMock).toBeCalledWith(302, {
+            Location: '/noServices',
         });
     });
 

--- a/tests/pages/api/register.test.ts
+++ b/tests/pages/api/register.test.ts
@@ -292,8 +292,8 @@ describe('operatorHasTndsData', () => {
     it('returns the correct noc codes if all noc codes have no TNDS data', async () => {
         getServicesByNocCodeSpy.mockImplementation(() => Promise.resolve([]));
         const result = await operatorHasTndsData(['AAA', 'BBB']);
-        expect(result.nocsWithNoTnds.length).toBe(2);
-        expect(result.nocsWithNoTnds).toStrictEqual(['AAA', 'BBB']);
+        expect(result.length).toBe(2);
+        expect(result).toStrictEqual(['AAA', 'BBB']);
     });
 
     it('returns the correct noc codes if some noc codes have no TNDS data', async () => {
@@ -310,8 +310,8 @@ describe('operatorHasTndsData', () => {
             )
             .mockImplementationOnce(() => Promise.resolve([]));
         const result = await operatorHasTndsData(['AAA', 'BBB']);
-        expect(result.nocsWithNoTnds.length).toBe(1);
-        expect(result.nocsWithNoTnds).toStrictEqual(['BBB']);
+        expect(result.length).toBe(1);
+        expect(result).toStrictEqual(['BBB']);
     });
 
     it('returns a result with true if noc codes have TNDS data', async () => {
@@ -337,7 +337,7 @@ describe('operatorHasTndsData', () => {
                 ]),
             );
         const result = await operatorHasTndsData(['AAA', 'BBB']);
-        expect(result.nocsWithNoTnds.length).toBe(0);
-        expect(result.nocsWithNoTnds).toStrictEqual([]);
+        expect(result.length).toBe(0);
+        expect(result).toStrictEqual([]);
     });
 });

--- a/tests/pages/confirmRegistration.test.tsx
+++ b/tests/pages/confirmRegistration.test.tsx
@@ -4,8 +4,12 @@ import ConfirmRegistration from '../../src/pages/confirmRegistration';
 
 describe('pages', () => {
     describe('confirmRegistration', () => {
-        it('should render correctly', () => {
-            const tree = shallow(<ConfirmRegistration />);
+        it('should render correctly with no tndsless nocs', () => {
+            const tree = shallow(<ConfirmRegistration tndslessNocs={[]} />);
+            expect(tree).toMatchSnapshot();
+        });
+        it('should render correctly with tndsless nocs', () => {
+            const tree = shallow(<ConfirmRegistration tndslessNocs={['AAAA', 'ZZZZ']} />);
             expect(tree).toMatchSnapshot();
         });
     });


### PR DESCRIPTION
# Description

-   To warn users when they register if they do not have TNDS data set for their NOC codes.

# Testing instructions

-   Run site locally and create new user, copy the register link after the / and paste it after localhost:555 (e.g. http://localhost:5555/register?key=TrMrsuNosJJTWPL6) and fill out reg form. Main scenarios are with a NOC code that has TNDS (e.g. WBTR), with a NOC code which has no TNDS (e.g AAAAAAA), and with a multi-NOC code (e.g. WBTR|AAAAAA).

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
