### PR TITLE
Allow for registration of scheme operators and fix registration intercept

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -32,6 +32,7 @@ const unauthenticatedGetRoutes = [
     '/cookieDetails',
     '/accessibility',
     '/privacy',
+    '/noServices',
 ];
 
 const unauthenticatedPostRoutes = [

--- a/src/pages/api/register.ts
+++ b/src/pages/api/register.ts
@@ -74,16 +74,14 @@ export default async (req: NextApiRequest, res: NextApiResponse): Promise<void> 
                 const isSchemeOperator = !!parameters['custom:schemeOperator'];
                 const nocsWithNoTnds = await operatorHasTndsData(cognitoNocs);
 
-                if (!isSchemeOperator) {
-                    if (!(nocsWithNoTnds.length < cognitoNocs.length)) {
-                        logger.warn('', {
-                            context: 'api.register',
-                            message: 'registration aborted, no TNDS data',
-                        });
+                if (!isSchemeOperator && !(nocsWithNoTnds.length < cognitoNocs.length)) {
+                    logger.warn('', {
+                        context: 'api.register',
+                        message: 'registration aborted, no TNDS data',
+                    });
 
-                        redirectTo(res, '/noServices');
-                        return;
-                    }
+                    redirectTo(res, '/noServices');
+                    return;
                 }
 
                 await respondToNewPasswordChallenge(ChallengeParameters.USER_ID_FOR_SRP, password, Session);

--- a/src/pages/fareType.tsx
+++ b/src/pages/fareType.tsx
@@ -103,7 +103,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
 
     const services = await getServicesByNocCode(opIdentifier);
 
-    if (services.length === 0) {
+    if (!schemeOp && services.length === 0) {
         if (ctx.res) {
             redirectTo(ctx.res, '/noServices');
         } else {

--- a/tests/pages/fareType.test.tsx
+++ b/tests/pages/fareType.test.tsx
@@ -73,10 +73,6 @@ describe('pages', () => {
                 (getServicesByNocCode as jest.Mock).mockImplementation(() => []);
                 const mockContext = getMockContext({
                     mockWriteHeadFn: writeHeadMock,
-                    cookies: {
-                        operator: { name: 'SCHEME_OPERATOR', region: 'SCHEME_REGION', nocCode: 'TESTSCHEME' },
-                        idToken: mockSchemOpIdToken,
-                    },
                 });
                 await getServerSideProps(mockContext);
                 expect(writeHeadMock).toBeCalledWith(302, { Location: '/noServices' });


### PR DESCRIPTION
# Description

-   Fix bug preventing scheme operators from registering
-   Fix bug causing silent failure of user registration when no TNDS data exists for their NOC code

# Testing instructions

-   Run the site while authenticated under cfd-test profile
-   Create a user with a NOC code with no TNDS data (e.g. NATX)
-   Follow the registration link, replacing 'https://test.dft-cfd.infinityworks.com' with 'http://localhost:5555'
-   Clear cookies and refresh the page
-   Register and confirm that you are redirected to the /noServices page
-   Also confirm a Scheme Operator can register

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
