### PR TITLE
fix: Removing ui tests being run as part of pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,21 +17,6 @@ jobs:
           paths:
             - "*"
 
-  run-ui-tests:
-    docker:
-      - image: circleci/openjdk:13-jdk-buster
-    executor: aws-cli/default
-    steps:
-      - aws-cli/setup:
-          profile-name: default
-      - run:
-          command: |
-            git clone https://github.com/fares-data-build-tool/fdbt-ui-automation.git
-            cd fdbt-ui-automation
-
-            ./ci_scripts/run_tests_in_browserstack.sh
-          no_output_timeout: 40m
-
   build-site:
     docker:
       - image: circleci/node:12
@@ -145,14 +130,6 @@ workflows:
           container-image-name-updates: "container=${SITE_ECS_FAMILY},tag=${CIRCLE_SHA1}"
           context: tfn-fdbt-test
           verify-revision-is-deployed: true
-          filters:
-            branches:
-              only: develop
-
-      - run-ui-tests:
-          requires:
-            - deploy-site-to-test
-          context: tfn-fdbt-automation-test
           filters:
             branches:
               only: develop


### PR DESCRIPTION
# Description

-   As we are moving away from Selenium, we can stop the UI tests running in the pipeline until they are rewritten.

# Testing instructions

-   n/a

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [ ] Able to run pr locally
-   [ ] Followed acceptance criteria
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
