### PR TITLE
fix: stop persisting end time when not selected

### DIFF
--- a/src/pages/api/periodValidity.ts
+++ b/src/pages/api/periodValidity.ts
@@ -21,6 +21,12 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
             const daysValidInfo = getSessionAttribute(req, DURATION_VALID_ATTRIBUTE);
             const productDetailsAttribute = getSessionAttribute(req, PRODUCT_DETAILS_ATTRIBUTE);
 
+            if (!isProductInfo(productDetailsAttribute) || !daysValidInfo) {
+                throw new Error('Necessary session data not found for period validity API');
+            }
+
+            const { productName, productPrice } = productDetailsAttribute;
+
             if (periodValid === 'endOfServiceDay') {
                 if (productEndTime === '') {
                     errors.push({ id: 'product-end-time', errorMessage: 'Specify an end time for service day' });
@@ -36,7 +42,10 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
                 }
 
                 if (errors.length > 0) {
-                    updateSessionAttribute(req, PERIOD_EXPIRY_ATTRIBUTE, { products: [], errors });
+                    updateSessionAttribute(req, PERIOD_EXPIRY_ATTRIBUTE, {
+                        products: [{ productEndTime, productName, productPrice }],
+                        errors,
+                    });
                     redirectTo(res, '/periodValidity');
                     return;
                 }
@@ -44,11 +53,6 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
                 productEndTime = '';
             }
 
-            if (!isProductInfo(productDetailsAttribute) || !daysValidInfo) {
-                throw new Error('Necessary session data not found for period validity API');
-            }
-
-            const { productName, productPrice } = productDetailsAttribute;
             const timePeriodValid = `${daysValidInfo.amount} ${daysValidInfo.duration}${
                 daysValidInfo.amount === '1' ? '' : 's'
             }`;

--- a/src/pages/api/periodValidity.ts
+++ b/src/pages/api/periodValidity.ts
@@ -15,7 +15,8 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
         }
 
         if (req.body.periodValid) {
-            const { periodValid, productEndTime } = req.body;
+            const { periodValid } = req.body;
+            let { productEndTime } = req.body;
 
             const daysValidInfo = getSessionAttribute(req, DURATION_VALID_ATTRIBUTE);
             const productDetailsAttribute = getSessionAttribute(req, PRODUCT_DETAILS_ATTRIBUTE);
@@ -39,6 +40,8 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
                     redirectTo(res, '/periodValidity');
                     return;
                 }
+            } else {
+                productEndTime = '';
             }
 
             if (!isProductInfo(productDetailsAttribute) || !daysValidInfo) {

--- a/tests/pages/api/periodValidity.test.ts
+++ b/tests/pages/api/periodValidity.test.ts
@@ -93,7 +93,10 @@ describe('periodValidity', () => {
         });
         periodValidity(req, res);
 
-        expect(updateSessionAttributeSpy).toHaveBeenCalledWith(req, PERIOD_EXPIRY_ATTRIBUTE, { errors, products: [] });
+        expect(updateSessionAttributeSpy).toHaveBeenCalledWith(req, PERIOD_EXPIRY_ATTRIBUTE, {
+            errors,
+            products: [{ productName: 'Product A', productEndTime: '', productPrice: '1234' }],
+        });
         expect(writeHeadMock).toBeCalledWith(302, {
             Location: '/periodValidity',
         });
@@ -116,7 +119,10 @@ describe('periodValidity', () => {
         });
         periodValidity(req, res);
 
-        expect(updateSessionAttributeSpy).toHaveBeenCalledWith(req, PERIOD_EXPIRY_ATTRIBUTE, { errors, products: [] });
+        expect(updateSessionAttributeSpy).toHaveBeenCalledWith(req, PERIOD_EXPIRY_ATTRIBUTE, {
+            errors,
+            products: [{ productName: 'Product A', productEndTime: '2400', productPrice: '1234' }],
+        });
         expect(writeHeadMock).toBeCalledWith(302, {
             Location: '/periodValidity',
         });
@@ -139,7 +145,10 @@ describe('periodValidity', () => {
         });
         periodValidity(req, res);
 
-        expect(updateSessionAttributeSpy).toHaveBeenCalledWith(req, PERIOD_EXPIRY_ATTRIBUTE, { errors, products: [] });
+        expect(updateSessionAttributeSpy).toHaveBeenCalledWith(req, PERIOD_EXPIRY_ATTRIBUTE, {
+            errors,
+            products: [{ productName: 'Product A', productEndTime: 'abcd', productPrice: '1234' }],
+        });
         expect(writeHeadMock).toBeCalledWith(302, {
             Location: '/periodValidity',
         });

--- a/tests/pages/api/periodValidity.test.ts
+++ b/tests/pages/api/periodValidity.test.ts
@@ -2,7 +2,7 @@ import { getMockRequestAndResponse } from '../../testData/mockData';
 import * as sessions from '../../../src/utils/sessions';
 import periodValidity from '../../../src/pages/api/periodValidity';
 import { ErrorInfo, ProductData } from '../../../src/interfaces';
-import { PERIOD_EXPIRY_ATTRIBUTE, SERVICE_LIST_ATTRIBUTE } from '../../../src/constants';
+import { PERIOD_EXPIRY_ATTRIBUTE } from '../../../src/constants';
 
 describe('periodValidity', () => {
     const updateSessionAttributeSpy = jest.spyOn(sessions, 'updateSessionAttribute');
@@ -26,9 +26,6 @@ describe('periodValidity', () => {
         };
 
         const { req, res } = getMockRequestAndResponse({
-            session: {
-                [SERVICE_LIST_ATTRIBUTE]: undefined,
-            },
             body: { periodValid: '24hr' },
             mockWriteHeadFn: writeHeadMock,
         });
@@ -36,6 +33,27 @@ describe('periodValidity', () => {
 
         expect(updateSessionAttributeSpy).toBeCalledWith(req, PERIOD_EXPIRY_ATTRIBUTE, mockProductInfo);
         expect(writeHeadMock).toBeCalledWith(302, { Location: '/ticketConfirmation' });
+    });
+
+    it('correctly generates product info, updates the PERIOD_EXPIRY_ATTRIBUTE with productEndTime empty even if supplied, if end of service day is not selected', () => {
+        const mockProductInfo: ProductData = {
+            products: [
+                {
+                    productName: 'Product A',
+                    productPrice: '1234',
+                    productDuration: '2 days',
+                    productValidity: '24hr',
+                    productEndTime: '',
+                },
+            ],
+        };
+
+        const { req, res } = getMockRequestAndResponse({
+            body: { periodValid: '24hr', productEndTime: '2300' },
+        });
+        periodValidity(req, res);
+
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, PERIOD_EXPIRY_ATTRIBUTE, mockProductInfo);
     });
 
     it('correctly generates period expiry error info, updates the PERIOD_EXPIRY_ATTRIBUTE and then redirects to periodValidity page when there is no period validity info', () => {


### PR DESCRIPTION
# Description

-   Stopped issue occuring where end time is being incorrectly saved.

# Testing instructions

-   Run locally and try to recreate the bug.

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
