### PR TITLE
Use papaparse skipEmtyLines to remove empty lines

### DIFF
--- a/src/pages/api/csvUpload.ts
+++ b/src/pages/api/csvUpload.ts
@@ -63,7 +63,7 @@ export const faresTriangleDataMapper = (
         fareStages: [],
     };
 
-    const fareStageLines = (Papa.parse(dataToMap).data as string[][]).filter(item => item.length > 1);
+    const fareStageLines = Papa.parse(dataToMap, { skipEmptyLines: 'greedy' }).data as string[][];
     const fareStageCount = fareStageLines.length;
 
     if (fareStageCount < 2) {

--- a/tests/testData/csvFareTriangleData.ts
+++ b/tests/testData/csvFareTriangleData.ts
@@ -26,7 +26,8 @@ export const validTestCsvWithEmptyCellsAndEmptyLine: string =
     '170,170,110,110,Cambridge Street (York),,,\n' +
     '170,170,110,110,100,"Blossom Street, test",,\n' +
     '170,170,170,170,100,100,Rail Station (York),\n' +
-    ' ,170,170,170,100,100,100, Piccadilly (York)\n';
+    ' ,170,170,170,100,100,100, Piccadilly (York)\n' +
+    ',,,,,,,\n';
 
 export const noPricesTestCsv: string =
     'Acomb Green Lane,,,,,,,\n' +
@@ -139,7 +140,8 @@ export const unprocessedObjectWithEmptyCells = {
         '170,170,110,110,Cambridge Street (York),,,\n' +
         '170,170,110,110,100,"Blossom Street, test",,\n' +
         '170,170,170,170,100,100,Rail Station (York),\n' +
-        ' ,170,170,170,100,100,100, Piccadilly (York)\n',
+        ' ,170,170,170,100,100,100, Piccadilly (York)\n' +
+        ',,,,,,,\n',
     ContentType: 'text/csv; charset=utf-8',
 };
 


### PR DESCRIPTION
# Description

-   Use papaparse skipEmtyLines to remove empty lines

# Testing instructions

-   Upload various csv and excel files to make sure they are all working as intended, with or without empty lines at the end of the file

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [ ] Able to run pr locally
-   [ ] Followed acceptance criteria
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
