### PR TITLE
fix: product date info inputs not retained

### DIFF
--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -487,6 +487,7 @@ export interface SalesOfferPackageWithErrors extends SalesOfferPackage {
 export interface TicketPeriod {
     startDate?: string;
     endDate?: string;
+    dateInput: ProductDateInformation;
 }
 
 export interface BaseProduct {

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -396,7 +396,7 @@ export interface PassengerDetails {
     email: string;
     uuid: string;
     timeRestriction: FullTimeRestriction[];
-    ticketPeriod: TicketPeriod;
+    ticketPeriod: TicketPeriodWithInput;
     proof?: string[];
 }
 
@@ -487,6 +487,9 @@ export interface SalesOfferPackageWithErrors extends SalesOfferPackage {
 export interface TicketPeriod {
     startDate?: string;
     endDate?: string;
+}
+
+export interface TicketPeriodWithInput extends TicketPeriod {
     dateInput: ProductDateInformation;
 }
 

--- a/src/interfaces/typeGuards.ts
+++ b/src/interfaces/typeGuards.ts
@@ -12,7 +12,8 @@ import {
     TicketRepresentationAttributeWithErrors,
     SalesOfferPackage,
     ProductWithSalesOfferPackages,
-    TicketPeriod,
+    TicketPeriodWithInput,
+    TicketPeriodWithErrors,
     MultiOperatorInfo,
     MultiOperatorInfoWithErrors,
     TermTimeAttribute,
@@ -24,7 +25,6 @@ import {
     FareTypeWithErrors,
     PassengerType,
     PassengerTypeWithErrors,
-    TicketPeriodWithErrors,
     SchoolFareTypeAttribute,
     MultipleOperatorsAttribute,
     MultipleOperatorsAttributeWithErrors,
@@ -154,16 +154,16 @@ export const isSalesOfferPackages = (
     (salesOfferPackageInfo as SalesOfferPackage[])[0].ticketFormats !== undefined;
 
 export const isTicketPeriodAttributeWithErrors = (
-    productDates: TicketPeriod | TicketPeriodWithErrors | undefined,
+    productDates: TicketPeriodWithInput | TicketPeriodWithErrors | undefined,
 ): productDates is TicketPeriodWithErrors =>
     productDates !== undefined && (productDates as TicketPeriodWithErrors).errors !== undefined;
 
-export const isTicketPeriodAttribute = (
-    productDates: TicketPeriod | TicketPeriodWithErrors | undefined,
-): productDates is TicketPeriod =>
+export const isTicketPeriodAttributeWithInput = (
+    productDates: TicketPeriodWithInput | TicketPeriodWithErrors | undefined,
+): productDates is TicketPeriodWithInput =>
     productDates !== undefined &&
-    (productDates as TicketPeriod).startDate !== undefined &&
-    (productDates as TicketPeriod).endDate !== undefined;
+    (productDates as TicketPeriodWithInput).startDate !== undefined &&
+    (productDates as TicketPeriodWithInput).endDate !== undefined;
 
 export const isMultipleOperatorAttributeWithErrors = (
     searchOperator: MultipleOperatorsAttribute | MultipleOperatorsAttributeWithErrors | undefined,

--- a/src/pages/api/apiUtils/userData.ts
+++ b/src/pages/api/apiUtils/userData.ts
@@ -26,6 +26,8 @@ import {
     WithErrors,
     isSchemeOperatorTicket,
     MultipleProductAttribute,
+    TicketPeriod,
+    TicketPeriodWithInput,
 } from '../../../interfaces';
 import {
     TERM_TIME_ATTRIBUTE,
@@ -56,7 +58,7 @@ import {
     isSalesOfferPackages,
     isFareType,
     isPassengerType,
-    isTicketPeriodAttribute,
+    isTicketPeriodAttributeWithInput,
 } from '../../../interfaces/typeGuards';
 
 import { getCsvZoneUploadData, putStringInS3 } from '../../../data/s3';
@@ -115,6 +117,11 @@ export const putUserDataInS3 = async (data: Ticket, uuid: string): Promise<void>
     await putStringInS3(MATCHING_DATA_BUCKET_NAME, filePath, JSON.stringify(s3Data), 'application/json; charset=utf-8');
 };
 
+const getTicketPeriod = (ticketPeriodWithInput: TicketPeriodWithInput): TicketPeriod => ({
+    startDate: ticketPeriodWithInput.startDate,
+    endDate: ticketPeriodWithInput.endDate,
+});
+
 export const getBaseTicketAttributes = (
     req: NextApiRequestWithSession,
     res: NextApiResponse,
@@ -138,7 +145,7 @@ export const getBaseTicketAttributes = (
         !isPassengerType(passengerTypeAttribute) ||
         !idToken ||
         !uuid ||
-        !isTicketPeriodAttribute(ticketPeriodAttribute)
+        !isTicketPeriodAttributeWithInput(ticketPeriodAttribute)
     ) {
         throw new Error(`Could not create ${ticketType} ticket json. BaseTicket attributes could not be found.`);
     }
@@ -159,7 +166,7 @@ export const getBaseTicketAttributes = (
             fullTimeRestriction && fullTimeRestriction.fullTimeRestrictions.length > 0
                 ? fullTimeRestriction.fullTimeRestrictions
                 : [],
-        ticketPeriod: ticketPeriodAttribute,
+        ticketPeriod: getTicketPeriod(ticketPeriodAttribute),
     };
 };
 
@@ -468,7 +475,7 @@ export const getSchemeOperatorTicketJson = async (
         !isPassengerType(passengerTypeAttribute) ||
         !idToken ||
         !uuid ||
-        !isTicketPeriodAttribute(ticketPeriodAttribute) ||
+        !isTicketPeriodAttributeWithInput(ticketPeriodAttribute) ||
         isSalesOfferPackageWithErrors(salesOfferPackages) ||
         !salesOfferPackages ||
         !fareZoneName ||
@@ -534,7 +541,7 @@ export const getSchemeOperatorTicketJson = async (
             fullTimeRestriction && fullTimeRestriction.fullTimeRestrictions.length > 0
                 ? fullTimeRestriction.fullTimeRestrictions
                 : [],
-        ticketPeriod: ticketPeriodAttribute,
+        ticketPeriod: getTicketPeriod(ticketPeriodAttribute),
         products: productDetailsList,
         zoneName: fareZoneName,
         stops: zoneStops,

--- a/src/pages/api/productDateInformation.ts
+++ b/src/pages/api/productDateInformation.ts
@@ -115,22 +115,11 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                 }
             }
 
-            let dateInfo;
-
-            if (startDate && endDate) {
-                dateInfo = {
-                    startDate: startDate.add(1, 'hours').toISOString(),
-                    endDate: endDate.toISOString(),
-                };
-            } else if (!startDate && endDate) {
-                dateInfo = {
-                    endDate: endDate.toISOString(),
-                };
-            } else if (startDate && !endDate) {
-                dateInfo = {
-                    startDate: startDate.add(1, 'hours').toISOString(),
-                };
-            }
+            const dateInfo = {
+                startDate: startDate?.add(1, 'hours').toISOString(),
+                endDate: endDate?.toISOString(),
+                dateInput,
+            };
 
             updateSessionAttribute(req, PRODUCT_DATE_ATTRIBUTE, dateInfo);
 

--- a/src/pages/api/salesConfirmation.ts
+++ b/src/pages/api/salesConfirmation.ts
@@ -47,6 +47,16 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                     : moment()
                           .add(100, 'y')
                           .toISOString(),
+            dateInput: productDating
+                ? productDating.dateInput
+                : {
+                      startDateDay: '',
+                      startDateMonth: '',
+                      startDateYear: '',
+                      endDateDay: '',
+                      endDateMonth: '',
+                      endDateYear: '',
+                  },
         });
 
         const uuid = getUuidFromCookie(req, res);

--- a/src/pages/api/salesConfirmation.ts
+++ b/src/pages/api/salesConfirmation.ts
@@ -26,7 +26,7 @@ import {
     getSchemeOperatorTicketJson,
 } from './apiUtils/userData';
 import { isSessionValid } from './apiUtils/validator';
-import { NextApiRequestWithSession, TicketPeriod } from '../../interfaces';
+import { NextApiRequestWithSession, TicketPeriodWithInput } from '../../interfaces';
 import { getSessionAttribute, updateSessionAttribute } from '../../utils/sessions';
 
 export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
@@ -37,7 +37,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
 
         const fareType = getFareTypeFromFromAttributes(req);
 
-        const productDating = getSessionAttribute(req, PRODUCT_DATE_ATTRIBUTE) as TicketPeriod | undefined;
+        const productDating = getSessionAttribute(req, PRODUCT_DATE_ATTRIBUTE) as TicketPeriodWithInput | undefined;
 
         updateSessionAttribute(req, PRODUCT_DATE_ATTRIBUTE, {
             startDate: productDating && productDating.startDate ? productDating.startDate : moment().toISOString(),

--- a/src/pages/productDateInformation.tsx
+++ b/src/pages/productDateInformation.tsx
@@ -112,9 +112,13 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Pr
         endDateMonth: '',
         endDateYear: '',
     };
-    if (productDateAttribute && isTicketPeriodAttributeWithErrors(productDateAttribute)) {
-        errors = productDateAttribute.errors;
-        dates = productDateAttribute.dates;
+    if (productDateAttribute) {
+        if (isTicketPeriodAttributeWithErrors(productDateAttribute)) {
+            errors = productDateAttribute.errors;
+            dates = productDateAttribute.dates;
+        } else {
+            dates = productDateAttribute.dateInput;
+        }
     }
 
     const fieldsets: RadioConditionalInputFieldset = getFieldsets(errors, dates);

--- a/src/pages/salesConfirmation.tsx
+++ b/src/pages/salesConfirmation.tsx
@@ -140,28 +140,23 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Sa
         startDefault = true;
         endDefault = true;
     } else {
-        dateInput = ticketDatingInfo.dateInput;
-        if (!ticketDatingInfo.startDate || !ticketDatingInfo.endDate) {
-            if (!ticketDatingInfo.startDate) {
-                startDefault = true;
-                startDate = moment()
-                    .add(1, 'hours')
-                    .toISOString();
-            } else {
-                startDate = ticketDatingInfo.startDate;
-            }
-            if (!ticketDatingInfo.endDate) {
-                endDefault = true;
-                endDate = moment()
-                    .add(100, 'y')
-                    .toISOString();
-            } else {
-                endDate = ticketDatingInfo.endDate;
-            }
-        } else {
+        if (ticketDatingInfo.startDate) {
             startDate = ticketDatingInfo.startDate;
-            endDate = ticketDatingInfo.endDate;
+        } else {
+            startDefault = true;
+            startDate = moment()
+                .add(1, 'hours')
+                .toISOString();
         }
+        if (ticketDatingInfo.endDate) {
+            endDate = ticketDatingInfo.endDate;
+        } else {
+            endDefault = true;
+            endDate = moment()
+                .add(100, 'y')
+                .toISOString();
+        }
+        dateInput = ticketDatingInfo.dateInput;
     }
 
     return {

--- a/src/pages/salesConfirmation.tsx
+++ b/src/pages/salesConfirmation.tsx
@@ -6,7 +6,7 @@ import {
     NextPageContextWithSession,
     SalesOfferPackage,
     ProductWithSalesOfferPackages,
-    TicketPeriod,
+    TicketPeriodWithInput,
     ConfirmationElement,
 } from '../interfaces';
 import TwoThirdsLayout from '../layout/Layout';
@@ -27,7 +27,7 @@ interface SalesConfirmationProps {
 }
 
 interface TicketDating {
-    productDates: TicketPeriod;
+    productDates: TicketPeriodWithInput;
     startDefault: boolean;
     endDefault: boolean;
 }

--- a/src/pages/salesConfirmation.tsx
+++ b/src/pages/salesConfirmation.tsx
@@ -119,6 +119,14 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Sa
 
     let startDate = '';
     let endDate = '';
+    let dateInput = {
+        startDateDay: '',
+        startDateMonth: '',
+        startDateYear: '',
+        endDateDay: '',
+        endDateMonth: '',
+        endDateYear: '',
+    };
     let startDefault = false;
     let endDefault = false;
 
@@ -131,26 +139,29 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Sa
             .toISOString();
         startDefault = true;
         endDefault = true;
-    } else if (!ticketDatingInfo.startDate || !ticketDatingInfo.endDate) {
-        if (!ticketDatingInfo.startDate) {
-            startDefault = true;
-            startDate = moment()
-                .add(1, 'hours')
-                .toISOString();
+    } else {
+        dateInput = ticketDatingInfo.dateInput;
+        if (!ticketDatingInfo.startDate || !ticketDatingInfo.endDate) {
+            if (!ticketDatingInfo.startDate) {
+                startDefault = true;
+                startDate = moment()
+                    .add(1, 'hours')
+                    .toISOString();
+            } else {
+                startDate = ticketDatingInfo.startDate;
+            }
+            if (!ticketDatingInfo.endDate) {
+                endDefault = true;
+                endDate = moment()
+                    .add(100, 'y')
+                    .toISOString();
+            } else {
+                endDate = ticketDatingInfo.endDate;
+            }
         } else {
             startDate = ticketDatingInfo.startDate;
-        }
-        if (!ticketDatingInfo.endDate) {
-            endDefault = true;
-            endDate = moment()
-                .add(100, 'y')
-                .toISOString();
-        } else {
             endDate = ticketDatingInfo.endDate;
         }
-    } else {
-        startDate = ticketDatingInfo.startDate;
-        endDate = ticketDatingInfo.endDate;
     }
 
     return {
@@ -160,6 +171,7 @@ export const getServerSideProps = (ctx: NextPageContextWithSession): { props: Sa
                 productDates: {
                     startDate,
                     endDate,
+                    dateInput,
                 },
                 startDefault,
                 endDefault,

--- a/src/utils/sessions.ts
+++ b/src/utils/sessions.ts
@@ -19,7 +19,8 @@ import {
     ProductWithSalesOfferPackages,
     ReturnPeriodValidity,
     MultiOperatorInfo,
-    TicketPeriod,
+    TicketPeriodWithInput,
+    TicketPeriodWithErrors,
     FullTimeRestrictionAttribute,
     TermTimeAttribute,
     WithErrors,
@@ -45,7 +46,6 @@ import {
     PassengerTypeWithErrors,
     PassengerType,
     FaresInformation,
-    TicketPeriodWithErrors,
     SchoolFareTypeAttribute,
     MultipleOperatorsAttribute,
     MultipleOperatorsAttributeWithErrors,
@@ -133,7 +133,7 @@ interface SessionAttributeTypes {
     [TICKET_REPRESENTATION_ATTRIBUTE]: TicketRepresentationAttribute | TicketRepresentationAttributeWithErrors;
     [FARE_STAGES_ATTRIBUTE]: FareStagesAttribute | FareStagesAttributeWithErrors;
     [RETURN_VALIDITY_ATTRIBUTE]: ReturnPeriodValidity | ReturnPeriodValidityWithErrors;
-    [PRODUCT_DATE_ATTRIBUTE]: TicketPeriod | TicketPeriodWithErrors;
+    [PRODUCT_DATE_ATTRIBUTE]: TicketPeriodWithInput | TicketPeriodWithErrors;
     [MULTIPLE_OPERATOR_ATTRIBUTE]: MultipleOperatorsAttribute | MultipleOperatorsAttributeWithErrors;
     [MULTIPLE_OPERATORS_SERVICES_ATTRIBUTE]: MultiOperatorInfo[] | MultiOperatorInfoWithErrors;
     [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: FullTimeRestrictionAttribute;

--- a/tests/pages/api/apiUtils/userData.test.ts
+++ b/tests/pages/api/apiUtils/userData.test.ts
@@ -159,6 +159,14 @@ describe('userData', () => {
                     [PRODUCT_DATE_ATTRIBUTE]: {
                         startDate: '2020-12-17T09:30:46.0Z',
                         endDate: '2020-12-18T09:30:46.0Z',
+                        dateInput: {
+                            startDateDay: '17',
+                            startDateMonth: '12',
+                            startDateYear: '2020',
+                            endDateDay: '18',
+                            endDateMonth: '12',
+                            endDateYear: '2020',
+                        },
                     },
                     [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: mockFullTimeRestrictions,
                     [TERM_TIME_ATTRIBUTE]: { termTime: true },
@@ -187,6 +195,14 @@ describe('userData', () => {
                     [PRODUCT_DATE_ATTRIBUTE]: {
                         startDate: '2020-12-17T09:30:46.0Z',
                         endDate: '2020-12-18T09:30:46.0Z',
+                        dateInput: {
+                            startDateDay: '17',
+                            startDateMonth: '12',
+                            startDateYear: '2020',
+                            endDateDay: '18',
+                            endDateMonth: '12',
+                            endDateYear: '2020',
+                        },
                     },
                     [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: mockFullTimeRestrictions,
                 },
@@ -209,6 +225,14 @@ describe('userData', () => {
                     [PRODUCT_DATE_ATTRIBUTE]: {
                         startDate: '2020-12-17T09:30:46.0Z',
                         endDate: '2020-12-18T09:30:46.0Z',
+                        dateInput: {
+                            startDateDay: '17',
+                            startDateMonth: '12',
+                            startDateYear: '2020',
+                            endDateDay: '18',
+                            endDateMonth: '12',
+                            endDateYear: '2020',
+                        },
                     },
                     [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: mockFullTimeRestrictions,
                 },
@@ -302,6 +326,14 @@ describe('userData', () => {
                     [PRODUCT_DATE_ATTRIBUTE]: {
                         startDate: '2020-12-17T09:30:46.0Z',
                         endDate: '2020-12-18T09:30:46.0Z',
+                        dateInput: {
+                            startDateDay: '17',
+                            startDateMonth: '12',
+                            startDateYear: '2020',
+                            endDateDay: '18',
+                            endDateMonth: '12',
+                            endDateYear: '2020',
+                        },
                     },
                     ...(fareType === 'multiOperator' && {
                         [MULTIPLE_OPERATOR_ATTRIBUTE]: { selectedOperators: mockMultiOpSelectedOperators },
@@ -365,6 +397,14 @@ describe('userData', () => {
                     [PRODUCT_DATE_ATTRIBUTE]: {
                         startDate: '2020-12-17T09:30:46.0Z',
                         endDate: '2020-12-18T09:30:46.0Z',
+                        dateInput: {
+                            startDateDay: '17',
+                            startDateMonth: '12',
+                            startDateYear: '2020',
+                            endDateDay: '18',
+                            endDateMonth: '12',
+                            endDateYear: '2020',
+                        },
                     },
                     [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: mockFullTimeRestrictions,
                 },
@@ -422,6 +462,14 @@ describe('userData', () => {
                     [PRODUCT_DATE_ATTRIBUTE]: {
                         startDate: '2020-12-17T09:30:46.0Z',
                         endDate: '2020-12-18T09:30:46.0Z',
+                        dateInput: {
+                            startDateDay: '17',
+                            startDateMonth: '12',
+                            startDateYear: '2020',
+                            endDateDay: '18',
+                            endDateMonth: '12',
+                            endDateYear: '2020',
+                        },
                     },
                     [MULTIPLE_OPERATORS_SERVICES_ATTRIBUTE]: [
                         {
@@ -473,6 +521,14 @@ describe('userData', () => {
                     [PRODUCT_DATE_ATTRIBUTE]: {
                         startDate: '2020-12-17T09:30:46.0Z',
                         endDate: '2020-12-18T09:30:46.0Z',
+                        dateInput: {
+                            startDateDay: '17',
+                            startDateMonth: '12',
+                            startDateYear: '2020',
+                            endDateDay: '18',
+                            endDateMonth: '12',
+                            endDateYear: '2020',
+                        },
                     },
                 },
             });
@@ -565,6 +621,14 @@ describe('userData', () => {
                     [PRODUCT_DATE_ATTRIBUTE]: {
                         startDate: '2020-12-17T09:30:46.0Z',
                         endDate: '2020-12-18T09:30:46.0Z',
+                        dateInput: {
+                            startDateDay: '17',
+                            startDateMonth: '12',
+                            startDateYear: '2020',
+                            endDateDay: '18',
+                            endDateMonth: '12',
+                            endDateYear: '2020',
+                        },
                     },
                     [MULTIPLE_OPERATOR_ATTRIBUTE]: { selectedOperators: mockMultiOpSelectedOperators },
                     [FULL_TIME_RESTRICTIONS_ATTRIBUTE]: {

--- a/tests/pages/api/productDateInformation.test.ts
+++ b/tests/pages/api/productDateInformation.test.ts
@@ -153,6 +153,14 @@ describe('productDataInformation', () => {
         expect(updateSessionAttributeSpy).toBeCalledWith(req, PRODUCT_DATE_ATTRIBUTE, {
             startDate: expect.any(String),
             endDate: expect.any(String),
+            dateInput: {
+                startDateDay: '12',
+                startDateMonth: '12',
+                startDateYear: '2020',
+                endDateDay: '15',
+                endDateMonth: '12',
+                endDateYear: '2020',
+            },
         });
 
         expect(writeHeadMock).toBeCalledWith(302, {
@@ -203,6 +211,14 @@ describe('productDataInformation', () => {
 
         expect(updateSessionAttributeSpy).toBeCalledWith(req, PRODUCT_DATE_ATTRIBUTE, {
             endDate: expect.any(String),
+            dateInput: {
+                startDateDay: '',
+                startDateMonth: '',
+                startDateYear: '',
+                endDateDay: '04',
+                endDateMonth: '11',
+                endDateYear: '4020',
+            },
         });
 
         expect(writeHeadMock).toBeCalledWith(302, {
@@ -229,6 +245,14 @@ describe('productDataInformation', () => {
 
         expect(updateSessionAttributeSpy).toBeCalledWith(req, PRODUCT_DATE_ATTRIBUTE, {
             startDate: expect.any(String),
+            dateInput: {
+                startDateDay: '06',
+                startDateMonth: '08',
+                startDateYear: '2021',
+                endDateDay: '',
+                endDateMonth: '',
+                endDateYear: '',
+            },
         });
 
         expect(writeHeadMock).toBeCalledWith(302, {

--- a/tests/pages/api/salesConfirmation.test.ts
+++ b/tests/pages/api/salesConfirmation.test.ts
@@ -223,6 +223,14 @@ describe('salesOfferPackages', () => {
             ticketPeriod: {
                 startDate: 'now',
                 endDate: 'a year later',
+                dateInput: {
+                    startDateDay: '',
+                    startDateMonth: '',
+                    startDateYear: '',
+                    endDateDay: '',
+                    endDateMonth: '',
+                    endDateYear: '',
+                },
             },
             operatorShortName: 'string',
             lineName: 'string',

--- a/tests/pages/createdFiles.test.tsx
+++ b/tests/pages/createdFiles.test.tsx
@@ -165,6 +165,14 @@ describe('pages', () => {
                     ticketPeriod: {
                         startDate: '',
                         endDate: '',
+                        dateInput: {
+                            startDateDay: '',
+                            startDateMonth: '',
+                            startDateYear: '',
+                            endDateDay: '',
+                            endDateMonth: '',
+                            endDateYear: '',
+                        },
                     },
                     zoneName: 'The Test Zone',
                     stops: [],
@@ -184,6 +192,14 @@ describe('pages', () => {
                     ticketPeriod: {
                         startDate: '',
                         endDate: '',
+                        dateInput: {
+                            startDateDay: '',
+                            startDateMonth: '',
+                            startDateYear: '',
+                            endDateDay: '',
+                            endDateMonth: '',
+                            endDateYear: '',
+                        },
                     },
                     zoneName: 'The Test Zone',
                     stops: [],

--- a/tests/pages/salesConfirmation.test.tsx
+++ b/tests/pages/salesConfirmation.test.tsx
@@ -26,6 +26,14 @@ describe('pages', () => {
                         productDates: {
                             startDate: '2017-03-13T18:00:00+00:00',
                             endDate: '2057-03-13T18:00:00+00:00',
+                            dateInput: {
+                                startDateDay: '13',
+                                startDateMonth: '03',
+                                startDateYear: '2017',
+                                endDateDay: '13',
+                                endDateMonth: '03',
+                                endDateYear: '2057',
+                            },
                         },
                         endDefault: true,
                         startDefault: true,
@@ -41,15 +49,29 @@ describe('pages', () => {
         const baseExpectedProps = { salesOfferPackages: expect.any(Array), csrfToken: '' };
         const mockStartDate = '2018-12-30T18:00:00+00:00Z';
         const mockEndDate = '2020-12-30T18:00:00+00:00Z';
+        const mockDateInput = {
+            startDateDay: '30',
+            startDateMonth: '12',
+            startDateYear: '2018',
+            endDateDay: '20',
+            endDateMonth: '12',
+            endDateYear: '2020',
+        };
 
         it('should extract the start date and end date from the PRODUCT_DATE_ATTRIBUTE when the user has entered both', () => {
             const ctx = getMockContext({
-                session: { [PRODUCT_DATE_ATTRIBUTE]: { startDate: mockStartDate, endDate: mockEndDate } },
+                session: {
+                    [PRODUCT_DATE_ATTRIBUTE]: {
+                        startDate: mockStartDate,
+                        endDate: mockEndDate,
+                        dateInput: mockDateInput,
+                    },
+                },
             });
             const expectedProps = {
                 ...baseExpectedProps,
                 ticketDating: {
-                    productDates: { startDate: mockStartDate, endDate: mockEndDate },
+                    productDates: { startDate: mockStartDate, endDate: mockEndDate, dateInput: mockDateInput },
                     startDefault: false,
                     endDefault: false,
                 },
@@ -63,7 +85,18 @@ describe('pages', () => {
             const expectedProps = {
                 ...baseExpectedProps,
                 ticketDating: {
-                    productDates: { startDate: expect.any(String), endDate: expect.any(String) },
+                    productDates: {
+                        startDate: expect.any(String),
+                        endDate: expect.any(String),
+                        dateInput: {
+                            startDateDay: '',
+                            startDateMonth: '',
+                            startDateYear: '',
+                            endDateDay: '',
+                            endDateMonth: '',
+                            endDateYear: '',
+                        },
+                    },
                     startDefault: true,
                     endDefault: true,
                 },
@@ -130,6 +163,14 @@ describe('pages', () => {
                         endDate: moment()
                             .add(100, 'years')
                             .toISOString(),
+                        dateInput: {
+                            startDateDay: '',
+                            startDateMonth: '',
+                            startDateYear: '',
+                            endDateDay: '',
+                            endDateMonth: '',
+                            endDateYear: '',
+                        },
                     },
                     endDefault: true,
                     startDefault: true,

--- a/tests/testData/mockData.ts
+++ b/tests/testData/mockData.ts
@@ -1217,6 +1217,14 @@ export const expectedSingleTicket: SingleTicket = {
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
+        dateInput: {
+            startDateDay: '17',
+            startDateMonth: '12',
+            startDateYear: '2020',
+            endDateDay: '18',
+            endDateMonth: '12',
+            endDateYear: '2020',
+        },
     },
     products: [
         {
@@ -1350,6 +1358,14 @@ export const expectedNonCircularReturnTicket: ReturnTicket = {
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
+        dateInput: {
+            startDateDay: '17',
+            startDateMonth: '12',
+            startDateYear: '2020',
+            endDateDay: '18',
+            endDateMonth: '12',
+            endDateYear: '2020',
+        },
     },
     products: [
         {
@@ -1513,6 +1529,14 @@ export const expectedCircularReturnTicket: ReturnTicket = {
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
+        dateInput: {
+            startDateDay: '17',
+            startDateMonth: '12',
+            startDateYear: '2020',
+            endDateDay: '18',
+            endDateMonth: '12',
+            endDateYear: '2020',
+        },
     },
     products: [
         {
@@ -1647,6 +1671,14 @@ export const expectedPeriodGeoZoneTicketWithMultipleProducts: PeriodGeoZoneTicke
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
+        dateInput: {
+            startDateDay: '17',
+            startDateMonth: '12',
+            startDateYear: '2020',
+            endDateDay: '18',
+            endDateMonth: '12',
+            endDateYear: '2020',
+        },
     },
     products: [
         {
@@ -1686,6 +1718,14 @@ export const expectedMultiOperatorGeoZoneTicketWithMultipleProducts: MultiOperat
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
+        dateInput: {
+            startDateDay: '17',
+            startDateMonth: '12',
+            startDateYear: '2020',
+            endDateDay: '18',
+            endDateMonth: '12',
+            endDateYear: '2020',
+        },
     },
     products: [
         {
@@ -1725,6 +1765,14 @@ export const expectedPeriodMultipleServicesTicketWithMultipleProducts: PeriodMul
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
+        dateInput: {
+            startDateDay: '17',
+            startDateMonth: '12',
+            startDateYear: '2020',
+            endDateDay: '18',
+            endDateMonth: '12',
+            endDateYear: '2020',
+        },
     },
     products: [
         {
@@ -1783,6 +1831,14 @@ export const expectedPeriodMultipleServicesTicketWithMultipleProductsAndMultiple
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
+        dateInput: {
+            startDateDay: '17',
+            startDateMonth: '12',
+            startDateYear: '2020',
+            endDateDay: '18',
+            endDateMonth: '12',
+            endDateYear: '2020',
+        },
     },
     products: [
         {
@@ -1911,6 +1967,14 @@ export const expectedFlatFareTicket: FlatFareTicket = {
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
+        dateInput: {
+            startDateDay: '17',
+            startDateMonth: '12',
+            startDateYear: '2020',
+            endDateDay: '18',
+            endDateMonth: '12',
+            endDateYear: '2020',
+        },
     },
     products: [
         {
@@ -1956,6 +2020,14 @@ export const expectedSchemeOperatorTicket: SchemeOperatorTicket = {
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
+        dateInput: {
+            startDateDay: '17',
+            startDateMonth: '12',
+            startDateYear: '2020',
+            endDateDay: '18',
+            endDateMonth: '12',
+            endDateYear: '2020',
+        },
     },
     products: [
         {

--- a/tests/testData/mockData.ts
+++ b/tests/testData/mockData.ts
@@ -1217,14 +1217,6 @@ export const expectedSingleTicket: SingleTicket = {
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
-        dateInput: {
-            startDateDay: '17',
-            startDateMonth: '12',
-            startDateYear: '2020',
-            endDateDay: '18',
-            endDateMonth: '12',
-            endDateYear: '2020',
-        },
     },
     products: [
         {
@@ -1358,14 +1350,6 @@ export const expectedNonCircularReturnTicket: ReturnTicket = {
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
-        dateInput: {
-            startDateDay: '17',
-            startDateMonth: '12',
-            startDateYear: '2020',
-            endDateDay: '18',
-            endDateMonth: '12',
-            endDateYear: '2020',
-        },
     },
     products: [
         {
@@ -1529,14 +1513,6 @@ export const expectedCircularReturnTicket: ReturnTicket = {
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
-        dateInput: {
-            startDateDay: '17',
-            startDateMonth: '12',
-            startDateYear: '2020',
-            endDateDay: '18',
-            endDateMonth: '12',
-            endDateYear: '2020',
-        },
     },
     products: [
         {
@@ -1671,14 +1647,6 @@ export const expectedPeriodGeoZoneTicketWithMultipleProducts: PeriodGeoZoneTicke
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
-        dateInput: {
-            startDateDay: '17',
-            startDateMonth: '12',
-            startDateYear: '2020',
-            endDateDay: '18',
-            endDateMonth: '12',
-            endDateYear: '2020',
-        },
     },
     products: [
         {
@@ -1718,14 +1686,6 @@ export const expectedMultiOperatorGeoZoneTicketWithMultipleProducts: MultiOperat
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
-        dateInput: {
-            startDateDay: '17',
-            startDateMonth: '12',
-            startDateYear: '2020',
-            endDateDay: '18',
-            endDateMonth: '12',
-            endDateYear: '2020',
-        },
     },
     products: [
         {
@@ -1765,14 +1725,6 @@ export const expectedPeriodMultipleServicesTicketWithMultipleProducts: PeriodMul
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
-        dateInput: {
-            startDateDay: '17',
-            startDateMonth: '12',
-            startDateYear: '2020',
-            endDateDay: '18',
-            endDateMonth: '12',
-            endDateYear: '2020',
-        },
     },
     products: [
         {
@@ -1831,14 +1783,6 @@ export const expectedPeriodMultipleServicesTicketWithMultipleProductsAndMultiple
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
-        dateInput: {
-            startDateDay: '17',
-            startDateMonth: '12',
-            startDateYear: '2020',
-            endDateDay: '18',
-            endDateMonth: '12',
-            endDateYear: '2020',
-        },
     },
     products: [
         {
@@ -1967,14 +1911,6 @@ export const expectedFlatFareTicket: FlatFareTicket = {
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
-        dateInput: {
-            startDateDay: '17',
-            startDateMonth: '12',
-            startDateYear: '2020',
-            endDateDay: '18',
-            endDateMonth: '12',
-            endDateYear: '2020',
-        },
     },
     products: [
         {
@@ -2020,14 +1956,6 @@ export const expectedSchemeOperatorTicket: SchemeOperatorTicket = {
     ticketPeriod: {
         startDate: '2020-12-17T09:30:46.0Z',
         endDate: '2020-12-18T09:30:46.0Z',
-        dateInput: {
-            startDateDay: '17',
-            startDateMonth: '12',
-            startDateYear: '2020',
-            endDateDay: '18',
-            endDateMonth: '12',
-            endDateYear: '2020',
-        },
     },
     products: [
         {


### PR DESCRIPTION
# Description

-   Fixes issue where product date inputs were not retained upon re-navigation to the productDateInformation page.

# Testing instructions

-   Run this branch locally and assure that the productDateInformation inputs are pre-populated with previous inputs when navigated back to.

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
