### PR TITLE
fix: passenger type definition persisted when no selected

### DIFF
--- a/src/pages/api/definePassengerType.ts
+++ b/src/pages/api/definePassengerType.ts
@@ -20,6 +20,7 @@ import {
     GroupPassengerTypesCollection,
 } from '../../interfaces';
 import { getSessionAttribute, updateSessionAttribute } from '../../utils/sessions';
+import { removeAllWhiteSpace } from './apiUtils/validator';
 
 interface FilteredRequestBody {
     minNumber?: string;
@@ -146,7 +147,7 @@ export const formatRequestBody = (req: NextApiRequestWithSession): FilteredReque
     Object.entries(req.body).forEach(entry => {
         if (entry[0] === 'minNumber' || entry[0] === 'maxNumber') {
             const input = entry[1] as string;
-            const strippedInput = input.replace(/\s+/g, '');
+            const strippedInput = removeAllWhiteSpace(input);
             if (strippedInput === '') {
                 return;
             }
@@ -154,22 +155,20 @@ export const formatRequestBody = (req: NextApiRequestWithSession): FilteredReque
             return;
         }
         if (entry[0] === 'ageRangeMin' || entry[0] === 'ageRangeMax') {
-            if (req.body.ageRange === 'No') {
-                return;
+            if (req.body.ageRange === 'Yes') {
+                const input = entry[1] as string;
+                const strippedInput = removeAllWhiteSpace(input);
+                if (strippedInput === '') {
+                    return;
+                }
+                filteredReqBody[entry[0]] = strippedInput;
             }
-            const input = entry[1] as string;
-            const strippedInput = input.replace(/\s+/g, '');
-            if (strippedInput === '') {
-                return;
-            }
-            filteredReqBody[entry[0]] = strippedInput;
             return;
         }
         if (entry[0] === 'proofDocuments') {
-            if (req.body.proof === 'No') {
-                return;
+            if (req.body.proof === 'Yes') {
+                filteredReqBody[entry[0]] = !isArray(entry[1]) ? [entry[1] as string] : (entry[1] as string[]);
             }
-            filteredReqBody[entry[0]] = !isArray(entry[1]) ? [entry[1] as string] : (entry[1] as string[]);
             return;
         }
         filteredReqBody[entry[0]] = entry[1] as string;

--- a/src/pages/api/definePassengerType.ts
+++ b/src/pages/api/definePassengerType.ts
@@ -144,12 +144,19 @@ export const passengerTypeDetailsSchema = yup
 export const formatRequestBody = (req: NextApiRequestWithSession): FilteredRequestBody => {
     const filteredReqBody: { [key: string]: string | string[] } = {};
     Object.entries(req.body).forEach(entry => {
-        if (
-            entry[0] === 'ageRangeMin' ||
-            entry[0] === 'ageRangeMax' ||
-            entry[0] === 'minNumber' ||
-            entry[0] === 'maxNumber'
-        ) {
+        if (entry[0] === 'minNumber' || entry[0] === 'maxNumber') {
+            const input = entry[1] as string;
+            const strippedInput = input.replace(/\s+/g, '');
+            if (strippedInput === '') {
+                return;
+            }
+            filteredReqBody[entry[0]] = strippedInput;
+            return;
+        }
+        if (entry[0] === 'ageRangeMin' || entry[0] === 'ageRangeMax') {
+            if (req.body.ageRange === 'No') {
+                return;
+            }
             const input = entry[1] as string;
             const strippedInput = input.replace(/\s+/g, '');
             if (strippedInput === '') {
@@ -159,6 +166,9 @@ export const formatRequestBody = (req: NextApiRequestWithSession): FilteredReque
             return;
         }
         if (entry[0] === 'proofDocuments') {
+            if (req.body.proof === 'No') {
+                return;
+            }
             filteredReqBody[entry[0]] = !isArray(entry[1]) ? [entry[1] as string] : (entry[1] as string[]);
             return;
         }

--- a/tests/pages/api/definePassengerType.test.ts
+++ b/tests/pages/api/definePassengerType.test.ts
@@ -150,6 +150,36 @@ describe('definePassengerType', () => {
             const filtered = formatRequestBody(req);
             expect(filtered).toEqual({ proofDocuments: ['membershipCard'], ...reqBodyParams });
         });
+
+        it('should remove age ranges when No is selected for ageRange', () => {
+            const reqBodyParams = { ageRange: 'No', proof: 'Yes' };
+            const { req } = getMockRequestAndResponse({
+                cookieValues: {},
+                body: {
+                    ageRangeMin: '16',
+                    ageRangeMax: '65',
+                    proofDocuments: 'membershipCard',
+                    ...reqBodyParams,
+                },
+            });
+            const filtered = formatRequestBody(req);
+            expect(filtered).toEqual({ proofDocuments: ['membershipCard'], ...reqBodyParams });
+        });
+
+        it('should remove proof documents when No is selected for proof', () => {
+            const reqBodyParams = { ageRange: 'Yes', proof: 'No' };
+            const { req } = getMockRequestAndResponse({
+                cookieValues: {},
+                body: {
+                    ageRangeMin: '16',
+                    ageRangeMax: '65',
+                    proofDocuments: 'membershipCard',
+                    ...reqBodyParams,
+                },
+            });
+            const filtered = formatRequestBody(req);
+            expect(filtered).toEqual({ ageRangeMin: '16', ageRangeMax: '65', ...reqBodyParams });
+        });
     });
 
     describe('getErrorIdFromValidityError', () => {


### PR DESCRIPTION
# Description

-   Prevents passenger type definitions (age ranges + proof documents) from being persisted when the user subsequently selects 'No' for each.

# Testing instructions

-   Test locally that age ranges and proof documents are not persisted when no is selected for their respective conditional radio inputs (check the fareConfirmation

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
