### PR TITLE
Feat/cfd 106 choose pounds or pence

### DIFF
--- a/src/components/FareTypeRadios.tsx
+++ b/src/components/FareTypeRadios.tsx
@@ -43,7 +43,7 @@ const FareTypeRadios = ({ standardFares, otherFares = [] }: FareTypeRadioProps):
                             Other Fares
                         </h2>
                         {otherFares.map(otherFare => (
-                            <div className="govuk-radios__item">
+                            <div className="govuk-radios__item" key={otherFare.fareType}>
                                 <input
                                     className="govuk-radios__input"
                                     id={`fare-type-${otherFare.fareType}`}

--- a/src/components/UserDataUploads.tsx
+++ b/src/components/UserDataUploads.tsx
@@ -21,7 +21,7 @@ export interface UserDataUploadsProps {
     detailSummary?: string;
     detailBody?: ReactElement;
     showPriceOption?: boolean;
-    poundsOrPence: string | null;
+    poundsOrPence?: string | null;
     csrfToken: string;
 }
 

--- a/src/components/UserDataUploads.tsx
+++ b/src/components/UserDataUploads.tsx
@@ -3,7 +3,7 @@ import FileAttachment from './FileAttachment';
 import guidanceDocImage from '../assets/images/Guidance-doc-front-page.png';
 import csvImage from '../assets/images/csv.png';
 import { ErrorInfo } from '../interfaces';
-import FormElementWrapper from './FormElementWrapper';
+import FormElementWrapper, { FormGroupWrapper } from './FormElementWrapper';
 import ErrorSummary from './ErrorSummary';
 import CsrfForm from './CsrfForm';
 
@@ -20,6 +20,8 @@ export interface UserDataUploadsProps {
     errors: ErrorInfo[];
     detailSummary?: string;
     detailBody?: ReactElement;
+    showPriceOption?: boolean;
+    poundsOrPence: string | null;
     csrfToken: string;
 }
 
@@ -36,6 +38,8 @@ const UserDataUploadComponent = ({
     errors,
     detailSummary,
     detailBody,
+    showPriceOption,
+    poundsOrPence,
     csrfToken,
 }: UserDataUploadsProps): ReactElement => (
     <div className="govuk-grid-row">
@@ -43,29 +47,90 @@ const UserDataUploadComponent = ({
             <ErrorSummary errors={errors} />
             <CsrfForm action={csvUploadApiRoute} method="post" encType="multipart/form-data" csrfToken={csrfToken}>
                 <>
-                    <div className={`govuk-form-group ${errors.length > 0 ? 'govuk-form-group--error' : ''}`}>
+                    <div
+                        className={`govuk-form-group ${
+                            errors.length > 0 && !showPriceOption ? 'govuk-form-group--error' : ''
+                        }`}
+                    >
                         <label htmlFor="csv-upload">
                             <h1 className="govuk-heading-l">{csvUploadTitle}</h1>
                         </label>
                         <span className="govuk-hint" id="csv-upload-hint">
                             {csvUploadHintText}
                         </span>
-                        <div className="govuk-form-group input-form">
-                            <FormElementWrapper
-                                errorId={errors?.[0]?.id}
-                                errorClass="govuk-file-upload--error"
-                                errors={errors}
-                            >
-                                <input
-                                    className="govuk-file-upload"
-                                    id="csv-upload"
-                                    name="csv-upload"
-                                    type="file"
-                                    accept=".csv,.xlsx,.xls"
-                                    aria-describedby="csv-upload-hint"
-                                />
-                            </FormElementWrapper>
-                        </div>
+                        {showPriceOption && (
+                            <FormGroupWrapper errors={errors} errorId="pounds">
+                                <fieldset className="govuk-fieldset">
+                                    <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">
+                                        <h2 className="govuk-fieldset__heading" id="passenger-type-page-heading">
+                                            Are prices in pounds or pence?
+                                        </h2>
+                                    </legend>
+                                    <FormElementWrapper
+                                        errors={errors}
+                                        errorId="pounds"
+                                        errorClass="govuk-radios--error"
+                                    >
+                                        <div className="govuk-radios">
+                                            <div className="govuk-radios__item">
+                                                <input
+                                                    className="govuk-radios__input"
+                                                    id="pounds"
+                                                    name="poundsOrPence"
+                                                    type="radio"
+                                                    value="pounds"
+                                                    defaultChecked={poundsOrPence === 'pounds'}
+                                                />
+
+                                                <label className="govuk-label govuk-radios__label" htmlFor="pounds">
+                                                    Pounds, for example 2.50
+                                                </label>
+                                            </div>
+                                            <div className="govuk-radios__item">
+                                                <input
+                                                    className="govuk-radios__input"
+                                                    id="pence"
+                                                    name="poundsOrPence"
+                                                    type="radio"
+                                                    value="pence"
+                                                    defaultChecked={poundsOrPence === 'pence'}
+                                                />
+                                                <label className="govuk-label govuk-radios__label" htmlFor="pence">
+                                                    Pence, for example 250
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </FormElementWrapper>
+                                </fieldset>
+                            </FormGroupWrapper>
+                        )}
+                        <FormGroupWrapper errors={errors} errorId="csv-upload">
+                            <fieldset className="govuk-fieldset">
+                                <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">
+                                    <h2
+                                        className={`govuk-fieldset__heading ${!showPriceOption &&
+                                            'govuk-visually-hidden'}`}
+                                        id="passenger-type-page-heading"
+                                    >
+                                        Upload file
+                                    </h2>
+                                </legend>
+                                <FormElementWrapper
+                                    errorId="csv-upload"
+                                    errorClass="govuk-file-upload--error"
+                                    errors={errors}
+                                >
+                                    <input
+                                        className="govuk-file-upload"
+                                        id="csv-upload"
+                                        name="csv-upload"
+                                        type="file"
+                                        accept=".csv,.xlsx,.xls"
+                                        aria-describedby="csv-upload-hint"
+                                    />
+                                </FormElementWrapper>
+                            </fieldset>
+                        </FormGroupWrapper>
                     </div>
                     {detailSummary && detailBody && (
                         <details className="govuk-details" data-module="govuk-details">

--- a/src/pages/api/csvUpload.ts
+++ b/src/pages/api/csvUpload.ts
@@ -6,7 +6,7 @@ import { getUuidFromCookie, redirectToError, redirectTo } from './apiUtils';
 import { putDataInS3, UserFareStages } from '../../data/s3';
 import { JOURNEY_ATTRIBUTE, INPUT_METHOD_ATTRIBUTE, CSV_UPLOAD_ATTRIBUTE } from '../../constants';
 import { isSessionValid } from './apiUtils/validator';
-import { processFileUpload } from './apiUtils/fileUpload';
+import { getFormData, processFileUpload } from './apiUtils/fileUpload';
 import logger from '../../utils/logger';
 import { getSessionAttribute, updateSessionAttribute } from '../../utils/sessions';
 import { isJourney } from '../../interfaces/typeGuards';
@@ -15,6 +15,7 @@ const errorId = 'csv-upload';
 
 export interface CsvUploadAttributeWithErrors {
     errors: ErrorInfo[];
+    poundsOrPence?: string;
 }
 
 interface FareTriangleData {
@@ -39,8 +40,9 @@ export const setCsvUploadAttributeAndRedirect = (
     req: NextApiRequestWithSession,
     res: NextApiResponse,
     errors: ErrorInfo[],
+    poundsOrPence?: string,
 ): void => {
-    updateSessionAttribute(req, CSV_UPLOAD_ATTRIBUTE, { errors });
+    updateSessionAttribute(req, CSV_UPLOAD_ATTRIBUTE, { errors, poundsOrPence });
     redirectTo(res, '/csvUpload');
 };
 
@@ -58,6 +60,7 @@ export const faresTriangleDataMapper = (
     dataToMap: string,
     req: NextApiRequestWithSession,
     res: NextApiResponse,
+    poundsOrPence: string,
 ): UserFareStages | null => {
     const fareTriangle: FareTriangleData = {
         fareStages: [],
@@ -65,6 +68,7 @@ export const faresTriangleDataMapper = (
 
     const fareStageLines = Papa.parse(dataToMap, { skipEmptyLines: 'greedy' }).data as string[][];
     const fareStageCount = fareStageLines.length;
+    const isPence = poundsOrPence === 'pence';
 
     if (fareStageCount < 2) {
         logger.warn('', {
@@ -72,7 +76,7 @@ export const faresTriangleDataMapper = (
             message: `At least 2 fare stages are needed, only ${fareStageCount} found`,
         });
         const errors: ErrorInfo[] = [{ id: errorId, errorMessage: 'At least 2 fare stages are needed' }];
-        setCsvUploadAttributeAndRedirect(req, res, errors);
+        setCsvUploadAttributeAndRedirect(req, res, errors, poundsOrPence);
 
         return null;
     }
@@ -84,7 +88,7 @@ export const faresTriangleDataMapper = (
                 message: `Uploaded CSV does not follow correct template`,
             });
             const errors: ErrorInfo[] = [{ id: errorId, errorMessage: 'The selected file must use the template' }];
-            setCsvUploadAttributeAndRedirect(req, res, errors);
+            setCsvUploadAttributeAndRedirect(req, res, errors, poundsOrPence);
 
             return null;
         }
@@ -104,7 +108,7 @@ export const faresTriangleDataMapper = (
                 message: `Empty fare stage name found in uploaded file`,
             });
             const errors: ErrorInfo[] = [{ id: errorId, errorMessage: 'Fare stage names must not be empty' }];
-            setCsvUploadAttributeAndRedirect(req, res, errors);
+            setCsvUploadAttributeAndRedirect(req, res, errors, poundsOrPence);
 
             return null;
         }
@@ -133,11 +137,11 @@ export const faresTriangleDataMapper = (
                     const errors: ErrorInfo[] = [
                         { id: errorId, errorMessage: 'The selected file contains an invalid price' },
                     ];
-                    setCsvUploadAttributeAndRedirect(req, res, errors);
+                    setCsvUploadAttributeAndRedirect(req, res, errors, poundsOrPence);
                     return null;
                 }
 
-                if (Number(price) % 1 !== 0) {
+                if (isPence && Number(price) % 1 !== 0) {
                     logger.warn('', {
                         context: 'api.csvUpload',
                         message: `decimal price in CSV upload`,
@@ -148,7 +152,7 @@ export const faresTriangleDataMapper = (
                             errorMessage: 'The selected file contains a decimal price, all prices must be in pence',
                         },
                     ];
-                    setCsvUploadAttributeAndRedirect(req, res, errors);
+                    setCsvUploadAttributeAndRedirect(req, res, errors, poundsOrPence);
                     return null;
                 }
 
@@ -156,7 +160,7 @@ export const faresTriangleDataMapper = (
                     fareTriangle.fareStages[colNum].prices[price].fareZones.push(stageName);
                 } else {
                     fareTriangle.fareStages[colNum].prices[price] = {
-                        price: (parseFloat(price) / 100).toFixed(2),
+                        price: isPence ? (parseFloat(price) / 100).toFixed(2) : parseFloat(price).toFixed(2),
                         fareZones: [stageName],
                     };
                 }
@@ -172,7 +176,7 @@ export const faresTriangleDataMapper = (
         const errors: ErrorInfo[] = [
             { id: errorId, errorMessage: 'At least one price must be set in the uploaded fares triangle' },
         ];
-        setCsvUploadAttributeAndRedirect(req, res, errors);
+        setCsvUploadAttributeAndRedirect(req, res, errors, poundsOrPence);
 
         return null;
     }
@@ -192,7 +196,7 @@ export const faresTriangleDataMapper = (
             message: `Duplicate fare stage names found, fare stage names: ${fareStageNames}`,
         });
         const errors: ErrorInfo[] = [{ id: errorId, errorMessage: 'Fare stage names cannot be the same' }];
-        setCsvUploadAttributeAndRedirect(req, res, errors);
+        setCsvUploadAttributeAndRedirect(req, res, errors, poundsOrPence);
         return null;
     }
 
@@ -205,18 +209,32 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             throw new Error('session is invalid.');
         }
 
-        const { fileContents, fileError } = await processFileUpload(req, 'csv-upload');
+        const formData = await getFormData(req);
+        const { fields } = formData;
+
+        if (!fields?.['poundsOrPence']) {
+            const errors: ErrorInfo[] = [
+                { id: 'pounds', errorMessage: 'You must select whether the prices are in pounds or pence' },
+            ];
+            setCsvUploadAttributeAndRedirect(req, res, errors);
+
+            return;
+        }
+
+        const { poundsOrPence } = fields;
+
+        const { fileContents, fileError } = await processFileUpload(formData, 'csv-upload');
 
         if (fileError) {
             const errors: ErrorInfo[] = [{ id: errorId, errorMessage: fileError }];
-            setCsvUploadAttributeAndRedirect(req, res, errors);
+            setCsvUploadAttributeAndRedirect(req, res, errors, fields.poundsOrPence as string);
             return;
         }
 
         if (fileContents) {
             const uuid = getUuidFromCookie(req, res);
             await putDataInS3(fileContents, `${uuid}.csv`, false);
-            const fareTriangleData = faresTriangleDataMapper(fileContents, req, res);
+            const fareTriangleData = faresTriangleDataMapper(fileContents, req, res, poundsOrPence as string);
             if (!fareTriangleData) {
                 return;
             }

--- a/src/pages/api/csvUpload.ts
+++ b/src/pages/api/csvUpload.ts
@@ -156,11 +156,13 @@ export const faresTriangleDataMapper = (
                     return null;
                 }
 
-                if (fareTriangle.fareStages?.[colNum].prices?.[price]?.fareZones) {
-                    fareTriangle.fareStages[colNum].prices[price].fareZones.push(stageName);
+                const formattedPrice = isPence ? (parseFloat(price) / 100).toFixed(2) : parseFloat(price).toFixed(2);
+
+                if (fareTriangle.fareStages?.[colNum].prices?.[formattedPrice]?.fareZones) {
+                    fareTriangle.fareStages[colNum].prices[formattedPrice].fareZones.push(stageName);
                 } else {
-                    fareTriangle.fareStages[colNum].prices[price] = {
-                        price: isPence ? (parseFloat(price) / 100).toFixed(2) : parseFloat(price).toFixed(2),
+                    fareTriangle.fareStages[colNum].prices[formattedPrice] = {
+                        price: formattedPrice,
                         fareZones: [stageName],
                     };
                 }

--- a/src/pages/api/csvZoneUpload.ts
+++ b/src/pages/api/csvZoneUpload.ts
@@ -6,7 +6,7 @@ import { getUuidFromCookie, redirectToError, redirectTo } from './apiUtils';
 import { putDataInS3, UserFareZone } from '../../data/s3';
 import { getAtcoCodesByNaptanCodes, batchGetStopsByAtcoCode } from '../../data/auroradb';
 import { isSessionValid } from './apiUtils/validator';
-import { processFileUpload } from './apiUtils/fileUpload';
+import { getFormData, processFileUpload } from './apiUtils/fileUpload';
 import logger from '../../utils/logger';
 import { ErrorInfo, NextApiRequestWithSession } from '../../interfaces';
 
@@ -144,7 +144,8 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             throw new Error('session is invalid.');
         }
 
-        const { fileContents, fileError } = await processFileUpload(req, 'csv-upload');
+        const formData = await getFormData(req);
+        const { fileContents, fileError } = await processFileUpload(formData, 'csv-upload');
 
         if (fileError) {
             const errors: ErrorInfo[] = [{ id: 'csv-upload', errorMessage: fileError }];

--- a/src/pages/csvUpload.tsx
+++ b/src/pages/csvUpload.tsx
@@ -35,7 +35,9 @@ const CsvUpload = (uploadProps: UserDataUploadsProps): ReactElement => (
 
 export const getServerSideProps = (ctx: NextPageContextWithSession): { props: UserDataUploadsProps } => {
     const csvUploadAttribute = getSessionAttribute(ctx.req, CSV_UPLOAD_ATTRIBUTE);
-    const errors: ErrorInfo[] = csvUploadAttribute ? csvUploadAttribute.errors : [];
+    const errors: ErrorInfo[] = csvUploadAttribute?.errors ?? [];
+    const poundsOrPence = csvUploadAttribute?.poundsOrPence ?? null;
+
     return {
         props: {
             csvUploadApiRoute: '/api/csvUpload',
@@ -50,6 +52,8 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Us
             csvTemplateSize: '255B',
             errors,
             detailSummary: "My fare triangle won't upload",
+            showPriceOption: true,
+            poundsOrPence,
             csrfToken: getCsrfToken(ctx),
         },
     };

--- a/tests/components/__snapshots__/FareTypeRadios.test.tsx.snap
+++ b/tests/components/__snapshots__/FareTypeRadios.test.tsx.snap
@@ -172,6 +172,7 @@ exports[`FareTypeRadios should render a set of radio buttons with standard fares
     </h2>
     <div
       className="govuk-radios__item"
+      key="multiOperator"
     >
       <input
         className="govuk-radios__input"
@@ -189,6 +190,7 @@ exports[`FareTypeRadios should render a set of radio buttons with standard fares
     </div>
     <div
       className="govuk-radios__item"
+      key="schoolService"
     >
       <input
         className="govuk-radios__input"

--- a/tests/pages/__snapshots__/csvUpload.test.tsx.snap
+++ b/tests/pages/__snapshots__/csvUpload.test.tsx.snap
@@ -38,6 +38,7 @@ exports[`pages csvUpload should render correctly 1`] = `
     guidanceDocAttachmentUrl=""
     guidanceDocDisplayName=""
     guidanceDocSize=""
+    showPriceOption={true}
   />
 </Component>
 `;

--- a/tests/pages/api/csvUpload.test.ts
+++ b/tests/pages/api/csvUpload.test.ts
@@ -42,6 +42,9 @@ describe('csvUpload', () => {
         getFormDataSpy.mockImplementation().mockResolvedValue({
             files: file,
             fileContents: csvData.testCsvDuplicateFareStages,
+            fields: {
+                poundsOrPence: 'pence',
+            },
         });
 
         jest.spyOn(fileUpload, 'containsViruses')
@@ -53,7 +56,10 @@ describe('csvUpload', () => {
         expect(res.writeHead).toBeCalledWith(302, {
             Location: '/csvUpload',
         });
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, CSV_UPLOAD_ATTRIBUTE, { errors: mockError });
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, CSV_UPLOAD_ATTRIBUTE, {
+            errors: mockError,
+            poundsOrPence: 'pence',
+        });
     });
 
     it('should return 302 redirect to /csvUpload when no file is attached', async () => {
@@ -78,6 +84,9 @@ describe('csvUpload', () => {
         getFormDataSpy.mockImplementation().mockResolvedValue({
             files: file,
             fileContents: '',
+            fields: {
+                poundsOrPence: 'pence',
+            },
         });
 
         jest.spyOn(fileUpload, 'containsViruses')
@@ -89,7 +98,10 @@ describe('csvUpload', () => {
         expect(res.writeHead).toBeCalledWith(302, {
             Location: '/csvUpload',
         });
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, CSV_UPLOAD_ATTRIBUTE, { errors: mockError });
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, CSV_UPLOAD_ATTRIBUTE, {
+            errors: mockError,
+            poundsOrPence: 'pence',
+        });
         expect(loggerSpy).toBeCalledWith('', { context: 'api.utils.processFileUpload', message: 'no file attached' });
     });
 
@@ -117,6 +129,9 @@ describe('csvUpload', () => {
         getFormDataSpy.mockImplementation().mockResolvedValue({
             files: file,
             fileContents: csvData.testCsv,
+            fields: {
+                poundsOrPence: 'pence',
+            },
         });
 
         jest.spyOn(fileUpload, 'containsViruses')
@@ -128,7 +143,10 @@ describe('csvUpload', () => {
         expect(res.writeHead).toBeCalledWith(302, {
             Location: '/csvUpload',
         });
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, CSV_UPLOAD_ATTRIBUTE, { errors: mockError });
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, CSV_UPLOAD_ATTRIBUTE, {
+            errors: mockError,
+            poundsOrPence: 'pence',
+        });
         expect(loggerSpy).toBeCalledWith('', {
             context: 'api.utils.validateFile',
             maxSize: 5242880,
@@ -161,6 +179,9 @@ describe('csvUpload', () => {
         getFormDataSpy.mockImplementation().mockResolvedValue({
             files: file,
             fileContents: csvData.testCsv,
+            fields: {
+                poundsOrPence: 'pence',
+            },
         });
 
         jest.spyOn(fileUpload, 'containsViruses')
@@ -172,7 +193,10 @@ describe('csvUpload', () => {
         expect(res.writeHead).toBeCalledWith(302, {
             Location: '/csvUpload',
         });
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, CSV_UPLOAD_ATTRIBUTE, { errors: mockError });
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, CSV_UPLOAD_ATTRIBUTE, {
+            errors: mockError,
+            poundsOrPence: 'pence',
+        });
         expect(loggerSpy).toBeCalledWith('', {
             context: 'api.utils.validateFile',
             message: 'file not of allowed type',
@@ -201,6 +225,9 @@ describe('csvUpload', () => {
         getFormDataSpy.mockImplementation().mockResolvedValue({
             files: file,
             fileContents: csvData.testCsv,
+            fields: {
+                poundsOrPence: 'pence',
+            },
         });
 
         jest.spyOn(fileUpload, 'containsViruses')
@@ -245,6 +272,9 @@ describe('csvUpload', () => {
         getFormDataSpy.mockImplementation().mockResolvedValue({
             files: file,
             fileContents: csvData.validTestCsvWithEmptyCellsAndEmptyLine,
+            fields: {
+                poundsOrPence: 'pence',
+            },
         });
 
         jest.spyOn(fileUpload, 'containsViruses')
@@ -264,6 +294,53 @@ describe('csvUpload', () => {
             'fdbt-user-data-dev',
             expect.any(String),
             JSON.stringify(csvData.processedObjectWithEmptyCells.Body),
+            'application/json; charset=utf-8',
+        );
+    });
+
+    it('should correctly generate data with decimal prices when pounds is selected', async () => {
+        const { req, res } = getMockRequestAndResponse({
+            cookieValues: {},
+            body: null,
+            uuid: {},
+        });
+        const file = {
+            'csv-upload': {
+                size: 999,
+                path: 'string',
+                name: 'string',
+                type: 'text/csv',
+                toJSON(): string {
+                    return '';
+                },
+            },
+        };
+
+        getFormDataSpy.mockImplementation().mockResolvedValue({
+            files: file,
+            fileContents: csvData.decimalPricesTestCsv,
+            fields: {
+                poundsOrPence: 'pounds',
+            },
+        });
+
+        jest.spyOn(fileUpload, 'containsViruses')
+            .mockImplementation()
+            .mockResolvedValue(false);
+
+        await csvUpload.default(req, res);
+
+        expect(s3.putStringInS3).toBeCalledWith(
+            'fdbt-raw-user-data-dev',
+            expect.any(String),
+            JSON.stringify(csvData.unprocessedObjectWithDecimalPrices.Body),
+            'text/csv; charset=utf-8',
+        );
+
+        expect(s3.putStringInS3).toBeCalledWith(
+            'fdbt-user-data-dev',
+            expect.any(String),
+            JSON.stringify(csvData.processedObject.Body),
             'application/json; charset=utf-8',
         );
     });
@@ -294,6 +371,9 @@ describe('csvUpload', () => {
         getFormDataSpy.mockImplementation().mockResolvedValue({
             files: file,
             fileContents: csvData.testCsv,
+            fields: {
+                poundsOrPence: 'pence',
+            },
         });
 
         jest.spyOn(fileUpload, 'containsViruses')
@@ -334,6 +414,9 @@ describe('csvUpload', () => {
         getFormDataSpy.mockImplementation().mockResolvedValue({
             files: file,
             fileContents: csvData.nonTicketerTestCsv,
+            fields: {
+                poundsOrPence: 'pence',
+            },
         });
 
         jest.spyOn(fileUpload, 'containsViruses')
@@ -372,6 +455,9 @@ describe('csvUpload', () => {
         getFormDataSpy.mockImplementation().mockResolvedValue({
             files: file,
             fileContents: csvData.nonNumericPricesTestCsv,
+            fields: {
+                poundsOrPence: 'pounds',
+            },
         });
 
         jest.spyOn(fileUpload, 'containsViruses')
@@ -383,10 +469,13 @@ describe('csvUpload', () => {
         expect(res.writeHead).toBeCalledWith(302, {
             Location: '/csvUpload',
         });
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, CSV_UPLOAD_ATTRIBUTE, { errors: mockError });
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, CSV_UPLOAD_ATTRIBUTE, {
+            errors: mockError,
+            poundsOrPence: 'pounds',
+        });
     });
 
-    it('should throw an error if the fares triangle data has decimal prices', async () => {
+    it('should throw an error if the fares triangle data has decimal prices and pence is selected', async () => {
         const mockError: ErrorInfo[] = [
             {
                 id: 'csv-upload',
@@ -413,6 +502,9 @@ describe('csvUpload', () => {
         getFormDataSpy.mockImplementation().mockResolvedValue({
             files: file,
             fileContents: csvData.decimalPricesTestCsv,
+            fields: {
+                poundsOrPence: 'pence',
+            },
         });
 
         jest.spyOn(fileUpload, 'containsViruses')
@@ -424,7 +516,50 @@ describe('csvUpload', () => {
         expect(res.writeHead).toBeCalledWith(302, {
             Location: '/csvUpload',
         });
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, CSV_UPLOAD_ATTRIBUTE, { errors: mockError });
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, CSV_UPLOAD_ATTRIBUTE, {
+            errors: mockError,
+            poundsOrPence: 'pence',
+        });
+    });
+
+    it('should return 302 redirect to /matching if the fares triangle data has decimal prices and pounds is selected', async () => {
+        const { req, res } = getMockRequestAndResponse({
+            cookieValues: {},
+            body: null,
+            uuid: {},
+        });
+        const file = {
+            'csv-upload': {
+                size: 999,
+                path: 'string',
+                name: 'string',
+                type: 'text/csv',
+                toJSON(): string {
+                    return '';
+                },
+            },
+        };
+
+        getFormDataSpy.mockImplementation().mockResolvedValue({
+            files: file,
+            fileContents: csvData.decimalPricesTestCsv,
+            fields: {
+                poundsOrPence: 'pounds',
+            },
+        });
+
+        jest.spyOn(fileUpload, 'containsViruses')
+            .mockImplementation()
+            .mockResolvedValue(false);
+
+        await csvUpload.default(req, res);
+
+        expect(res.writeHead).toBeCalledWith(302, {
+            Location: '/matching',
+        });
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, CSV_UPLOAD_ATTRIBUTE, {
+            errors: [],
+        });
     });
 
     it('should throw an error if there is an empty fare stage name', async () => {
@@ -454,6 +589,9 @@ describe('csvUpload', () => {
         getFormDataSpy.mockImplementation().mockResolvedValue({
             files: file,
             fileContents: csvData.emptyStageNameTestCsv,
+            fields: {
+                poundsOrPence: 'pence',
+            },
         });
 
         jest.spyOn(fileUpload, 'containsViruses')
@@ -465,7 +603,10 @@ describe('csvUpload', () => {
         expect(res.writeHead).toBeCalledWith(302, {
             Location: '/csvUpload',
         });
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, CSV_UPLOAD_ATTRIBUTE, { errors: mockError });
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, CSV_UPLOAD_ATTRIBUTE, {
+            errors: mockError,
+            poundsOrPence: 'pence',
+        });
     });
 
     it('should throw an error if no prices are set', async () => {
@@ -495,6 +636,9 @@ describe('csvUpload', () => {
         getFormDataSpy.mockImplementation().mockResolvedValue({
             files: file,
             fileContents: csvData.noPricesTestCsv,
+            fields: {
+                poundsOrPence: 'pence',
+            },
         });
 
         jest.spyOn(fileUpload, 'containsViruses')
@@ -506,7 +650,10 @@ describe('csvUpload', () => {
         expect(res.writeHead).toBeCalledWith(302, {
             Location: '/csvUpload',
         });
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, CSV_UPLOAD_ATTRIBUTE, { errors: mockError });
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, CSV_UPLOAD_ATTRIBUTE, {
+            errors: mockError,
+            poundsOrPence: 'pence',
+        });
     });
 
     it('should return 302 redirect to /matching if the fares triangle data has empty prices', async () => {
@@ -530,6 +677,9 @@ describe('csvUpload', () => {
         getFormDataSpy.mockImplementation().mockResolvedValue({
             files: file,
             fileContents: csvData.missingPricesTestCsv,
+            fields: {
+                poundsOrPence: 'pence',
+            },
         });
 
         jest.spyOn(fileUpload, 'containsViruses')
@@ -567,6 +717,9 @@ describe('csvUpload', () => {
         getFormDataSpy.mockImplementation().mockResolvedValue({
             files: file,
             fileContents: 'i am a virus',
+            fields: {
+                poundsOrPence: 'pence',
+            },
         });
 
         jest.spyOn(fileUpload, 'containsViruses')
@@ -578,7 +731,10 @@ describe('csvUpload', () => {
         expect(res.writeHead).toBeCalledWith(302, {
             Location: '/csvUpload',
         });
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, CSV_UPLOAD_ATTRIBUTE, { errors: mockError });
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, CSV_UPLOAD_ATTRIBUTE, {
+            errors: mockError,
+            poundsOrPence: 'pence',
+        });
     });
 
     describe('containsDuplicateFareStages', () => {

--- a/tests/pages/csvUpload.test.tsx
+++ b/tests/pages/csvUpload.test.tsx
@@ -17,6 +17,7 @@ describe('pages', () => {
                     csvTemplateAttachmentUrl=""
                     csvTemplateSize=""
                     errors={[]}
+                    showPriceOption
                     csrfToken=""
                 />,
             );

--- a/tests/testData/csvFareTriangleData.ts
+++ b/tests/testData/csvFareTriangleData.ts
@@ -71,13 +71,13 @@ export const nonNumericPricesTestCsv: string =
 
 export const decimalPricesTestCsv: string =
     'Acomb Green Lane,,,,,,,\n' +
-    '110,Mattison Way,,,,,,\n' +
-    '110,110,Nursery Drive,,,,,\n' +
-    '110,1.10,110,Holl Bank/Beech Ave,,,,\n' +
-    '170,110,110,110,Cambridge Street (York),,,\n' +
-    '170,170,120,110,100,Blossom Street,,\n' +
-    '170,170,170,170,100,100,Rail Station (York),\n' +
-    '170,170,170,100,100,100,100,Piccadilly (York)';
+    '1.10,Mattison Way,,,,,,\n' +
+    '1.10,1.10,Nursery Drive,,,,,\n' +
+    '1.10,1.10,1.10,Holl Bank/Beech Ave,,,,\n' +
+    '1.70,1.70,1.10,1.10,Cambridge Street (York),,,\n' +
+    '1.70,1.70,1.10,1.10,1.00,Blossom Street,,\n' +
+    '1.70,1.70,1.70,1.70,1,1.00,Rail Station (York),\n' +
+    '1.70,1.70,1.70,1.70,1.00,1.00,1,Piccadilly (York)';
 
 export const emptyStageNameTestCsv: string =
     'Acomb Green Lane,,,,,,,\n' +
@@ -142,6 +142,21 @@ export const unprocessedObjectWithEmptyCells = {
         '170,170,170,170,100,100,Rail Station (York),\n' +
         ' ,170,170,170,100,100,100, Piccadilly (York)\n' +
         ',,,,,,,\n',
+    ContentType: 'text/csv; charset=utf-8',
+};
+
+export const unprocessedObjectWithDecimalPrices = {
+    Bucket: 'fdbt-raw-user-data',
+    Key: '780e3459-6305-4ae5-9082-b925b92cb46c',
+    Body:
+        'Acomb Green Lane,,,,,,,\n' +
+        '1.10,Mattison Way,,,,,,\n' +
+        '1.10,1.10,Nursery Drive,,,,,\n' +
+        '1.10,1.10,1.10,Holl Bank/Beech Ave,,,,\n' +
+        '1.70,1.70,1.10,1.10,Cambridge Street (York),,,\n' +
+        '1.70,1.70,1.10,1.10,1.00,Blossom Street,,\n' +
+        '1.70,1.70,1.70,1.70,1,1.00,Rail Station (York),\n' +
+        '1.70,1.70,1.70,1.70,1.00,1.00,1,Piccadilly (York)',
     ContentType: 'text/csv; charset=utf-8',
 };
 


### PR DESCRIPTION
# Description

-   Add option for pounds or pence on CSV upload

# Testing instructions

-  Upload a variety of CSV and Excel files, with both pounds and pence
-  Uploading a file with pounds should not work when pence is selected
-  Both 1 and 1.00 should work the same when pounds is selected
-  Pence should still be divided by 100 as it currently is, pounds should simply be set to 2 decimal places

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [ ] Able to run pr locally
-   [ ] Followed acceptance criteria
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
