### PR TITLE
fix: no passengerType query string on fareConfirmation redirect

### DIFF
--- a/src/pages/fareConfirmation.tsx
+++ b/src/pages/fareConfirmation.tsx
@@ -60,32 +60,33 @@ export const buildFareConfirmationElements = (
 
     if (passengerType.passengerType === 'group' && groupPassengerInfo.length > 0) {
         groupPassengerInfo.forEach(passenger => {
+            const href = `definePassengerType?groupPassengerType=${passenger.passengerType}`;
             if (passenger.ageRangeMin || passenger.ageRangeMax) {
                 confirmationElements.push({
                     name: `${sentenceCaseString(passenger.passengerType)} passenger - age range`,
                     content: `Minimum age: ${passenger.ageRangeMin ? passenger.ageRangeMin : 'N/A'} Maximum age: ${
                         passenger.ageRangeMax ? passenger.ageRangeMax : 'N/A'
                     }`,
-                    href: `definePassengerType?groupPassengerType=${passenger.passengerType}`,
+                    href,
                 });
             } else {
                 confirmationElements.push({
                     name: `${sentenceCaseString(passenger.passengerType)} passenger - age range`,
                     content: 'N/A',
-                    href: `definePassengerType?groupPassengerType=${passenger.passengerType}`,
+                    href,
                 });
             }
             if (passenger.proofDocuments && passenger.proofDocuments.length > 0) {
                 confirmationElements.push({
                     name: `${sentenceCaseString(passenger.passengerType)} passenger - proof documents`,
                     content: passenger.proofDocuments.map(proofDoc => sentenceCaseString(proofDoc)).join(', '),
-                    href: `definePassengerType?groupPassengerType=${passenger.passengerType}`,
+                    href,
                 });
             } else {
                 confirmationElements.push({
                     name: `${sentenceCaseString(passenger.passengerType)} passenger - proof documents`,
                     content: 'N/A',
-                    href: `definePassengerType?groupPassengerType=${passenger.passengerType}`,
+                    href,
                 });
             }
         });

--- a/src/pages/fareConfirmation.tsx
+++ b/src/pages/fareConfirmation.tsx
@@ -66,26 +66,26 @@ export const buildFareConfirmationElements = (
                     content: `Minimum age: ${passenger.ageRangeMin ? passenger.ageRangeMin : 'N/A'} Maximum age: ${
                         passenger.ageRangeMax ? passenger.ageRangeMax : 'N/A'
                     }`,
-                    href: 'definePassengerType',
+                    href: `definePassengerType?groupPassengerType=${passenger.passengerType}`,
                 });
             } else {
                 confirmationElements.push({
                     name: `${sentenceCaseString(passenger.passengerType)} passenger - age range`,
                     content: 'N/A',
-                    href: 'definePassengerType',
+                    href: `definePassengerType?groupPassengerType=${passenger.passengerType}`,
                 });
             }
             if (passenger.proofDocuments && passenger.proofDocuments.length > 0) {
                 confirmationElements.push({
                     name: `${sentenceCaseString(passenger.passengerType)} passenger - proof documents`,
                     content: passenger.proofDocuments.map(proofDoc => sentenceCaseString(proofDoc)).join(', '),
-                    href: 'definePassengerType',
+                    href: `definePassengerType?groupPassengerType=${passenger.passengerType}`,
                 });
             } else {
                 confirmationElements.push({
                     name: `${sentenceCaseString(passenger.passengerType)} passenger - proof documents`,
                     content: 'N/A',
-                    href: 'definePassengerType',
+                    href: `definePassengerType?groupPassengerType=${passenger.passengerType}`,
                 });
             }
         });

--- a/tests/pages/__snapshots__/fareConfirmation.test.tsx.snap
+++ b/tests/pages/__snapshots__/fareConfirmation.test.tsx.snap
@@ -1,6 +1,84 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`pages fareConfirmation should render correctly for non school tickets 1`] = `
+exports[`pages fareConfirmation should render correctly for group tickets 1`] = `
+<Component
+  description="Fare Confirmation page of the Create Fares Data Service"
+  errors={Array []}
+  title="Fare Confirmation - Create Fares Data Service"
+>
+  <CsrfForm
+    action="/api/fareConfirmation"
+    csrfToken=""
+    method="post"
+  >
+    <h1
+      className="govuk-heading-l"
+    >
+      Check your answers before sending your fares information
+    </h1>
+    <ConfirmationTable
+      confirmationElements={
+        Array [
+          Object {
+            "content": "Single",
+            "href": "fareType",
+            "name": "Fare type",
+          },
+          Object {
+            "content": "Group",
+            "href": "passengerType",
+            "name": "Passenger type",
+          },
+          Object {
+            "content": "Minimum age: 16 Maximum age: 65",
+            "href": "definePassengerType?groupPassengerType=adult",
+            "name": "Adult passenger - age range",
+          },
+          Object {
+            "content": "N/A",
+            "href": "definePassengerType?groupPassengerType=adult",
+            "name": "Adult passenger - proof documents",
+          },
+          Object {
+            "content": "Minimum age: 0 Maximum age: 16",
+            "href": "definePassengerType?groupPassengerType=child",
+            "name": "Child passenger - age range",
+          },
+          Object {
+            "content": "Identity document",
+            "href": "definePassengerType?groupPassengerType=child",
+            "name": "Child passenger - proof documents",
+          },
+          Object {
+            "content": "Start time: 0900 End time: 1600",
+            "href": "defineTimeRestrictions",
+            "name": "Time restrictions - Thursday",
+          },
+          Object {
+            "content": "Start time: N/A End time: 1600",
+            "href": "defineTimeRestrictions",
+            "name": "Time restrictions - Friday",
+          },
+          Object {
+            "content": "Start time: N/A End time: N/A",
+            "href": "defineTimeRestrictions",
+            "name": "Time restrictions - Bank holiday",
+          },
+        ]
+      }
+      header="Fare Information"
+    />
+    <input
+      className="govuk-button"
+      id="continue-button"
+      type="submit"
+      value="Continue"
+    />
+  </CsrfForm>
+</Component>
+`;
+
+exports[`pages fareConfirmation should render correctly for non school single tickets 1`] = `
 <Component
   description="Fare Confirmation page of the Create Fares Data Service"
   errors={Array []}

--- a/tests/pages/fareConfirmation.test.tsx
+++ b/tests/pages/fareConfirmation.test.tsx
@@ -4,7 +4,7 @@ import FareConfirmation, { buildFareConfirmationElements } from '../../src/pages
 
 describe('pages', () => {
     describe('fareConfirmation', () => {
-        it('should render correctly for non school tickets', () => {
+        it('should render correctly for non school single tickets', () => {
             const tree = shallow(
                 <FareConfirmation
                     fareType="single"
@@ -17,6 +17,55 @@ describe('pages', () => {
                         proofDocuments: ['membership card'],
                     }}
                     groupPassengerInfo={[]}
+                    schoolFareType=""
+                    termTime=""
+                    fullTimeRestrictions={[
+                        {
+                            day: 'thursday',
+                            startTime: '0900',
+                            endTime: '1600',
+                        },
+                        {
+                            day: 'friday',
+                            startTime: '',
+                            endTime: '1600',
+                        },
+                        {
+                            day: 'bank holiday',
+                            startTime: '',
+                            endTime: '',
+                        },
+                    ]}
+                    csrfToken=""
+                />,
+            );
+            expect(tree).toMatchSnapshot();
+        });
+
+        it('should render correctly for group tickets', () => {
+            const tree = shallow(
+                <FareConfirmation
+                    fareType="single"
+                    passengerType={{
+                        passengerType: 'group',
+                    }}
+                    groupPassengerInfo={[
+                        {
+                            passengerType: 'adult',
+                            minNumber: '1',
+                            maxNumber: '1',
+                            ageRangeMin: '16',
+                            ageRangeMax: '65',
+                        },
+                        {
+                            passengerType: 'child',
+                            minNumber: '1',
+                            maxNumber: '1',
+                            ageRangeMin: '0',
+                            ageRangeMax: '16',
+                            proofDocuments: ['Identity Document'],
+                        },
+                    ]}
                     schoolFareType=""
                     termTime=""
                     fullTimeRestrictions={[


### PR DESCRIPTION
# Description

-   Adds a corresponding passengerType query string to the redirect when users choose to change the passenger type details on the fareConfirmation page

# Testing instructions

-   Run this branch locally
-   Ensure the 'change’ links for passenger type info fields redirect back to the /definePassengerType page with the correct query string parameter

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
