### PR TITLE
feat: Created new static page for no services

### DIFF
--- a/src/pages/noServices.tsx
+++ b/src/pages/noServices.tsx
@@ -1,0 +1,40 @@
+import React, { ReactElement } from 'react';
+import TwoThirdsLayout from '../layout/Layout';
+
+const title = 'No Services - Create Fares Data Service';
+const description = 'No Services error page of the Create Fares Data Service';
+
+const NoServices = (): ReactElement => (
+    <TwoThirdsLayout title={title} description={description}>
+        <h1 className="govuk-heading-l">
+            Sorry, there is no service data available for your National Operator Code (NOC)
+        </h1>
+        <p className="govuk-body-m">
+            This service utilises the Traveline National Dataset (TNDS) to obtain operators&apos; service data in order
+            to help them create fares data.
+        </p>
+        <p className="govuk-body-m">
+            It appears there is no service data for this operator in the Traveline National Dataset.
+        </p>
+        <p className="govuk-body-m">You will not be able to continue creating fares data without this.</p>
+        <p className="govuk-body-m">
+            <a href="/contact">Contact</a> us if you have further questions.
+        </p>
+        <a
+            href="/home"
+            role="button"
+            draggable="false"
+            className="govuk-button"
+            data-module="govuk-button"
+            id="home-button"
+        >
+            Home
+        </a>
+    </TwoThirdsLayout>
+);
+
+export const getServerSideProps = (): {} => {
+    return { props: {} };
+};
+
+export default NoServices;

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -86,12 +86,9 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     }
 
     const { name } = JSON.parse(operatorCookie);
-
     const services = await getServicesByNocCode(nocCode);
 
-    const emptyservices = [];
-
-    if (emptyservices.length === 0) {
+    if (services.length === 0) {
         if (ctx.res) {
             redirectTo(ctx.res, '/noServices');
         } else {

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -11,6 +11,7 @@ import { getAndValidateNoc, getCsrfToken } from '../utils';
 import CsrfForm from '../components/CsrfForm';
 import { isPassengerType, isServiceAttributeWithErrors } from '../interfaces/typeGuards';
 import { getSessionAttribute } from '../utils/sessions';
+import { redirectTo } from './api/apiUtils';
 
 const title = 'Service - Create Fares Data Service';
 const description = 'Service selection page of the Create Fares Data Service';
@@ -88,8 +89,14 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
 
     const services = await getServicesByNocCode(nocCode);
 
-    if (services.length === 0) {
-        throw new Error(`No services found for NOC Code: ${nocCode}`);
+    const emptyservices = [];
+
+    if (emptyservices.length === 0) {
+        if (ctx.res) {
+            redirectTo(ctx.res, '/noServices');
+        } else {
+            throw new Error(`No services found for NOC Code: ${nocCode}`);
+        }
     }
 
     return {

--- a/tests/pages/__snapshots__/noServices.test.tsx.snap
+++ b/tests/pages/__snapshots__/noServices.test.tsx.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pages noServices should render correctly 1`] = `
+<Component
+  description="No Services error page of the Create Fares Data Service"
+  title="No Services - Create Fares Data Service"
+>
+  <h1
+    className="govuk-heading-l"
+  >
+    Sorry, there is no service data available for your National Operator Code (NOC)
+  </h1>
+  <p
+    className="govuk-body-m"
+  >
+    This service utilises the Traveline National Dataset (TNDS) to obtain operators' service data in order to help them create fares data.
+  </p>
+  <p
+    className="govuk-body-m"
+  >
+    It appears there is no service data for this operator in the Traveline National Dataset.
+  </p>
+  <p
+    className="govuk-body-m"
+  >
+    You will not be able to continue creating fares data without this.
+  </p>
+  <p
+    className="govuk-body-m"
+  >
+    <a
+      href="/contact"
+    >
+      Contact
+    </a>
+     us if you have further questions.
+  </p>
+  <a
+    className="govuk-button"
+    data-module="govuk-button"
+    draggable="false"
+    href="/home"
+    id="home-button"
+    role="button"
+  >
+    Home
+  </a>
+</Component>
+`;

--- a/tests/pages/fareType.test.tsx
+++ b/tests/pages/fareType.test.tsx
@@ -2,6 +2,9 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import FareType, { buildUuid, getServerSideProps } from '../../src/pages/fareType';
 import { getMockContext, mockSchemOpIdToken } from '../testData/mockData';
+import { getServicesByNocCode } from '../../src/data/auroradb';
+
+jest.mock('../../src/data/auroradb');
 
 describe('pages', () => {
     const writeHeadMock = jest.fn();
@@ -24,14 +27,37 @@ describe('pages', () => {
         });
 
         describe('getServerSideProps', () => {
-            it('should return expected props when a the user logged in is not a scheme operator', () => {
+            beforeEach(() => {
+                (getServicesByNocCode as jest.Mock).mockImplementation(() => [
+                    {
+                        lineName: '123',
+                        startDate: '05/02/2020',
+                        description: 'this bus service is 123',
+                        serviceCode: 'NW_05_BLAC_123_1',
+                    },
+                    {
+                        lineName: 'X1',
+                        startDate: '06/02/2020',
+                        description: 'this bus service is X1',
+                        serviceCode: 'NW_05_BLAC_X1_1',
+                    },
+                    {
+                        lineName: 'Infinity Line',
+                        startDate: '07/02/2020',
+                        description: 'this bus service is Infinity Line',
+                        serviceCode: 'WY_13_IWBT_07_1',
+                    },
+                ]);
+            });
+
+            it('should return expected props when a the user logged in is not a scheme operator', async () => {
                 const expectedProps = { props: { operatorName: expect.any(String), errors: [], csrfToken: '' } };
                 const mockContext = getMockContext();
-                const actualProps = getServerSideProps(mockContext);
+                const actualProps = await getServerSideProps(mockContext);
                 expect(actualProps).toEqual(expectedProps);
             });
 
-            it('should redirect straight to /passengerType when a the user logged in is a scheme operator', () => {
+            it('should redirect to /passengerType when the user logged in is a scheme operator', async () => {
                 const mockContext = getMockContext({
                     mockWriteHeadFn: writeHeadMock,
                     cookies: {
@@ -39,8 +65,21 @@ describe('pages', () => {
                         idToken: mockSchemOpIdToken,
                     },
                 });
-                getServerSideProps(mockContext);
+                await getServerSideProps(mockContext);
                 expect(writeHeadMock).toBeCalledWith(302, { Location: '/passengerType' });
+            });
+
+            it('should redirect to /noServices when the chosen NOC has no services', async () => {
+                (getServicesByNocCode as jest.Mock).mockImplementation(() => []);
+                const mockContext = getMockContext({
+                    mockWriteHeadFn: writeHeadMock,
+                    cookies: {
+                        operator: { name: 'SCHEME_OPERATOR', region: 'SCHEME_REGION', nocCode: 'TESTSCHEME' },
+                        idToken: mockSchemOpIdToken,
+                    },
+                });
+                await getServerSideProps(mockContext);
+                expect(writeHeadMock).toBeCalledWith(302, { Location: '/noServices' });
             });
         });
     });

--- a/tests/pages/noServices.test.tsx
+++ b/tests/pages/noServices.test.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import NoServices from '../../src/pages/noServices';
+
+describe('pages', () => {
+    describe('noServices', () => {
+        it('should render correctly', () => {
+            const tree = shallow(<NoServices />);
+            expect(tree).toMatchSnapshot();
+        });
+    });
+});

--- a/tests/pages/service.test.tsx
+++ b/tests/pages/service.test.tsx
@@ -121,7 +121,9 @@ describe('pages', () => {
                 mockEndFn,
             });
 
-            await expect(getServerSideProps(ctx)).rejects.toThrow('No services found for NOC Code: TEST');
+            await getServerSideProps(ctx);
+
+            expect(ctx.res?.writeHead).toBeCalledWith(302, { Location: '/noServices' });
         });
 
         it('throws error if noc invalid', async () => {


### PR DESCRIPTION
# Description

-   To have a page specifically for when the service page would error for there being no services found.

# Testing instructions

-   To test, go to the serverSideProps for the service.tsx page, and change the service array to an empty array, and it will redirect you there when you run it locally (single ticket).

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
