### PR TITLE
feat: TXC data changer for Single & Return

### DIFF
--- a/src/components/SwitchDataSource.tsx
+++ b/src/components/SwitchDataSource.tsx
@@ -1,0 +1,32 @@
+import React, { ReactElement } from 'react';
+import { TxcSourceAttribute } from '../interfaces';
+import CsrfForm from './CsrfForm';
+
+interface SwitchDataSourceProps {
+    dataSourceAttribute: TxcSourceAttribute;
+    pageUrl: string;
+    csrfToken: string;
+}
+
+const SwitchDataSource = ({ dataSourceAttribute, pageUrl, csrfToken }: SwitchDataSourceProps): ReactElement => {
+    const { hasBods, hasTnds, source } = dataSourceAttribute;
+    const buttonDisabled = (source === 'bods' && !hasTnds) || (source === 'tnds' && !hasBods);
+
+    return (
+        <CsrfForm action="/api/switchDataSource" method="post" csrfToken={csrfToken}>
+            <>
+                <input type="hidden" name="referer" value={pageUrl} />
+                <button
+                    id="change-data-source"
+                    type="submit"
+                    className="govuk-button govuk-button--secondary"
+                    disabled={buttonDisabled}
+                >
+                    Change TransXChange datasource to {source === 'bods' ? 'TNDS' : 'BODS'}
+                </button>
+            </>
+        </CsrfForm>
+    );
+};
+
+export default SwitchDataSource;

--- a/src/constants/attributes.ts
+++ b/src/constants/attributes.ts
@@ -77,3 +77,5 @@ export const FORGOT_PASSWORD_ATTRIBUTE = 'fdbt-reset-password';
 export const USER_ATTRIBUTE = 'fdbt-user';
 
 export const OPERATOR_ATTRIBUTE = 'fdbt-operator';
+
+export const TXC_SOURCE_ATTRIBUTE = 'fdbt-txc-source';

--- a/src/data/auroradb.ts
+++ b/src/data/auroradb.ts
@@ -146,7 +146,7 @@ export const getAllServicesByNocCode = async (nocCode: string): Promise<ServiceT
 
     try {
         const queryInput = `
-            SELECT lineName, startDate, serviceDescription AS description, serviceCode
+            SELECT lineName, startDate, serviceDescription AS description, serviceCode, dataSource
             FROM txcOperatorLine
             WHERE nocCode = ?
             ORDER BY CAST(lineName AS UNSIGNED) = 0, CAST(lineName AS UNSIGNED), LEFT(lineName, 1), MID(lineName, 2), startDate;
@@ -160,6 +160,7 @@ export const getAllServicesByNocCode = async (nocCode: string): Promise<ServiceT
                 startDate: convertDateFormat(item.startDate),
                 description: item.description,
                 serviceCode: item.serviceCode,
+                dataSource: item.dataSource,
             })) || []
         );
     } catch (error) {

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -763,3 +763,9 @@ export interface OperatorAttribute {
 export interface ForgotPasswordAttribute {
     email: string;
 }
+
+export interface TxcSourceAttribute {
+    source: 'tnds' | 'bods';
+    hasTnds: boolean;
+    hasBods: boolean;
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -662,6 +662,7 @@ export interface ServiceType {
     startDate: string;
     description: string;
     serviceCode: string;
+    dataSource?: string;
 }
 
 export interface ServicesInfo extends ServiceType {

--- a/src/pages/api/register.ts
+++ b/src/pages/api/register.ts
@@ -7,7 +7,7 @@ import logger from '../../utils/logger';
 import { getAllServicesByNocCode } from '../../data/auroradb';
 import { updateSessionAttribute } from '../../utils/sessions';
 
-export const operatorHasServices = async (nocs: string[]): Promise<string[]> => {
+export const nocsWithNoServices = async (nocs: string[]): Promise<string[]> => {
     const servicesFoundPromise = nocs.map((noc: string) => getAllServicesByNocCode(noc));
 
     const servicesFound = await Promise.all(servicesFoundPromise);
@@ -74,7 +74,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                 }
 
                 const isSchemeOperator = !!parameters['custom:schemeOperator'];
-                const nocsWithNoTnds = await operatorHasServices(cognitoNocs);
+                const nocsWithNoTnds = await nocsWithNoServices(cognitoNocs);
 
                 if (!isSchemeOperator && !(nocsWithNoTnds.length < cognitoNocs.length)) {
                     logger.warn('', {

--- a/src/pages/api/register.ts
+++ b/src/pages/api/register.ts
@@ -8,7 +8,7 @@ import { getServicesByNocCode } from '../../data/auroradb';
 import { updateSessionAttribute } from '../../utils/sessions';
 
 export const operatorHasTndsData = async (nocs: string[]): Promise<string[]> => {
-    const servicesFoundPromise = nocs.map((noc: string) => getServicesByNocCode(noc));
+    const servicesFoundPromise = nocs.map((noc: string) => getServicesByNocCode(noc, 'tnds'));
 
     const servicesFound = await Promise.all(servicesFoundPromise);
 
@@ -22,6 +22,23 @@ export const operatorHasTndsData = async (nocs: string[]): Promise<string[]> => 
         .filter(noc => noc);
 
     return nocsWithNoTnds;
+};
+
+export const operatorHasBodsData = async (nocs: string[]): Promise<string[]> => {
+    const servicesFoundPromise = nocs.map((noc: string) => getServicesByNocCode(noc, 'bods'));
+
+    const servicesFound = await Promise.all(servicesFoundPromise);
+
+    const nocsWithNoBods = nocs
+        .map((noc, index) => {
+            if (servicesFound[index].length === 0) {
+                return noc;
+            }
+            return '';
+        })
+        .filter(noc => noc);
+
+    return nocsWithNoBods;
 };
 
 export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {

--- a/src/pages/api/service.ts
+++ b/src/pages/api/service.ts
@@ -1,6 +1,6 @@
 import { NextApiResponse } from 'next';
-import { getUuidFromSession, redirectToError, redirectTo } from './apiUtils/index';
 import { FARE_TYPE_ATTRIBUTE, SERVICE_ATTRIBUTE } from '../../constants/attributes';
+import { getUuidFromSession, redirectToError, redirectTo } from './apiUtils/index';
 import { getSessionAttribute, updateSessionAttribute } from '../../utils/sessions';
 import { isFareType } from '../../interfaces/typeGuards';
 import { ErrorInfo, NextApiRequestWithSession } from '../../interfaces';
@@ -11,7 +11,6 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
 
         if (!service) {
             const errors: ErrorInfo[] = [{ id: 'service', errorMessage: 'Choose a service from the options' }];
-
             updateSessionAttribute(req, SERVICE_ATTRIBUTE, { errors });
             redirectTo(res, '/service');
             return;

--- a/src/pages/api/switchDataSource.ts
+++ b/src/pages/api/switchDataSource.ts
@@ -1,0 +1,23 @@
+import { NextApiResponse } from 'next';
+import { getSessionAttribute, updateSessionAttribute } from '../../utils/sessions';
+import { TXC_SOURCE_ATTRIBUTE } from '../../constants/attributes';
+import { redirectToError, redirectTo } from './apiUtils/index';
+import { NextApiRequestWithSession } from '../../interfaces';
+
+export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
+    try {
+        const { referer } = req.body;
+        const dataSource = getSessionAttribute(req, TXC_SOURCE_ATTRIBUTE);
+
+        if (!dataSource) {
+            throw new Error('Datasource has been incorrectly set and is neither TNDS nor BODS');
+        }
+
+        const newDataSource = dataSource.source === 'bods' ? 'tnds' : 'bods';
+        updateSessionAttribute(req, TXC_SOURCE_ATTRIBUTE, { ...dataSource, source: newDataSource });
+        redirectTo(res, referer);
+    } catch (error) {
+        const message = 'There was a problem switching the TXC datasource:';
+        redirectToError(res, message, 'api.switchDataSource', error);
+    }
+};

--- a/src/pages/fareType.tsx
+++ b/src/pages/fareType.tsx
@@ -18,7 +18,7 @@ import { getAndValidateNoc, getCsrfToken, isSchemeOperator } from '../utils/inde
 import logger from '../utils/logger';
 import { getSessionAttribute, updateSessionAttribute } from '../utils/sessions';
 import { redirectTo } from './api/apiUtils';
-import { getServicesByNocCode } from '../data/auroradb';
+import { getServicesByNocCodeAndDataSource } from '../data/auroradb';
 
 const title = 'Fare Type - Create Fares Data Service ';
 const description = 'Fare Type selection page of the Create Fares Data Service';
@@ -105,8 +105,8 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     const schemeOp = isSchemeOperator(ctx);
     const nocCode = getAndValidateNoc(ctx);
 
-    const bodsServices = await getServicesByNocCode(nocCode, 'bods');
-    const tndsServices = await getServicesByNocCode(nocCode, 'tnds');
+    const bodsServices = await getServicesByNocCodeAndDataSource(nocCode, 'bods');
+    const tndsServices = await getServicesByNocCodeAndDataSource(nocCode, 'tnds');
 
     if (!schemeOp && bodsServices.length === 0 && tndsServices.length === 0) {
         if (ctx.res) {

--- a/src/pages/fareType.tsx
+++ b/src/pages/fareType.tsx
@@ -2,7 +2,12 @@ import React, { ReactElement } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import TwoThirdsLayout from '../layout/Layout';
 import { INTERNAL_NOC } from '../constants';
-import { FARE_TYPE_ATTRIBUTE, OPERATOR_ATTRIBUTE, TICKET_REPRESENTATION_ATTRIBUTE } from '../constants/attributes';
+import {
+    FARE_TYPE_ATTRIBUTE,
+    OPERATOR_ATTRIBUTE,
+    TICKET_REPRESENTATION_ATTRIBUTE,
+    TXC_SOURCE_ATTRIBUTE,
+} from '../constants/attributes';
 import { ErrorInfo, NextPageContextWithSession, FareTypeRadioProps } from '../interfaces';
 import { isFareTypeAttributeWithErrors } from '../interfaces/typeGuards';
 import CsrfForm from '../components/CsrfForm';
@@ -98,32 +103,41 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     const csrfToken = getCsrfToken(ctx);
 
     const schemeOp = isSchemeOperator(ctx);
-    const opIdentifier = getAndValidateNoc(ctx);
+    const nocCode = getAndValidateNoc(ctx);
 
-    const services = await getServicesByNocCode(opIdentifier);
+    const bodsServices = await getServicesByNocCode(nocCode, 'bods');
+    const tndsServices = await getServicesByNocCode(nocCode, 'tnds');
 
-    if (!schemeOp && services.length === 0) {
+    if (!schemeOp && bodsServices.length === 0 && tndsServices.length === 0) {
         if (ctx.res) {
             redirectTo(ctx.res, '/noServices');
         } else {
-            throw new Error(`No services found for NOC Code: ${opIdentifier}`);
+            throw new Error(`No services found for NOC Code: ${nocCode}`);
         }
+    }
+    const dataSouceAttribute = getSessionAttribute(ctx.req, TXC_SOURCE_ATTRIBUTE);
+    if (!dataSouceAttribute) {
+        updateSessionAttribute(ctx.req, TXC_SOURCE_ATTRIBUTE, {
+            source: bodsServices.length > 0 && tndsServices.length === 0 ? 'bods' : 'tnds',
+            hasBods: bodsServices.length > 0,
+            hasTnds: tndsServices.length > 0,
+        });
     }
 
     const operatorAttribute = getSessionAttribute(ctx.req, OPERATOR_ATTRIBUTE);
 
-    if (!operatorAttribute || !opIdentifier) {
+    if (!operatorAttribute || !nocCode) {
         throw new Error('Could not extract the necessary operator info for the fareType page.');
     }
     const operatorName = operatorAttribute.name || '';
-    const uuid = buildUuid(opIdentifier);
+    const uuid = buildUuid(nocCode);
 
     updateSessionAttribute(ctx.req, OPERATOR_ATTRIBUTE, {
         ...operatorAttribute,
         uuid,
     });
 
-    if (schemeOp || opIdentifier !== INTERNAL_NOC) {
+    if (schemeOp || nocCode !== INTERNAL_NOC) {
         logger.info('', {
             context: 'pages.fareType',
             message: 'transaction start',

--- a/src/pages/inboundMatching.tsx
+++ b/src/pages/inboundMatching.tsx
@@ -4,12 +4,13 @@ import {
     JOURNEY_ATTRIBUTE,
     INBOUND_MATCHING_ATTRIBUTE,
     OPERATOR_ATTRIBUTE,
+    TXC_SOURCE_ATTRIBUTE,
 } from '../constants/attributes';
-import { getServiceByNocCodeAndLineName, batchGetStopsByAtcoCode } from '../data/auroradb';
+import { getServiceByNocCodeLineNameAndDataSource, batchGetStopsByAtcoCode } from '../data/auroradb';
 import { getUserFareStages } from '../data/s3';
 import { getJourneysByStartAndEndPoint, getMasterStopList } from '../utils/dataTransform';
 import MatchingBase from '../components/MatchingBase';
-import { BasicService, NextPageContextWithSession, Stop, UserFareStages } from '../interfaces';
+import { BasicService, NextPageContextWithSession, Stop, UserFareStages, TxcSourceAttribute } from '../interfaces';
 import { getAndValidateNoc, getCsrfToken } from '../utils';
 import { getSessionAttribute } from '../utils/sessions';
 import { InboundMatchingInfo, MatchingWithErrors } from '../interfaces/matchingInterface';
@@ -73,7 +74,8 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     const lineName = serviceAttribute.service.split('#')[0];
     const [selectedStartPoint, selectedEndPoint] =
         (journeyAttribute && journeyAttribute.inboundJourney && journeyAttribute.inboundJourney.split('#')) || [];
-    const service = await getServiceByNocCodeAndLineName(nocCode, lineName);
+    const dataSource = (getSessionAttribute(ctx.req, TXC_SOURCE_ATTRIBUTE) as TxcSourceAttribute).source;
+    const service = await getServiceByNocCodeLineNameAndDataSource(nocCode, lineName, dataSource);
     const userFareStages = await getUserFareStages(operatorAttribute.uuid);
     const relevantJourneys = getJourneysByStartAndEndPoint(service, selectedStartPoint, selectedEndPoint);
     const masterStopList = getMasterStopList(relevantJourneys);

--- a/src/pages/matching.tsx
+++ b/src/pages/matching.tsx
@@ -1,7 +1,13 @@
 import React, { ReactElement } from 'react';
-import { OPERATOR_ATTRIBUTE, SERVICE_ATTRIBUTE, JOURNEY_ATTRIBUTE, MATCHING_ATTRIBUTE } from '../constants/attributes';
-import { getServiceByNocCodeAndLineName, batchGetStopsByAtcoCode } from '../data/auroradb';
-import { BasicService, NextPageContextWithSession, Stop, UserFareStages } from '../interfaces';
+import {
+    OPERATOR_ATTRIBUTE,
+    SERVICE_ATTRIBUTE,
+    JOURNEY_ATTRIBUTE,
+    MATCHING_ATTRIBUTE,
+    TXC_SOURCE_ATTRIBUTE,
+} from '../constants/attributes';
+import { getServiceByNocCodeLineNameAndDataSource, batchGetStopsByAtcoCode } from '../data/auroradb';
+import { BasicService, NextPageContextWithSession, Stop, UserFareStages, TxcSourceAttribute } from '../interfaces';
 import { getUserFareStages } from '../data/s3';
 import MatchingBase from '../components/MatchingBase';
 import { getAndValidateNoc, getCsrfToken } from '../utils';
@@ -72,8 +78,8 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
             journeyAttribute.directionJourneyPattern &&
             journeyAttribute.directionJourneyPattern.split('#')) ||
         [];
-
-    const service = await getServiceByNocCodeAndLineName(nocCode, lineName);
+    const dataSource = (getSessionAttribute(ctx.req, TXC_SOURCE_ATTRIBUTE) as TxcSourceAttribute).source;
+    const service = await getServiceByNocCodeLineNameAndDataSource(nocCode, lineName, dataSource);
     const userFareStages = await getUserFareStages(operatorAttribute.uuid);
     const relevantJourneys = getJourneysByStartAndEndPoint(service, selectedStartPoint, selectedEndPoint);
     const masterStopList = getMasterStopList(relevantJourneys);

--- a/src/pages/multipleOperatorsServiceList.tsx
+++ b/src/pages/multipleOperatorsServiceList.tsx
@@ -5,7 +5,7 @@ import { isMultiOperatorInfoWithErrors } from '../interfaces/typeGuards';
 import ErrorSummary from '../components/ErrorSummary';
 import FormElementWrapper from '../components/FormElementWrapper';
 import { FullColumnLayout } from '../layout/Layout';
-import { getServicesByNocCode } from '../data/auroradb';
+import { getServicesByNocCodeAndDataSource } from '../data/auroradb';
 import {
     ErrorInfo,
     NextPageContextWithSession,
@@ -144,7 +144,7 @@ export const getServerSideProps = async (
         throw new Error('Necessary operator not found to show multipleOperatorsServiceList page');
     }
 
-    const services = await getServicesByNocCode(operatorToUse.nocCode, 'tnds');
+    const services = await getServicesByNocCodeAndDataSource(operatorToUse.nocCode, 'tnds');
 
     if (!services) {
         throw new Error(`No services found for ${operatorToUse.nocCode}`);

--- a/src/pages/multipleOperatorsServiceList.tsx
+++ b/src/pages/multipleOperatorsServiceList.tsx
@@ -144,7 +144,7 @@ export const getServerSideProps = async (
         throw new Error('Necessary operator not found to show multipleOperatorsServiceList page');
     }
 
-    const services = await getServicesByNocCode(operatorToUse.nocCode);
+    const services = await getServicesByNocCode(operatorToUse.nocCode, 'tnds');
 
     if (!services) {
         throw new Error(`No services found for ${operatorToUse.nocCode}`);

--- a/src/pages/noServices.tsx
+++ b/src/pages/noServices.tsx
@@ -10,11 +10,12 @@ const NoServices = (): ReactElement => (
             Sorry, there is no service data available for your National Operator Code (NOC)
         </h1>
         <p className="govuk-body-m">
-            This service utilises the Traveline National Dataset (TNDS) to obtain operators&apos; service data in order
-            to help them create fares data.
+            This service utilises the Traveline National Dataset (TNDS) and the Bus Open Data Service (BODS) to obtain
+            operators&apos; service data in order to help them create fares data.
         </p>
         <p className="govuk-body-m">
-            It appears there is no service data for this operator in the Traveline National Dataset.
+            It appears there is no service data for this operator in the Traveline National Dataset or in the Bus Open
+            Data Service.
         </p>
         <p className="govuk-body-m">You will not be able to continue creating fares data without this.</p>
         <p className="govuk-body-m">

--- a/src/pages/outboundMatching.tsx
+++ b/src/pages/outboundMatching.tsx
@@ -1,10 +1,16 @@
 import React, { ReactElement } from 'react';
-import { batchGetStopsByAtcoCode, getServiceByNocCodeAndLineName } from '../data/auroradb';
-import { JOURNEY_ATTRIBUTE, MATCHING_ATTRIBUTE, OPERATOR_ATTRIBUTE, SERVICE_ATTRIBUTE } from '../constants/attributes';
+import { batchGetStopsByAtcoCode, getServiceByNocCodeLineNameAndDataSource } from '../data/auroradb';
+import {
+    JOURNEY_ATTRIBUTE,
+    MATCHING_ATTRIBUTE,
+    OPERATOR_ATTRIBUTE,
+    SERVICE_ATTRIBUTE,
+    TXC_SOURCE_ATTRIBUTE,
+} from '../constants/attributes';
 import { getUserFareStages } from '../data/s3';
 import { getJourneysByStartAndEndPoint, getMasterStopList } from '../utils/dataTransform';
 import MatchingBase from '../components/MatchingBase';
-import { BasicService, NextPageContextWithSession, Stop, UserFareStages } from '../interfaces';
+import { BasicService, NextPageContextWithSession, Stop, UserFareStages, TxcSourceAttribute } from '../interfaces';
 import { getAndValidateNoc, getCsrfToken } from '../utils';
 import { getSessionAttribute } from '../utils/sessions';
 import { isMatchingWithErrors } from './matching';
@@ -65,8 +71,8 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     const lineName = serviceAttribute.service.split('#')[0];
     const [selectedStartPoint, selectedEndPoint] =
         (journeyAttribute && journeyAttribute.outboundJourney && journeyAttribute.outboundJourney.split('#')) || [];
-
-    const service = await getServiceByNocCodeAndLineName(nocCode, lineName);
+    const dataSource = (getSessionAttribute(ctx.req, TXC_SOURCE_ATTRIBUTE) as TxcSourceAttribute).source;
+    const service = await getServiceByNocCodeLineNameAndDataSource(nocCode, lineName, dataSource);
     const userFareStages = await getUserFareStages(operatorAttribute.uuid);
     const relevantJourneys = getJourneysByStartAndEndPoint(service, selectedStartPoint, selectedEndPoint);
     const masterStopList = getMasterStopList(relevantJourneys);

--- a/src/pages/returnDirection.tsx
+++ b/src/pages/returnDirection.tsx
@@ -1,10 +1,15 @@
 import React, { ReactElement } from 'react';
 import TwoThirdsLayout from '../layout/Layout';
-import { FARE_TYPE_ATTRIBUTE, JOURNEY_ATTRIBUTE, SERVICE_ATTRIBUTE } from '../constants/attributes';
-import { getServiceByNocCodeAndLineName } from '../data/auroradb';
+import {
+    FARE_TYPE_ATTRIBUTE,
+    JOURNEY_ATTRIBUTE,
+    SERVICE_ATTRIBUTE,
+    TXC_SOURCE_ATTRIBUTE,
+} from '../constants/attributes';
+import { getServiceByNocCodeLineNameAndDataSource } from '../data/auroradb';
 import DirectionDropdown from '../components/DirectionDropdown';
 import ErrorSummary from '../components/ErrorSummary';
-import { ErrorInfo, NextPageContextWithSession, ServiceDB, RawService } from '../interfaces';
+import { ErrorInfo, NextPageContextWithSession, ServiceDB, RawService, TxcSourceAttribute } from '../interfaces';
 import { enrichJourneyPatternsWithNaptanInfo } from '../utils/dataTransform';
 import { getAndValidateNoc, getCsrfToken } from '../utils';
 import { redirectTo } from './api/apiUtils';
@@ -24,6 +29,7 @@ interface ReturnDirectionProps {
     outboundJourney?: string;
     inboundJourney?: string;
     csrfToken: string;
+    dataSource: string;
 }
 
 const ReturnDirection = ({
@@ -32,6 +38,7 @@ const ReturnDirection = ({
     outboundJourney,
     inboundJourney,
     csrfToken,
+    dataSource,
 }: ReturnDirectionProps): ReactElement => (
     <TwoThirdsLayout title={title} description={description} errors={errors}>
         <CsrfForm action="/api/returnDirection" method="post" csrfToken={csrfToken}>
@@ -65,8 +72,11 @@ const ReturnDirection = ({
                             />
                         </div>
                         <span className="govuk-hint hint-text" id="traveline-main-hint">
-                            This data is taken from the Traveline National Dataset (TNDS) and should include all of your
-                            registered routes for this service
+                            This data is taken from the{' '}
+                            {dataSource === 'bods'
+                                ? 'Bus Open Data Service (BODS)'
+                                : 'Traveline National Dataset (TNDS)'}{' '}
+                            and should include all of your registered routes for this service
                         </span>
                         <span className="govuk-hint hint-text" id="traveline-sub-hint">
                             If you have route variations within your fares triangle, you are only required to upload one
@@ -93,8 +103,8 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     }
 
     const lineName = serviceAttribute.service.split('#')[0];
-
-    const rawService: RawService = await getServiceByNocCodeAndLineName(nocCode, lineName);
+    const dataSource = (getSessionAttribute(ctx.req, TXC_SOURCE_ATTRIBUTE) as TxcSourceAttribute).source;
+    const rawService: RawService = await getServiceByNocCodeLineNameAndDataSource(nocCode, lineName, dataSource);
     const service: ServiceDB = {
         ...rawService,
         journeyPatterns: await enrichJourneyPatternsWithNaptanInfo(rawService.journeyPatterns),
@@ -137,6 +147,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
                 outboundJourney,
                 inboundJourney,
                 csrfToken,
+                dataSource,
             },
         };
     }
@@ -146,6 +157,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
             service,
             errors: [],
             csrfToken,
+            dataSource,
         },
     };
 };

--- a/src/pages/returnDirection.tsx
+++ b/src/pages/returnDirection.tsx
@@ -73,9 +73,11 @@ const ReturnDirection = ({
                         </div>
                         <span className="govuk-hint hint-text" id="traveline-main-hint">
                             This data is taken from the{' '}
-                            {dataSource === 'bods'
-                                ? 'Bus Open Data Service (BODS)'
-                                : 'Traveline National Dataset (TNDS)'}{' '}
+                            <b>
+                                {dataSource === 'bods'
+                                    ? 'Bus Open Data Service (BODS)'
+                                    : 'Traveline National Dataset (TNDS)'}{' '}
+                            </b>
                             and should include all of your registered routes for this service
                         </span>
                         <span className="govuk-hint hint-text" id="traveline-sub-hint">

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -70,11 +70,13 @@ const Service = ({
                     </FormElementWrapper>
                     <span className="govuk-hint hint-text" id="traveline-hint">
                         This data is taken from the{' '}
-                        {dataSourceAttribute.source === 'tnds'
-                            ? 'Traveline National Dataset (TNDS)'
-                            : 'Bus Open Data Service (BODS)'}
-                        . If any of your services are not listed, contact your local transport authority for further
-                        advice.
+                        <b>
+                            {dataSourceAttribute.source === 'tnds'
+                                ? 'Traveline National Dataset (TNDS)'
+                                : 'Bus Open Data Service (BODS)'}
+                        </b>
+                        . If the service you are looking for is not listed, contact the BODS help desk for advice{' '}
+                        <a href="/contact">here</a>
                     </span>
                 </div>
                 <input type="submit" value="Continue" id="continue-button" className="govuk-button" />

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -9,7 +9,7 @@ import {
     PASSENGER_TYPE_ATTRIBUTE,
     TXC_SOURCE_ATTRIBUTE,
 } from '../constants/attributes';
-import { getServicesByNocCode } from '../data/auroradb';
+import { getServicesByNocCodeAndDataSource } from '../data/auroradb';
 import ErrorSummary from '../components/ErrorSummary';
 import { getAndValidateNoc, getCsrfToken } from '../utils';
 import CsrfForm from '../components/CsrfForm';
@@ -107,7 +107,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     if (!dataSourceAttribute) {
         throw new Error('Data source attribute not found');
     }
-    const services = await getServicesByNocCode(nocCode, dataSourceAttribute?.source);
+    const services = await getServicesByNocCodeAndDataSource(nocCode, dataSourceAttribute?.source);
 
     if (services.length === 0) {
         if (ctx.res) {

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -1,9 +1,14 @@
 import React, { ReactElement } from 'react';
 import upperFirst from 'lodash/upperFirst';
-import { ErrorInfo, NextPageContextWithSession, ServiceType } from '../interfaces';
+import { ErrorInfo, NextPageContextWithSession, ServiceType, TxcSourceAttribute } from '../interfaces';
 import FormElementWrapper from '../components/FormElementWrapper';
 import TwoThirdsLayout from '../layout/Layout';
-import { OPERATOR_ATTRIBUTE, SERVICE_ATTRIBUTE, PASSENGER_TYPE_ATTRIBUTE } from '../constants/attributes';
+import {
+    OPERATOR_ATTRIBUTE,
+    SERVICE_ATTRIBUTE,
+    PASSENGER_TYPE_ATTRIBUTE,
+    TXC_SOURCE_ATTRIBUTE,
+} from '../constants/attributes';
 import { getServicesByNocCode } from '../data/auroradb';
 import ErrorSummary from '../components/ErrorSummary';
 import { getAndValidateNoc, getCsrfToken } from '../utils';
@@ -11,6 +16,7 @@ import CsrfForm from '../components/CsrfForm';
 import { isPassengerType, isServiceAttributeWithErrors } from '../interfaces/typeGuards';
 import { getSessionAttribute } from '../utils/sessions';
 import { redirectTo } from './api/apiUtils';
+import SwitchDataSource from '../components/SwitchDataSource';
 
 const title = 'Service - Create Fares Data Service';
 const description = 'Service selection page of the Create Fares Data Service';
@@ -21,24 +27,31 @@ interface ServiceProps {
     passengerType: string;
     services: ServiceType[];
     error: ErrorInfo[];
+    dataSourceAttribute: TxcSourceAttribute;
     csrfToken: string;
 }
 
-const Service = ({ operator, passengerType, services, error, csrfToken }: ServiceProps): ReactElement => (
+const Service = ({
+    operator,
+    passengerType,
+    services,
+    dataSourceAttribute,
+    error,
+    csrfToken,
+}: ServiceProps): ReactElement => (
     <TwoThirdsLayout title={title} description={description} errors={error}>
         <CsrfForm action="/api/service" method="post" csrfToken={csrfToken}>
             <>
+                <label htmlFor="service">
+                    <h1 className="govuk-heading-l" id="service-page-heading">
+                        Select a service
+                    </h1>
+                </label>
+                <span className="govuk-hint" id="service-operator-passenger-type-hint">
+                    {operator} - {upperFirst(passengerType)}
+                </span>
                 <ErrorSummary errors={error} />
                 <div className={`govuk-form-group ${error.length > 0 ? 'govuk-form-group--error' : ''}`}>
-                    <label htmlFor="service">
-                        <h1 className="govuk-heading-l" id="service-page-heading">
-                            Select a service
-                        </h1>
-                    </label>
-
-                    <span className="govuk-hint" id="service-operator-passenger-type-hint">
-                        {operator} - {upperFirst(passengerType)}
-                    </span>
                     <FormElementWrapper errors={error} errorId={errorId} errorClass="govuk-select--error">
                         <select className="govuk-select" id="service" name="service" defaultValue="">
                             <option value="" disabled>
@@ -56,13 +69,18 @@ const Service = ({ operator, passengerType, services, error, csrfToken }: Servic
                         </select>
                     </FormElementWrapper>
                     <span className="govuk-hint hint-text" id="traveline-hint">
-                        This data is taken from the Traveline National Dataset (TNDS). If any of your services are not
-                        listed, contact your local transport authority for further advice.
+                        This data is taken from the{' '}
+                        {dataSourceAttribute.source === 'tnds'
+                            ? 'Traveline National Dataset (TNDS)'
+                            : 'Bus Open Data Service (BODS)'}
+                        . If any of your services are not listed, contact your local transport authority for further
+                        advice.
                     </span>
                 </div>
                 <input type="submit" value="Continue" id="continue-button" className="govuk-button" />
             </>
         </CsrfForm>
+        <SwitchDataSource dataSourceAttribute={dataSourceAttribute} pageUrl="/service" csrfToken={csrfToken} />
     </TwoThirdsLayout>
 );
 
@@ -83,13 +101,17 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
         throw new Error('Could not render the service selection page. Necessary attributes not found.');
     }
 
-    const services = await getServicesByNocCode(nocCode);
+    const dataSourceAttribute = getSessionAttribute(ctx.req, TXC_SOURCE_ATTRIBUTE);
+    if (!dataSourceAttribute) {
+        throw new Error('Data source attribute not found');
+    }
+    const services = await getServicesByNocCode(nocCode, dataSourceAttribute?.source);
 
     if (services.length === 0) {
         if (ctx.res) {
             redirectTo(ctx.res, '/noServices');
         } else {
-            throw new Error(`No services found for NOC Code: ${nocCode}`);
+            throw new Error(`No services found in TNDS or BODS for NOC Code: ${nocCode}`);
         }
     }
 
@@ -99,6 +121,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
             passengerType: passengerTypeAttribute.passengerType,
             services,
             error,
+            dataSourceAttribute,
             csrfToken,
         },
     };

--- a/src/pages/serviceList.tsx
+++ b/src/pages/serviceList.tsx
@@ -3,7 +3,7 @@ import ErrorSummary from '../components/ErrorSummary';
 import FormElementWrapper from '../components/FormElementWrapper';
 import { FullColumnLayout } from '../layout/Layout';
 import { SERVICE_LIST_ATTRIBUTE, FARE_TYPE_ATTRIBUTE } from '../constants/attributes';
-import { getServicesByNocCode } from '../data/auroradb';
+import { getServicesByNocCodeAndDataSource } from '../data/auroradb';
 import {
     ErrorInfo,
     NextPageContextWithSession,
@@ -110,7 +110,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     const nocCode = getAndValidateNoc(ctx);
     const serviceListAttribute = getSessionAttribute(ctx.req, SERVICE_LIST_ATTRIBUTE);
 
-    const services = await getServicesByNocCode(nocCode, 'tnds');
+    const services = await getServicesByNocCodeAndDataSource(nocCode, 'tnds');
 
     const { selectAll } = ctx.query;
 

--- a/src/pages/serviceList.tsx
+++ b/src/pages/serviceList.tsx
@@ -110,7 +110,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     const nocCode = getAndValidateNoc(ctx);
     const serviceListAttribute = getSessionAttribute(ctx.req, SERVICE_LIST_ATTRIBUTE);
 
-    const services = await getServicesByNocCode(nocCode);
+    const services = await getServicesByNocCode(nocCode, 'tnds');
 
     const { selectAll } = ctx.query;
 

--- a/src/pages/singleDirection.tsx
+++ b/src/pages/singleDirection.tsx
@@ -6,11 +6,12 @@ import {
     SERVICE_ATTRIBUTE,
     JOURNEY_ATTRIBUTE,
     PASSENGER_TYPE_ATTRIBUTE,
+    TXC_SOURCE_ATTRIBUTE,
 } from '../constants/attributes';
-import { getServiceByNocCodeAndLineName } from '../data/auroradb';
+import { getServiceByNocCodeLineNameAndDataSource } from '../data/auroradb';
 import DirectionDropdown from '../components/DirectionDropdown';
 import { enrichJourneyPatternsWithNaptanInfo } from '../utils/dataTransform';
-import { ErrorInfo, NextPageContextWithSession, ServiceDB, RawService } from '../interfaces';
+import { ErrorInfo, NextPageContextWithSession, ServiceDB, RawService, TxcSourceAttribute } from '../interfaces';
 import ErrorSummary from '../components/ErrorSummary';
 import { getAndValidateNoc, getCsrfToken } from '../utils';
 import CsrfForm from '../components/CsrfForm';
@@ -26,6 +27,7 @@ interface SingleDirectionProps {
     lineName: string;
     service: ServiceDB;
     error: ErrorInfo[];
+    dataSource: string;
     csrfToken: string;
 }
 
@@ -35,6 +37,7 @@ const SingleDirection = ({
     lineName,
     service,
     error,
+    dataSource,
     csrfToken,
 }: SingleDirectionProps): ReactElement => (
     <TwoThirdsLayout title={title} description={description} errors={error}>
@@ -61,8 +64,9 @@ const SingleDirection = ({
                         errors={error}
                     />
                     <span className="govuk-hint hint-text" id="traveline-main-hint">
-                        This data is taken from the Traveline National Dataset (TNDS) and should include all of your
-                        registered routes for this service
+                        This data is taken from the{' '}
+                        {dataSource === 'bods' ? 'Bus Open Data Service (BODS)' : 'Traveline National Dataset (TNDS)'}{' '}
+                        and should include all of your registered routes for this service
                     </span>
                     <span className="govuk-hint hint-text" id="traveline-sub-hint">
                         If you have route variations within your fares triangle, you are only required to upload one
@@ -95,8 +99,8 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
     }
 
     const lineName = serviceAttribute.service.split('#')[0];
-
-    const rawService: RawService = await getServiceByNocCodeAndLineName(nocCode, lineName);
+    const dataSource = (getSessionAttribute(ctx.req, TXC_SOURCE_ATTRIBUTE) as TxcSourceAttribute).source;
+    const rawService: RawService = await getServiceByNocCodeLineNameAndDataSource(nocCode, lineName, dataSource);
     const service: ServiceDB = {
         ...rawService,
         journeyPatterns: await enrichJourneyPatternsWithNaptanInfo(rawService.journeyPatterns),
@@ -121,6 +125,7 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
             lineName,
             service,
             error: (isJourney(journeyAttribute) && journeyAttribute.errors) || [],
+            dataSource,
             csrfToken,
         },
     };

--- a/src/pages/singleDirection.tsx
+++ b/src/pages/singleDirection.tsx
@@ -65,7 +65,11 @@ const SingleDirection = ({
                     />
                     <span className="govuk-hint hint-text" id="traveline-main-hint">
                         This data is taken from the{' '}
-                        {dataSource === 'bods' ? 'Bus Open Data Service (BODS)' : 'Traveline National Dataset (TNDS)'}{' '}
+                        <b>
+                            {dataSource === 'bods'
+                                ? 'Bus Open Data Service (BODS)'
+                                : 'Traveline National Dataset (TNDS)'}{' '}
+                        </b>
                         and should include all of your registered routes for this service
                     </span>
                     <span className="govuk-hint hint-text" id="traveline-sub-hint">

--- a/src/pages/ticketConfirmation.tsx
+++ b/src/pages/ticketConfirmation.tsx
@@ -17,6 +17,7 @@ import {
     MultipleOperatorsAttribute,
     Service,
     ServiceListAttribute,
+    TxcSourceAttribute,
 } from '../interfaces';
 import TwoThirdsLayout from '../layout/Layout';
 import CsrfForm from '../components/CsrfForm';
@@ -39,6 +40,7 @@ import {
     MULTIPLE_OPERATOR_ATTRIBUTE,
     MULTIPLE_OPERATORS_SERVICES_ATTRIBUTE,
     OPERATOR_ATTRIBUTE,
+    TXC_SOURCE_ATTRIBUTE,
 } from '../constants/attributes';
 import { isFareType } from '../interfaces/typeGuards';
 import { MatchingInfo, MatchingFareZones, InboundMatchingInfo } from '../interfaces/matchingInterface';
@@ -76,11 +78,17 @@ export const buildSingleTicketConfirmationElements = (ctx: NextPageContextWithSe
     const matchedFareStages: MatchedFareStages[] = buildMatchedFareStages(
         (getSessionAttribute(ctx.req, MATCHING_ATTRIBUTE) as MatchingInfo).matchingFareZones,
     );
+    const dataSource = (getSessionAttribute(ctx.req, TXC_SOURCE_ATTRIBUTE) as TxcSourceAttribute).source;
 
     confirmationElements.push(
         {
             name: 'Service',
-            content: service.split('#')[0],
+            content: `${service.split('#')[0]}`,
+            href: 'service',
+        },
+        {
+            name: 'TransXChange source',
+            content: dataSource.toUpperCase(),
             href: 'service',
         },
         {
@@ -109,12 +117,20 @@ export const buildReturnTicketConfirmationElements = (ctx: NextPageContextWithSe
     const validity = getSessionAttribute(ctx.req, RETURN_VALIDITY_ATTRIBUTE) as ReturnPeriodValidity;
 
     const circular = !outboundJourney && !inboundJourney;
+    const dataSource = (getSessionAttribute(ctx.req, TXC_SOURCE_ATTRIBUTE) as TxcSourceAttribute).source;
 
-    confirmationElements.push({
-        name: 'Service',
-        content: service.split('#')[0],
-        href: 'service',
-    });
+    confirmationElements.push(
+        {
+            name: 'Service',
+            content: service.split('#')[0],
+            href: 'service',
+        },
+        {
+            name: 'TransXChange source',
+            content: dataSource.toUpperCase(),
+            href: 'service',
+        },
+    );
 
     if (!circular) {
         const outboundMatchingFareZones = (getSessionAttribute(ctx.req, MATCHING_ATTRIBUTE) as MatchingInfo)

--- a/src/utils/sessions.ts
+++ b/src/utils/sessions.ts
@@ -60,6 +60,7 @@ import {
     UserAttribute,
     OperatorAttribute,
     ForgotPasswordAttribute,
+    TxcSourceAttribute,
 } from '../interfaces';
 
 import {
@@ -102,6 +103,7 @@ import {
     FORGOT_PASSWORD_ATTRIBUTE,
     USER_ATTRIBUTE,
     OPERATOR_ATTRIBUTE,
+    TXC_SOURCE_ATTRIBUTE,
 } from '../constants/attributes';
 
 import * as attributes from '../constants/attributes';
@@ -152,6 +154,7 @@ interface SessionAttributeTypes {
     [FORGOT_PASSWORD_ATTRIBUTE]: ForgotPasswordAttribute | WithErrors<ForgotPasswordAttribute>;
     [USER_ATTRIBUTE]: UserAttribute | WithErrors<UserAttribute>;
     [OPERATOR_ATTRIBUTE]: OperatorAttribute | WithErrors<OperatorAttribute>;
+    [TXC_SOURCE_ATTRIBUTE]: TxcSourceAttribute;
 }
 
 export type SessionAttribute<T extends string> = T extends keyof SessionAttributeTypes

--- a/tests/components/SwitchDataSource.test.tsx
+++ b/tests/components/SwitchDataSource.test.tsx
@@ -1,0 +1,29 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import SwitchDataSource from '../../src/components/SwitchDataSource';
+
+describe('SwitchDataSource', () => {
+    it('should render the button not disabled', () => {
+        const wrapper = shallow(
+            <SwitchDataSource
+                dataSourceAttribute={{ source: 'bods', hasTnds: true, hasBods: true }}
+                pageUrl="/service"
+                csrfToken="token"
+            />,
+        );
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find('#change-data-source').props().disabled).toBeFalsy();
+    });
+
+    it('should render the button disabled', () => {
+        const wrapper = shallow(
+            <SwitchDataSource
+                dataSourceAttribute={{ source: 'bods', hasTnds: false, hasBods: true }}
+                pageUrl="/service"
+                csrfToken="token"
+            />,
+        );
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find('#change-data-source').props().disabled).toBeTruthy();
+    });
+});

--- a/tests/components/__snapshots__/SwitchDataSource.test.tsx.snap
+++ b/tests/components/__snapshots__/SwitchDataSource.test.tsx.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SwitchDataSource should render the button disabled 1`] = `
+<CsrfForm
+  action="/api/switchDataSource"
+  csrfToken="token"
+  method="post"
+>
+  <input
+    name="referer"
+    type="hidden"
+    value="/service"
+  />
+  <button
+    className="govuk-button govuk-button--secondary"
+    disabled={true}
+    id="change-data-source"
+    type="submit"
+  >
+    Change TransXChange datasource to 
+    TNDS
+  </button>
+</CsrfForm>
+`;
+
+exports[`SwitchDataSource should render the button not disabled 1`] = `
+<CsrfForm
+  action="/api/switchDataSource"
+  csrfToken="token"
+  method="post"
+>
+  <input
+    name="referer"
+    type="hidden"
+    value="/service"
+  />
+  <button
+    className="govuk-button govuk-button--secondary"
+    disabled={false}
+    id="change-data-source"
+    type="submit"
+  >
+    Change TransXChange datasource to 
+    TNDS
+  </button>
+</CsrfForm>
+`;

--- a/tests/pages/__snapshots__/noServices.test.tsx.snap
+++ b/tests/pages/__snapshots__/noServices.test.tsx.snap
@@ -13,12 +13,12 @@ exports[`pages noServices should render correctly 1`] = `
   <p
     className="govuk-body-m"
   >
-    This service utilises the Traveline National Dataset (TNDS) to obtain operators' service data in order to help them create fares data.
+    This service utilises the Traveline National Dataset (TNDS) and the Bus Open Data Service (BODS) to obtain operators' service data in order to help them create fares data.
   </p>
   <p
     className="govuk-body-m"
   >
-    It appears there is no service data for this operator in the Traveline National Dataset.
+    It appears there is no service data for this operator in the Traveline National Dataset or in the Bus Open Data Service.
   </p>
   <p
     className="govuk-body-m"

--- a/tests/pages/__snapshots__/returnDirection.test.tsx.snap
+++ b/tests/pages/__snapshots__/returnDirection.test.tsx.snap
@@ -171,7 +171,11 @@ exports[`pages returnDirection should render correctly 1`] = `
           className="govuk-hint hint-text"
           id="traveline-main-hint"
         >
-          This data is taken from the Traveline National Dataset (TNDS) and should include all of your registered routes for this service
+          This data is taken from the
+           
+          Bus Open Data Service (BODS)
+           
+          and should include all of your registered routes for this service
         </span>
         <span
           className="govuk-hint hint-text"
@@ -406,7 +410,11 @@ exports[`pages returnDirection should render errors correctly 1`] = `
           className="govuk-hint hint-text"
           id="traveline-main-hint"
         >
-          This data is taken from the Traveline National Dataset (TNDS) and should include all of your registered routes for this service
+          This data is taken from the
+           
+          Bus Open Data Service (BODS)
+           
+          and should include all of your registered routes for this service
         </span>
         <span
           className="govuk-hint hint-text"

--- a/tests/pages/__snapshots__/returnDirection.test.tsx.snap
+++ b/tests/pages/__snapshots__/returnDirection.test.tsx.snap
@@ -173,8 +173,10 @@ exports[`pages returnDirection should render correctly 1`] = `
         >
           This data is taken from the
            
-          Bus Open Data Service (BODS)
-           
+          <b>
+            Bus Open Data Service (BODS)
+             
+          </b>
           and should include all of your registered routes for this service
         </span>
         <span
@@ -412,8 +414,10 @@ exports[`pages returnDirection should render errors correctly 1`] = `
         >
           This data is taken from the
            
-          Bus Open Data Service (BODS)
-           
+          <b>
+            Bus Open Data Service (BODS)
+             
+          </b>
           and should include all of your registered routes for this service
         </span>
         <span

--- a/tests/pages/__snapshots__/service.test.tsx.snap
+++ b/tests/pages/__snapshots__/service.test.tsx.snap
@@ -11,30 +11,30 @@ exports[`pages service should render correctly 1`] = `
     csrfToken=""
     method="post"
   >
+    <label
+      htmlFor="service"
+    >
+      <h1
+        className="govuk-heading-l"
+        id="service-page-heading"
+      >
+        Select a service
+      </h1>
+    </label>
+    <span
+      className="govuk-hint"
+      id="service-operator-passenger-type-hint"
+    >
+      Connexions Buses
+       - 
+      Adult
+    </span>
     <ErrorSummary
       errors={Array []}
     />
     <div
       className="govuk-form-group "
     >
-      <label
-        htmlFor="service"
-      >
-        <h1
-          className="govuk-heading-l"
-          id="service-page-heading"
-        >
-          Select a service
-        </h1>
-      </label>
-      <span
-        className="govuk-hint"
-        id="service-operator-passenger-type-hint"
-      >
-        Connexions Buses
-         - 
-        Adult
-      </span>
       <FormElementWrapper
         errorClass="govuk-select--error"
         errorId="service"
@@ -85,7 +85,10 @@ exports[`pages service should render correctly 1`] = `
         className="govuk-hint hint-text"
         id="traveline-hint"
       >
-        This data is taken from the Traveline National Dataset (TNDS). If any of your services are not listed, contact your local transport authority for further advice.
+        This data is taken from the
+         
+        Traveline National Dataset (TNDS)
+        . If any of your services are not listed, contact your local transport authority for further advice.
       </span>
     </div>
     <input
@@ -95,5 +98,16 @@ exports[`pages service should render correctly 1`] = `
       value="Continue"
     />
   </CsrfForm>
+  <SwitchDataSource
+    csrfToken=""
+    dataSourceAttribute={
+      Object {
+        "hasBods": false,
+        "hasTnds": true,
+        "source": "tnds",
+      }
+    }
+    pageUrl="/service"
+  />
 </Component>
 `;

--- a/tests/pages/__snapshots__/service.test.tsx.snap
+++ b/tests/pages/__snapshots__/service.test.tsx.snap
@@ -87,8 +87,16 @@ exports[`pages service should render correctly 1`] = `
       >
         This data is taken from the
          
-        Traveline National Dataset (TNDS)
-        . If any of your services are not listed, contact your local transport authority for further advice.
+        <b>
+          Traveline National Dataset (TNDS)
+        </b>
+        . If the service you are looking for is not listed, contact the BODS help desk for advice
+         
+        <a
+          href="/contact"
+        >
+          here
+        </a>
       </span>
     </div>
     <input

--- a/tests/pages/__snapshots__/singleDirection.test.tsx.snap
+++ b/tests/pages/__snapshots__/singleDirection.test.tsx.snap
@@ -111,8 +111,10 @@ exports[`pages singleDirection should render correctly 1`] = `
       >
         This data is taken from the
          
-        Bus Open Data Service (BODS)
-         
+        <b>
+          Bus Open Data Service (BODS)
+           
+        </b>
         and should include all of your registered routes for this service
       </span>
       <span

--- a/tests/pages/__snapshots__/singleDirection.test.tsx.snap
+++ b/tests/pages/__snapshots__/singleDirection.test.tsx.snap
@@ -109,7 +109,11 @@ exports[`pages singleDirection should render correctly 1`] = `
         className="govuk-hint hint-text"
         id="traveline-main-hint"
       >
-        This data is taken from the Traveline National Dataset (TNDS) and should include all of your registered routes for this service
+        This data is taken from the
+         
+        Bus Open Data Service (BODS)
+         
+        and should include all of your registered routes for this service
       </span>
       <span
         className="govuk-hint hint-text"

--- a/tests/pages/api/register.test.ts
+++ b/tests/pages/api/register.test.ts
@@ -1,5 +1,5 @@
 import { CognitoIdentityServiceProvider } from 'aws-sdk';
-import register, { operatorHasServices } from '../../../src/pages/api/register';
+import register, { nocsWithNoServices } from '../../../src/pages/api/register';
 import * as auth from '../../../src/data/cognito';
 import * as auroradb from '../../../src/data/auroradb';
 import { getMockRequestAndResponse } from '../../testData/mockData';
@@ -307,14 +307,14 @@ describe('register', () => {
     });
 });
 
-describe('operatorHasServices', () => {
+describe('nocsWithNoServices', () => {
     const getAllServicesByNocCodeSpy = jest.spyOn(auroradb, 'getAllServicesByNocCode');
     afterEach(() => {
         getAllServicesByNocCodeSpy.mockReset();
     });
     it('returns the correct noc codes if all noc codes have no TNDS data', async () => {
         getAllServicesByNocCodeSpy.mockImplementation(() => Promise.resolve([]));
-        const result = await operatorHasServices(['AAA', 'BBB']);
+        const result = await nocsWithNoServices(['AAA', 'BBB']);
         expect(result.length).toBe(2);
         expect(result).toStrictEqual(['AAA', 'BBB']);
     });
@@ -332,7 +332,7 @@ describe('operatorHasServices', () => {
                 ]),
             )
             .mockImplementationOnce(() => Promise.resolve([]));
-        const result = await operatorHasServices(['AAA', 'BBB']);
+        const result = await nocsWithNoServices(['AAA', 'BBB']);
         expect(result.length).toBe(1);
         expect(result).toStrictEqual(['BBB']);
     });
@@ -359,7 +359,7 @@ describe('operatorHasServices', () => {
                     },
                 ]),
             );
-        const result = await operatorHasServices(['AAA', 'BBB']);
+        const result = await nocsWithNoServices(['AAA', 'BBB']);
         expect(result.length).toBe(0);
         expect(result).toStrictEqual([]);
     });

--- a/tests/pages/api/register.test.ts
+++ b/tests/pages/api/register.test.ts
@@ -1,10 +1,10 @@
 import { CognitoIdentityServiceProvider } from 'aws-sdk';
-import register, { operatorHasTndsData } from '../../../src/pages/api/register';
+import register, { operatorHasServices } from '../../../src/pages/api/register';
 import * as auth from '../../../src/data/cognito';
 import * as auroradb from '../../../src/data/auroradb';
 import { getMockRequestAndResponse } from '../../testData/mockData';
 import { USER_ATTRIBUTE } from '../../../src/constants/attributes';
-import { getServicesByNocCode } from '../../../src/data/auroradb';
+import { getAllServicesByNocCode } from '../../../src/data/auroradb';
 import * as sessions from '../../../src/utils/sessions';
 
 jest.mock('../../../src/data/auroradb.ts');
@@ -21,7 +21,7 @@ describe('register', () => {
         Session: 'session',
     };
 
-    const getServicesByNocCodeSpy = jest.spyOn(auroradb, 'getServicesByNocCode');
+    const getAllServicesByNocCodeSpy = jest.spyOn(auroradb, 'getAllServicesByNocCode');
     const authSignInSpy = jest.spyOn(auth, 'initiateAuth');
     const authCompletePasswordSpy = jest.spyOn(auth, 'respondToNewPasswordChallenge');
     const authUpdateAttributesSpy = jest.spyOn(auth, 'updateUserAttributes');
@@ -33,7 +33,7 @@ describe('register', () => {
         authCompletePasswordSpy.mockImplementation(() => Promise.resolve());
         authSignOutSpy.mockImplementation(() => Promise.resolve());
         authUpdateAttributesSpy.mockImplementation(() => Promise.resolve());
-        getServicesByNocCodeSpy.mockImplementation(() =>
+        getAllServicesByNocCodeSpy.mockImplementation(() =>
             Promise.resolve([
                 {
                     lineName: '2AC',
@@ -186,7 +186,7 @@ describe('register', () => {
     });
 
     it('should redirect when there are no services for the noc code', async () => {
-        (getServicesByNocCode as jest.Mock).mockImplementation(() => []);
+        (getAllServicesByNocCode as jest.Mock).mockImplementation(() => []);
 
         const { req, res } = getMockRequestAndResponse({
             cookieValues: {},
@@ -307,20 +307,20 @@ describe('register', () => {
     });
 });
 
-describe('operatorHasTndsData', () => {
-    const getServicesByNocCodeSpy = jest.spyOn(auroradb, 'getServicesByNocCode');
+describe('operatorHasServices', () => {
+    const getAllServicesByNocCodeSpy = jest.spyOn(auroradb, 'getAllServicesByNocCode');
     afterEach(() => {
-        getServicesByNocCodeSpy.mockReset();
+        getAllServicesByNocCodeSpy.mockReset();
     });
     it('returns the correct noc codes if all noc codes have no TNDS data', async () => {
-        getServicesByNocCodeSpy.mockImplementation(() => Promise.resolve([]));
-        const result = await operatorHasTndsData(['AAA', 'BBB']);
+        getAllServicesByNocCodeSpy.mockImplementation(() => Promise.resolve([]));
+        const result = await operatorHasServices(['AAA', 'BBB']);
         expect(result.length).toBe(2);
         expect(result).toStrictEqual(['AAA', 'BBB']);
     });
 
     it('returns the correct noc codes if some noc codes have no TNDS data', async () => {
-        getServicesByNocCodeSpy
+        getAllServicesByNocCodeSpy
             .mockImplementationOnce(() =>
                 Promise.resolve([
                     {
@@ -332,13 +332,13 @@ describe('operatorHasTndsData', () => {
                 ]),
             )
             .mockImplementationOnce(() => Promise.resolve([]));
-        const result = await operatorHasTndsData(['AAA', 'BBB']);
+        const result = await operatorHasServices(['AAA', 'BBB']);
         expect(result.length).toBe(1);
         expect(result).toStrictEqual(['BBB']);
     });
 
     it('returns a result with true if noc codes have TNDS data', async () => {
-        getServicesByNocCodeSpy
+        getAllServicesByNocCodeSpy
             .mockImplementationOnce(() =>
                 Promise.resolve([
                     {
@@ -359,7 +359,7 @@ describe('operatorHasTndsData', () => {
                     },
                 ]),
             );
-        const result = await operatorHasTndsData(['AAA', 'BBB']);
+        const result = await operatorHasServices(['AAA', 'BBB']);
         expect(result.length).toBe(0);
         expect(result).toStrictEqual([]);
     });

--- a/tests/pages/fareType.test.tsx
+++ b/tests/pages/fareType.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import FareType, { buildUuid, getServerSideProps } from '../../src/pages/fareType';
 import { getMockContext, mockSchemOpIdToken } from '../testData/mockData';
-import { getServicesByNocCode } from '../../src/data/auroradb';
+import { getServicesByNocCodeAndDataSource } from '../../src/data/auroradb';
 import { OPERATOR_ATTRIBUTE } from '../../src/constants/attributes';
 
 jest.mock('../../src/data/auroradb');
@@ -29,7 +29,7 @@ describe('pages', () => {
 
         describe('getServerSideProps', () => {
             beforeEach(() => {
-                (getServicesByNocCode as jest.Mock).mockImplementation(() => [
+                (getServicesByNocCodeAndDataSource as jest.Mock).mockImplementation(() => [
                     {
                         lineName: '123',
                         startDate: '05/02/2020',
@@ -77,7 +77,7 @@ describe('pages', () => {
             });
 
             it('should redirect to /noServices when the chosen NOC has no services', async () => {
-                (getServicesByNocCode as jest.Mock).mockImplementation(() => []);
+                (getServicesByNocCodeAndDataSource as jest.Mock).mockImplementation(() => []);
                 const mockContext = getMockContext({
                     mockWriteHeadFn: writeHeadMock,
                 });

--- a/tests/pages/fareType.test.tsx
+++ b/tests/pages/fareType.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import FareType, { buildUuid, getServerSideProps } from '../../src/pages/fareType';
 import { getMockContext, mockSchemOpIdToken } from '../testData/mockData';
-import { getServicesByNocCodeAndDataSource } from '../../src/data/auroradb';
+import { getAllServicesByNocCode } from '../../src/data/auroradb';
 import { OPERATOR_ATTRIBUTE } from '../../src/constants/attributes';
 
 jest.mock('../../src/data/auroradb');
@@ -29,7 +29,7 @@ describe('pages', () => {
 
         describe('getServerSideProps', () => {
             beforeEach(() => {
-                (getServicesByNocCodeAndDataSource as jest.Mock).mockImplementation(() => [
+                (getAllServicesByNocCode as jest.Mock).mockImplementation(() => [
                     {
                         lineName: '123',
                         startDate: '05/02/2020',
@@ -77,7 +77,7 @@ describe('pages', () => {
             });
 
             it('should redirect to /noServices when the chosen NOC has no services', async () => {
-                (getServicesByNocCodeAndDataSource as jest.Mock).mockImplementation(() => []);
+                (getAllServicesByNocCode as jest.Mock).mockImplementation(() => []);
                 const mockContext = getMockContext({
                     mockWriteHeadFn: writeHeadMock,
                 });

--- a/tests/pages/inboundMatching.test.tsx
+++ b/tests/pages/inboundMatching.test.tsx
@@ -13,7 +13,12 @@ import {
     selectedFareStages,
 } from '../testData/mockData';
 import InboundMatching, { getServerSideProps } from '../../src/pages/inboundMatching';
-import { JOURNEY_ATTRIBUTE, OPERATOR_ATTRIBUTE, SERVICE_ATTRIBUTE } from '../../src/constants/attributes';
+import {
+    JOURNEY_ATTRIBUTE,
+    OPERATOR_ATTRIBUTE,
+    SERVICE_ATTRIBUTE,
+    TXC_SOURCE_ATTRIBUTE,
+} from '../../src/constants/attributes';
 
 jest.mock('../../src/data/auroradb.ts');
 jest.mock('../../src/data/s3.ts');
@@ -79,6 +84,11 @@ describe('Inbound Matching Page', () => {
                     [JOURNEY_ATTRIBUTE]: {
                         inboundJourney: '13003921A#13003655B',
                     },
+                    [TXC_SOURCE_ATTRIBUTE]: {
+                        source: 'bods',
+                        hasBods: true,
+                        hasTnds: true,
+                    },
                 },
             });
 
@@ -113,6 +123,11 @@ describe('Inbound Matching Page', () => {
                     [JOURNEY_ATTRIBUTE]: {
                         inboundJourney: '13003921A#13003655B',
                     },
+                    [TXC_SOURCE_ATTRIBUTE]: {
+                        source: 'bods',
+                        hasBods: true,
+                        hasTnds: true,
+                    },
                 },
             });
 
@@ -131,6 +146,11 @@ describe('Inbound Matching Page', () => {
                 session: {
                     [JOURNEY_ATTRIBUTE]: {
                         inboundJourney: '13003655B#13003921A',
+                    },
+                    [TXC_SOURCE_ATTRIBUTE]: {
+                        source: 'bods',
+                        hasBods: true,
+                        hasTnds: true,
                     },
                 },
             });
@@ -164,6 +184,11 @@ describe('Inbound Matching Page', () => {
                     [JOURNEY_ATTRIBUTE]: {
                         inboundJourney: '123ZZZ#13003921A',
                     },
+                    [TXC_SOURCE_ATTRIBUTE]: {
+                        source: 'bods',
+                        hasBods: true,
+                        hasTnds: true,
+                    },
                 },
             });
 
@@ -176,6 +201,11 @@ describe('Inbound Matching Page', () => {
             const ctx = getMockContext({
                 session: {
                     [OPERATOR_ATTRIBUTE]: undefined,
+                    [TXC_SOURCE_ATTRIBUTE]: {
+                        source: 'bods',
+                        hasBods: true,
+                        hasTnds: true,
+                    },
                 },
             });
 
@@ -186,6 +216,23 @@ describe('Inbound Matching Page', () => {
             const ctx = getMockContext({
                 session: {
                     [SERVICE_ATTRIBUTE]: undefined,
+                    [TXC_SOURCE_ATTRIBUTE]: {
+                        source: 'bods',
+                        hasBods: true,
+                        hasTnds: true,
+                    },
+                },
+            });
+
+            await expect(getServerSideProps(ctx)).rejects.toThrow(
+                'Necessary attributes not found to show matching page',
+            );
+        });
+
+        it('throws an error if txc source attribute not set', async () => {
+            const ctx = getMockContext({
+                session: {
+                    [TXC_SOURCE_ATTRIBUTE]: undefined,
                 },
             });
 

--- a/tests/pages/inboundMatching.test.tsx
+++ b/tests/pages/inboundMatching.test.tsx
@@ -20,16 +20,16 @@ jest.mock('../../src/data/s3.ts');
 
 describe('Inbound Matching Page', () => {
     let wrapper: any;
-    let getServiceByNocCodeAndLineNameSpy: any;
+    let getServiceByNocCodeLineNameAndDataSourceSpy: any;
     let batchGetStopsByAtcoCodeSpy: any;
     let getUserFareStagesSpy: any;
 
     beforeEach(() => {
-        getServiceByNocCodeAndLineNameSpy = jest.spyOn(auroradb, 'getServiceByNocCodeAndLineName');
+        getServiceByNocCodeLineNameAndDataSourceSpy = jest.spyOn(auroradb, 'getServiceByNocCodeLineNameAndDataSource');
         batchGetStopsByAtcoCodeSpy = jest.spyOn(auroradb, 'batchGetStopsByAtcoCode');
         getUserFareStagesSpy = jest.spyOn(s3, 'getUserFareStages');
 
-        getServiceByNocCodeAndLineNameSpy.mockImplementation(() => Promise.resolve(mockRawService));
+        getServiceByNocCodeLineNameAndDataSourceSpy.mockImplementation(() => Promise.resolve(mockRawService));
         batchGetStopsByAtcoCodeSpy.mockImplementation(() => Promise.resolve([]));
         getUserFareStagesSpy.mockImplementation(() => Promise.resolve(userFareStages));
 
@@ -105,7 +105,7 @@ describe('Inbound Matching Page', () => {
         });
 
         it('preserves the stops order', async () => {
-            getServiceByNocCodeAndLineNameSpy.mockImplementation(() => Promise.resolve(mockRawService));
+            getServiceByNocCodeLineNameAndDataSourceSpy.mockImplementation(() => Promise.resolve(mockRawService));
             batchGetStopsByAtcoCodeSpy.mockImplementation(() => Promise.resolve(zoneStops));
 
             const ctx = getMockContext({
@@ -123,7 +123,9 @@ describe('Inbound Matching Page', () => {
         });
 
         it('generates the correct list of master stops given journeys with duplicate start and end points', async () => {
-            getServiceByNocCodeAndLineNameSpy.mockImplementation(() => Promise.resolve(mockRawServiceWithDuplicates));
+            getServiceByNocCodeLineNameAndDataSourceSpy.mockImplementation(() =>
+                Promise.resolve(mockRawServiceWithDuplicates),
+            );
 
             const ctx = getMockContext({
                 session: {

--- a/tests/pages/matching.test.tsx
+++ b/tests/pages/matching.test.tsx
@@ -13,7 +13,12 @@ import {
     selectedFareStages,
 } from '../testData/mockData';
 import Matching, { getServerSideProps } from '../../src/pages/matching';
-import { JOURNEY_ATTRIBUTE, OPERATOR_ATTRIBUTE, SERVICE_ATTRIBUTE } from '../../src/constants/attributes';
+import {
+    JOURNEY_ATTRIBUTE,
+    OPERATOR_ATTRIBUTE,
+    SERVICE_ATTRIBUTE,
+    TXC_SOURCE_ATTRIBUTE,
+} from '../../src/constants/attributes';
 
 jest.mock('../../src/data/auroradb.ts');
 jest.mock('../../src/data/s3.ts');
@@ -80,6 +85,11 @@ describe('Matching Page', () => {
                     [JOURNEY_ATTRIBUTE]: {
                         directionJourneyPattern: '13003921A#13003655B',
                     },
+                    [TXC_SOURCE_ATTRIBUTE]: {
+                        source: 'bods',
+                        hasBods: true,
+                        hasTnds: true,
+                    },
                 },
             });
 
@@ -114,6 +124,11 @@ describe('Matching Page', () => {
                     [JOURNEY_ATTRIBUTE]: {
                         directionJourneyPattern: '13003921A#13003655B',
                     },
+                    [TXC_SOURCE_ATTRIBUTE]: {
+                        source: 'bods',
+                        hasBods: true,
+                        hasTnds: true,
+                    },
                 },
             });
 
@@ -132,6 +147,11 @@ describe('Matching Page', () => {
                 session: {
                     [JOURNEY_ATTRIBUTE]: {
                         directionJourneyPattern: '13003655B#13003921A',
+                    },
+                    [TXC_SOURCE_ATTRIBUTE]: {
+                        source: 'bods',
+                        hasBods: true,
+                        hasTnds: true,
                     },
                 },
             });
@@ -165,6 +185,11 @@ describe('Matching Page', () => {
                     [JOURNEY_ATTRIBUTE]: {
                         directionJourneyPattern: '123ZZZ#13003921A',
                     },
+                    [TXC_SOURCE_ATTRIBUTE]: {
+                        source: 'bods',
+                        hasBods: true,
+                        hasTnds: true,
+                    },
                 },
             });
 
@@ -177,6 +202,11 @@ describe('Matching Page', () => {
             const ctx = getMockContext({
                 session: {
                     [OPERATOR_ATTRIBUTE]: undefined,
+                    [TXC_SOURCE_ATTRIBUTE]: {
+                        source: 'bods',
+                        hasBods: true,
+                        hasTnds: true,
+                    },
                 },
             });
 
@@ -187,6 +217,23 @@ describe('Matching Page', () => {
             const ctx = getMockContext({
                 session: {
                     [SERVICE_ATTRIBUTE]: undefined,
+                    [TXC_SOURCE_ATTRIBUTE]: {
+                        source: 'bods',
+                        hasBods: true,
+                        hasTnds: true,
+                    },
+                },
+            });
+
+            await expect(getServerSideProps(ctx)).rejects.toThrow(
+                'Necessary attributes not found to show matching page',
+            );
+        });
+
+        it('throws an error if txc source attribute not set', async () => {
+            const ctx = getMockContext({
+                session: {
+                    [TXC_SOURCE_ATTRIBUTE]: undefined,
                 },
             });
 

--- a/tests/pages/matching.test.tsx
+++ b/tests/pages/matching.test.tsx
@@ -20,16 +20,16 @@ jest.mock('../../src/data/s3.ts');
 
 describe('Matching Page', () => {
     let wrapper: any;
-    let getServiceByNocCodeAndLineNameSpy: any;
+    let getServiceByNocCodeLineNameAndDataSourceSpy: any;
     let batchGetStopsByAtcoCodeSpy: any;
     let getUserFareStagesSpy: any;
 
     beforeEach(() => {
-        getServiceByNocCodeAndLineNameSpy = jest.spyOn(auroradb, 'getServiceByNocCodeAndLineName');
+        getServiceByNocCodeLineNameAndDataSourceSpy = jest.spyOn(auroradb, 'getServiceByNocCodeLineNameAndDataSource');
         batchGetStopsByAtcoCodeSpy = jest.spyOn(auroradb, 'batchGetStopsByAtcoCode');
         getUserFareStagesSpy = jest.spyOn(s3, 'getUserFareStages');
 
-        getServiceByNocCodeAndLineNameSpy.mockImplementation(() => Promise.resolve(mockRawService));
+        getServiceByNocCodeLineNameAndDataSourceSpy.mockImplementation(() => Promise.resolve(mockRawService));
         batchGetStopsByAtcoCodeSpy.mockImplementation(() => Promise.resolve([]));
         getUserFareStagesSpy.mockImplementation(() => Promise.resolve(userFareStages));
 
@@ -106,7 +106,7 @@ describe('Matching Page', () => {
         });
 
         it('preserves the stops order', async () => {
-            getServiceByNocCodeAndLineNameSpy.mockImplementation(() => Promise.resolve(mockRawService));
+            getServiceByNocCodeLineNameAndDataSourceSpy.mockImplementation(() => Promise.resolve(mockRawService));
             batchGetStopsByAtcoCodeSpy.mockImplementation(() => Promise.resolve(zoneStops));
 
             const ctx = getMockContext({
@@ -124,7 +124,9 @@ describe('Matching Page', () => {
         });
 
         it('generates the correct list of master stops given journeys with duplicate start and end points', async () => {
-            getServiceByNocCodeAndLineNameSpy.mockImplementation(() => Promise.resolve(mockRawServiceWithDuplicates));
+            getServiceByNocCodeLineNameAndDataSourceSpy.mockImplementation(() =>
+                Promise.resolve(mockRawServiceWithDuplicates),
+            );
 
             const ctx = getMockContext({
                 session: {

--- a/tests/pages/multipleOperatorsServiceList.test.tsx
+++ b/tests/pages/multipleOperatorsServiceList.test.tsx
@@ -61,10 +61,10 @@ describe('pages', () => {
             },
         ];
 
-        const getServicesByNocCodeSpy = jest.spyOn(aurora, 'getServicesByNocCode');
+        const getServicesByNocCodeAndDataSourceSpy = jest.spyOn(aurora, 'getServicesByNocCodeAndDataSource');
 
         beforeEach(() => {
-            getServicesByNocCodeSpy.mockImplementation(() => Promise.resolve(mockServices));
+            getServicesByNocCodeAndDataSourceSpy.mockImplementation(() => Promise.resolve(mockServices));
         });
 
         afterEach(() => {

--- a/tests/pages/outboundMatching.test.tsx
+++ b/tests/pages/outboundMatching.test.tsx
@@ -13,7 +13,12 @@ import {
     selectedFareStages,
 } from '../testData/mockData';
 import OutboundMatching, { getServerSideProps } from '../../src/pages/outboundMatching';
-import { JOURNEY_ATTRIBUTE, OPERATOR_ATTRIBUTE, SERVICE_ATTRIBUTE } from '../../src/constants/attributes';
+import {
+    JOURNEY_ATTRIBUTE,
+    OPERATOR_ATTRIBUTE,
+    SERVICE_ATTRIBUTE,
+    TXC_SOURCE_ATTRIBUTE,
+} from '../../src/constants/attributes';
 
 jest.mock('../../src/data/auroradb.ts');
 jest.mock('../../src/data/s3.ts');
@@ -80,6 +85,11 @@ describe('OutboundMatching Page', () => {
                     [JOURNEY_ATTRIBUTE]: {
                         outboundJourney: '13003921A#13003655B',
                     },
+                    [TXC_SOURCE_ATTRIBUTE]: {
+                        source: 'bods',
+                        hasBods: true,
+                        hasTnds: true,
+                    },
                 },
             });
 
@@ -114,6 +124,11 @@ describe('OutboundMatching Page', () => {
                     [JOURNEY_ATTRIBUTE]: {
                         outboundJourney: '13003921A#13003655B',
                     },
+                    [TXC_SOURCE_ATTRIBUTE]: {
+                        source: 'bods',
+                        hasBods: true,
+                        hasTnds: true,
+                    },
                 },
             });
 
@@ -132,6 +147,11 @@ describe('OutboundMatching Page', () => {
                 session: {
                     [JOURNEY_ATTRIBUTE]: {
                         outboundJourney: '13003655B#13003921A',
+                    },
+                    [TXC_SOURCE_ATTRIBUTE]: {
+                        source: 'bods',
+                        hasBods: true,
+                        hasTnds: true,
                     },
                 },
             });
@@ -166,6 +186,11 @@ describe('OutboundMatching Page', () => {
                         outboundJourney: '123ZZZ#13003921A',
                         inboundJourney: '123ZZZ#13003921A',
                     },
+                    [TXC_SOURCE_ATTRIBUTE]: {
+                        source: 'bods',
+                        hasBods: true,
+                        hasTnds: true,
+                    },
                 },
             });
 
@@ -188,6 +213,18 @@ describe('OutboundMatching Page', () => {
             const ctx = getMockContext({
                 session: {
                     [SERVICE_ATTRIBUTE]: undefined,
+                },
+            });
+
+            await expect(getServerSideProps(ctx)).rejects.toThrow(
+                'Necessary attributes not found to show matching page',
+            );
+        });
+
+        it('throws an error if txc source attribute not set', async () => {
+            const ctx = getMockContext({
+                session: {
+                    [TXC_SOURCE_ATTRIBUTE]: undefined,
                 },
             });
 

--- a/tests/pages/outboundMatching.test.tsx
+++ b/tests/pages/outboundMatching.test.tsx
@@ -20,16 +20,16 @@ jest.mock('../../src/data/s3.ts');
 
 describe('OutboundMatching Page', () => {
     let wrapper: any;
-    let getServiceByNocCodeAndLineNameSpy: any;
+    let getServiceByNocCodeLineNameAndDataSourceSpy: any;
     let batchGetStopsByAtcoCodeSpy: any;
     let getUserFareStagesSpy: any;
 
     beforeEach(() => {
-        getServiceByNocCodeAndLineNameSpy = jest.spyOn(auroradb, 'getServiceByNocCodeAndLineName');
+        getServiceByNocCodeLineNameAndDataSourceSpy = jest.spyOn(auroradb, 'getServiceByNocCodeLineNameAndDataSource');
         batchGetStopsByAtcoCodeSpy = jest.spyOn(auroradb, 'batchGetStopsByAtcoCode');
         getUserFareStagesSpy = jest.spyOn(s3, 'getUserFareStages');
 
-        getServiceByNocCodeAndLineNameSpy.mockImplementation(() => Promise.resolve(mockRawService));
+        getServiceByNocCodeLineNameAndDataSourceSpy.mockImplementation(() => Promise.resolve(mockRawService));
         batchGetStopsByAtcoCodeSpy.mockImplementation(() => Promise.resolve([]));
         getUserFareStagesSpy.mockImplementation(() => Promise.resolve(userFareStages));
 
@@ -106,7 +106,7 @@ describe('OutboundMatching Page', () => {
         });
 
         it('preserves the stops order', async () => {
-            getServiceByNocCodeAndLineNameSpy.mockImplementation(() => Promise.resolve(mockRawService));
+            getServiceByNocCodeLineNameAndDataSourceSpy.mockImplementation(() => Promise.resolve(mockRawService));
             batchGetStopsByAtcoCodeSpy.mockImplementation(() => Promise.resolve(zoneStops));
 
             const ctx = getMockContext({
@@ -124,7 +124,9 @@ describe('OutboundMatching Page', () => {
         });
 
         it('generates the correct list of master stops given journeys with duplicate start and end points', async () => {
-            getServiceByNocCodeAndLineNameSpy.mockImplementation(() => Promise.resolve(mockRawServiceWithDuplicates));
+            getServiceByNocCodeLineNameAndDataSourceSpy.mockImplementation(() =>
+                Promise.resolve(mockRawServiceWithDuplicates),
+            );
 
             const ctx = getMockContext({
                 session: {

--- a/tests/pages/returnDirection.test.tsx
+++ b/tests/pages/returnDirection.test.tsx
@@ -3,7 +3,7 @@ import { mount, shallow } from 'enzyme';
 import { getServiceByNocCodeLineNameAndDataSource, batchGetStopsByAtcoCode } from '../../src/data/auroradb';
 import { getMockContext, mockRawService, mockRawServiceWithDuplicates, mockService } from '../testData/mockData';
 import ReturnDirection, { getServerSideProps } from '../../src/pages/returnDirection';
-import { OPERATOR_ATTRIBUTE, SERVICE_ATTRIBUTE } from '../../src/constants/attributes';
+import { OPERATOR_ATTRIBUTE, SERVICE_ATTRIBUTE, TXC_SOURCE_ATTRIBUTE } from '../../src/constants/attributes';
 
 jest.mock('../../src/data/auroradb.ts');
 
@@ -76,7 +76,15 @@ describe('pages', () => {
                     () => mockRawService,
                 ));
 
-                const ctx = getMockContext();
+                const ctx = getMockContext({
+                    session: {
+                        [TXC_SOURCE_ATTRIBUTE]: {
+                            source: 'bods',
+                            hasBods: true,
+                            hasTnds: true,
+                        },
+                    },
+                });
 
                 const result = await getServerSideProps(ctx);
 
@@ -85,6 +93,7 @@ describe('pages', () => {
                         errors: [],
                         service: mockService,
                         csrfToken: '',
+                        dataSource: 'bods',
                     },
                 });
             });
@@ -94,7 +103,15 @@ describe('pages', () => {
                     () => mockRawServiceWithDuplicates,
                 ));
 
-                const ctx = getMockContext();
+                const ctx = getMockContext({
+                    session: {
+                        [TXC_SOURCE_ATTRIBUTE]: {
+                            source: 'bods',
+                            hasBods: true,
+                            hasTnds: true,
+                        },
+                    },
+                });
 
                 const result = await getServerSideProps(ctx);
 
@@ -103,6 +120,7 @@ describe('pages', () => {
                         errors: [],
                         service: mockService,
                         csrfToken: '',
+                        dataSource: 'bods',
                     },
                 });
             });
@@ -111,7 +129,15 @@ describe('pages', () => {
                 (({ ...getServiceByNocCodeLineNameAndDataSource } as jest.Mock).mockImplementation(() =>
                     Promise.resolve(null),
                 ));
-                const ctx = getMockContext();
+                const ctx = getMockContext({
+                    session: {
+                        [TXC_SOURCE_ATTRIBUTE]: {
+                            source: 'bods',
+                            hasBods: true,
+                            hasTnds: true,
+                        },
+                    },
+                });
 
                 await expect(getServerSideProps(ctx)).rejects.toThrow();
             });
@@ -120,6 +146,11 @@ describe('pages', () => {
                 const ctx = getMockContext({
                     session: {
                         [SERVICE_ATTRIBUTE]: undefined,
+                        [TXC_SOURCE_ATTRIBUTE]: {
+                            source: 'bods',
+                            hasBods: true,
+                            hasTnds: true,
+                        },
                     },
                 });
 
@@ -129,9 +160,28 @@ describe('pages', () => {
             });
 
             it('throws an error if the noc is invalid', async () => {
-                const ctx = getMockContext({ session: { [OPERATOR_ATTRIBUTE]: undefined } });
+                const ctx = getMockContext({
+                    session: {
+                        [OPERATOR_ATTRIBUTE]: undefined,
+                        [TXC_SOURCE_ATTRIBUTE]: {
+                            source: 'bods',
+                            hasBods: true,
+                            hasTnds: true,
+                        },
+                    },
+                });
 
                 await expect(getServerSideProps(ctx)).rejects.toThrow('invalid NOC set');
+            });
+
+            it('throws an error if txc source attribute not set', async () => {
+                const ctx = getMockContext({
+                    session: {
+                        [TXC_SOURCE_ATTRIBUTE]: undefined,
+                    },
+                });
+
+                await expect(getServerSideProps(ctx)).rejects.toThrow("Cannot read property 'source' of undefined");
             });
         });
     });

--- a/tests/pages/returnDirection.test.tsx
+++ b/tests/pages/returnDirection.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { mount, shallow } from 'enzyme';
-import { getServiceByNocCodeAndLineName, batchGetStopsByAtcoCode } from '../../src/data/auroradb';
+import { getServiceByNocCodeLineNameAndDataSource, batchGetStopsByAtcoCode } from '../../src/data/auroradb';
 import { getMockContext, mockRawService, mockRawServiceWithDuplicates, mockService } from '../testData/mockData';
 import ReturnDirection, { getServerSideProps } from '../../src/pages/returnDirection';
 import { OPERATOR_ATTRIBUTE, SERVICE_ATTRIBUTE } from '../../src/constants/attributes';
@@ -15,7 +15,7 @@ describe('pages', () => {
         ];
 
         beforeEach(() => {
-            (getServiceByNocCodeAndLineName as jest.Mock).mockImplementation(() => mockRawService);
+            (getServiceByNocCodeLineNameAndDataSource as jest.Mock).mockImplementation(() => mockRawService);
             (batchGetStopsByAtcoCode as jest.Mock).mockImplementation(() => [{ localityName: '' }]);
         });
 
@@ -25,7 +25,14 @@ describe('pages', () => {
 
         it('should render correctly', () => {
             const tree = shallow(
-                <ReturnDirection service={mockService} errors={[]} inboundJourney="" outboundJourney="" csrfToken="" />,
+                <ReturnDirection
+                    service={mockService}
+                    errors={[]}
+                    inboundJourney=""
+                    outboundJourney=""
+                    csrfToken=""
+                    dataSource="bods"
+                />,
             );
             expect(tree).toMatchSnapshot();
         });
@@ -38,6 +45,7 @@ describe('pages', () => {
                     inboundJourney=""
                     outboundJourney=""
                     csrfToken=""
+                    dataSource="bods"
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -45,7 +53,14 @@ describe('pages', () => {
 
         it('shows a list of journey patterns for the service in each of the select boxes', () => {
             const wrapper = mount(
-                <ReturnDirection service={mockService} errors={[]} inboundJourney="" outboundJourney="" csrfToken="" />,
+                <ReturnDirection
+                    service={mockService}
+                    errors={[]}
+                    inboundJourney=""
+                    outboundJourney=""
+                    csrfToken=""
+                    dataSource="tnds"
+                />,
             );
 
             const serviceJourney = wrapper.find('.journey-option');
@@ -57,7 +72,9 @@ describe('pages', () => {
 
         describe('getServerSideProps', () => {
             it('returns operator value and list of services when operator attribute exists with NOCCode', async () => {
-                (({ ...getServiceByNocCodeAndLineName } as jest.Mock).mockImplementation(() => mockRawService));
+                (({ ...getServiceByNocCodeLineNameAndDataSource } as jest.Mock).mockImplementation(
+                    () => mockRawService,
+                ));
 
                 const ctx = getMockContext();
 
@@ -73,7 +90,7 @@ describe('pages', () => {
             });
 
             it('removes journeys that have the same start and end points before rendering', async () => {
-                (({ ...getServiceByNocCodeAndLineName } as jest.Mock).mockImplementation(
+                (({ ...getServiceByNocCodeLineNameAndDataSource } as jest.Mock).mockImplementation(
                     () => mockRawServiceWithDuplicates,
                 ));
 
@@ -91,7 +108,9 @@ describe('pages', () => {
             });
 
             it('throws an error if no journey patterns can be found', async () => {
-                (({ ...getServiceByNocCodeAndLineName } as jest.Mock).mockImplementation(() => Promise.resolve(null)));
+                (({ ...getServiceByNocCodeLineNameAndDataSource } as jest.Mock).mockImplementation(() =>
+                    Promise.resolve(null),
+                ));
                 const ctx = getMockContext();
 
                 await expect(getServerSideProps(ctx)).rejects.toThrow();

--- a/tests/pages/service.test.tsx
+++ b/tests/pages/service.test.tsx
@@ -37,6 +37,11 @@ describe('pages', () => {
                     passengerType="Adult"
                     services={mockServices}
                     error={[]}
+                    dataSourceAttribute={{
+                        source: 'tnds',
+                        hasTnds: true,
+                        hasBods: false,
+                    }}
                     csrfToken=""
                 />,
             );
@@ -50,6 +55,11 @@ describe('pages', () => {
                     passengerType="Adult"
                     services={mockServices}
                     error={[]}
+                    dataSourceAttribute={{
+                        source: 'tnds',
+                        hasTnds: true,
+                        hasBods: false,
+                    }}
                     csrfToken=""
                 />,
             );
@@ -65,6 +75,11 @@ describe('pages', () => {
                     passengerType="Adult"
                     services={mockServices}
                     error={[]}
+                    dataSourceAttribute={{
+                        source: 'tnds',
+                        hasTnds: true,
+                        hasBods: false,
+                    }}
                     csrfToken=""
                 />,
             );

--- a/tests/pages/service.test.tsx
+++ b/tests/pages/service.test.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import Service, { getServerSideProps } from '../../src/pages/service';
 import { getServicesByNocCode } from '../../src/data/auroradb';
 import { getMockContext } from '../testData/mockData';
-import { OPERATOR_ATTRIBUTE, PASSENGER_TYPE_ATTRIBUTE } from '../../src/constants/attributes';
+import { OPERATOR_ATTRIBUTE, PASSENGER_TYPE_ATTRIBUTE, TXC_SOURCE_ATTRIBUTE } from '../../src/constants/attributes';
 import { ServiceType } from '../../src/interfaces';
 
 jest.mock('../../src/data/auroradb');
@@ -92,7 +92,15 @@ describe('pages', () => {
         });
 
         it('returns operator value and list of services when operator attribute exists with NOCCode', async () => {
-            const ctx = getMockContext();
+            const ctx = getMockContext({
+                session: {
+                    [TXC_SOURCE_ATTRIBUTE]: {
+                        source: 'bods',
+                        hasBods: true,
+                        hasTnds: true,
+                    },
+                },
+            });
             const result = await getServerSideProps(ctx);
             expect(result).toEqual({
                 props: {
@@ -119,6 +127,11 @@ describe('pages', () => {
                             serviceCode: 'WY_13_IWBT_07_1',
                         },
                     ],
+                    dataSourceAttribute: {
+                        source: 'bods',
+                        hasBods: true,
+                        hasTnds: true,
+                    },
                     csrfToken: '',
                 },
             });
@@ -132,6 +145,13 @@ describe('pages', () => {
 
             const ctx = getMockContext({
                 body: null,
+                session: {
+                    [TXC_SOURCE_ATTRIBUTE]: {
+                        source: 'bods',
+                        hasBods: true,
+                        hasTnds: true,
+                    },
+                },
                 uuid: {},
                 mockWriteHeadFn,
                 mockEndFn,
@@ -147,7 +167,14 @@ describe('pages', () => {
             const mockEndFn = jest.fn();
 
             const ctx = getMockContext({
-                session: { [OPERATOR_ATTRIBUTE]: undefined },
+                session: {
+                    [OPERATOR_ATTRIBUTE]: undefined,
+                    [TXC_SOURCE_ATTRIBUTE]: {
+                        source: 'bods',
+                        hasBods: true,
+                        hasTnds: true,
+                    },
+                },
                 body: null,
                 uuid: {},
                 mockWriteHeadFn,
@@ -174,6 +201,16 @@ describe('pages', () => {
             await expect(getServerSideProps(ctx)).rejects.toThrow(
                 'Could not render the service selection page. Necessary attributes not found.',
             );
+        });
+
+        it('throws an error if txc source attribute not set', async () => {
+            const ctx = getMockContext({
+                session: {
+                    [TXC_SOURCE_ATTRIBUTE]: undefined,
+                },
+            });
+
+            await expect(getServerSideProps(ctx)).rejects.toThrow('Data source attribute not found');
         });
     });
 });

--- a/tests/pages/service.test.tsx
+++ b/tests/pages/service.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import Service, { getServerSideProps } from '../../src/pages/service';
-import { getServicesByNocCode } from '../../src/data/auroradb';
+import { getServicesByNocCodeAndDataSource } from '../../src/data/auroradb';
 import { getMockContext } from '../testData/mockData';
 import { OPERATOR_ATTRIBUTE, PASSENGER_TYPE_ATTRIBUTE, TXC_SOURCE_ATTRIBUTE } from '../../src/constants/attributes';
 import { ServiceType } from '../../src/interfaces';
@@ -27,7 +27,7 @@ const mockServices: ServiceType[] = [
 describe('pages', () => {
     describe('service', () => {
         beforeEach(() => {
-            (getServicesByNocCode as jest.Mock).mockImplementation(() => mockServices);
+            (getServicesByNocCodeAndDataSource as jest.Mock).mockImplementation(() => mockServices);
         });
 
         it('should render correctly', () => {
@@ -138,7 +138,7 @@ describe('pages', () => {
         });
 
         it('throws error if no services can be found', async () => {
-            (getServicesByNocCode as jest.Mock).mockImplementation(() => []);
+            (getServicesByNocCodeAndDataSource as jest.Mock).mockImplementation(() => []);
 
             const mockWriteHeadFn = jest.fn();
             const mockEndFn = jest.fn();

--- a/tests/pages/serviceList.test.tsx
+++ b/tests/pages/serviceList.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import ServiceList, { getServerSideProps } from '../../src/pages/serviceList';
 import { getMockContext } from '../testData/mockData';
-import { getServicesByNocCode } from '../../src/data/auroradb';
+import { getServicesByNocCodeAndDataSource } from '../../src/data/auroradb';
 import { OPERATOR_ATTRIBUTE, SERVICE_LIST_ATTRIBUTE } from '../../src/constants/attributes';
 import { ErrorInfo, ServiceType, ServicesInfo } from '../../src/interfaces';
 
@@ -63,7 +63,7 @@ describe('pages', () => {
         ];
 
         beforeEach(() => {
-            (getServicesByNocCode as jest.Mock).mockImplementation(() => mockServices);
+            (getServicesByNocCodeAndDataSource as jest.Mock).mockImplementation(() => mockServices);
         });
 
         it('should render correctly', () => {

--- a/tests/pages/singleDirection.test.tsx
+++ b/tests/pages/singleDirection.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { mount, shallow } from 'enzyme';
 
 import SingleDirection, { getServerSideProps } from '../../src/pages/singleDirection';
-import { getServiceByNocCodeAndLineName, batchGetStopsByAtcoCode } from '../../src/data/auroradb';
+import { getServiceByNocCodeLineNameAndDataSource, batchGetStopsByAtcoCode } from '../../src/data/auroradb';
 import { mockRawService, mockService, mockRawServiceWithDuplicates, getMockContext } from '../testData/mockData';
 import { OPERATOR_ATTRIBUTE, SERVICE_ATTRIBUTE } from '../../src/constants/attributes';
 
@@ -11,7 +11,7 @@ jest.mock('../../src/data/auroradb.ts');
 describe('pages', () => {
     describe('singleDirection', () => {
         beforeEach(() => {
-            (getServiceByNocCodeAndLineName as jest.Mock).mockImplementation(() => mockRawService);
+            (getServiceByNocCodeLineNameAndDataSource as jest.Mock).mockImplementation(() => mockRawService);
             (batchGetStopsByAtcoCode as jest.Mock).mockImplementation(() => [{ localityName: '' }]);
         });
 
@@ -23,6 +23,7 @@ describe('pages', () => {
                     lineName="X6A"
                     service={mockService}
                     error={[]}
+                    dataSource="bods"
                     csrfToken=""
                 />,
             );
@@ -37,6 +38,7 @@ describe('pages', () => {
                     lineName="X6A"
                     service={mockService}
                     error={[]}
+                    dataSource="tnds"
                     csrfToken=""
                 />,
             );
@@ -53,6 +55,7 @@ describe('pages', () => {
                     lineName="X6A"
                     service={mockService}
                     error={[]}
+                    dataSource="bods"
                     csrfToken=""
                 />,
             );
@@ -66,7 +69,9 @@ describe('pages', () => {
 
         describe('getServerSideProps', () => {
             it('returns operator value and list of services when operator attribute exists with NOCCode', async () => {
-                (({ ...getServiceByNocCodeAndLineName } as jest.Mock).mockImplementation(() => mockRawService));
+                (({ ...getServiceByNocCodeLineNameAndDataSource } as jest.Mock).mockImplementation(
+                    () => mockRawService,
+                ));
 
                 const ctx = getMockContext();
 
@@ -76,7 +81,7 @@ describe('pages', () => {
             });
 
             it('removes journeys that have the same start and end points before rendering', async () => {
-                (({ ...getServiceByNocCodeAndLineName } as jest.Mock).mockImplementation(
+                (({ ...getServiceByNocCodeLineNameAndDataSource } as jest.Mock).mockImplementation(
                     () => mockRawServiceWithDuplicates,
                 ));
 
@@ -87,7 +92,9 @@ describe('pages', () => {
             });
 
             it('throws an error if no journey patterns can be found', async () => {
-                (({ ...getServiceByNocCodeAndLineName } as jest.Mock).mockImplementation(() => Promise.resolve(null)));
+                (({ ...getServiceByNocCodeLineNameAndDataSource } as jest.Mock).mockImplementation(() =>
+                    Promise.resolve(null),
+                ));
                 const ctx = getMockContext();
 
                 await expect(getServerSideProps(ctx)).rejects.toThrow();

--- a/tests/pages/singleDirection.test.tsx
+++ b/tests/pages/singleDirection.test.tsx
@@ -4,7 +4,7 @@ import { mount, shallow } from 'enzyme';
 import SingleDirection, { getServerSideProps } from '../../src/pages/singleDirection';
 import { getServiceByNocCodeLineNameAndDataSource, batchGetStopsByAtcoCode } from '../../src/data/auroradb';
 import { mockRawService, mockService, mockRawServiceWithDuplicates, getMockContext } from '../testData/mockData';
-import { OPERATOR_ATTRIBUTE, SERVICE_ATTRIBUTE } from '../../src/constants/attributes';
+import { OPERATOR_ATTRIBUTE, SERVICE_ATTRIBUTE, TXC_SOURCE_ATTRIBUTE } from '../../src/constants/attributes';
 
 jest.mock('../../src/data/auroradb.ts');
 
@@ -73,7 +73,15 @@ describe('pages', () => {
                     () => mockRawService,
                 ));
 
-                const ctx = getMockContext();
+                const ctx = getMockContext({
+                    session: {
+                        [TXC_SOURCE_ATTRIBUTE]: {
+                            source: 'bods',
+                            hasBods: true,
+                            hasTnds: true,
+                        },
+                    },
+                });
 
                 const result = await getServerSideProps(ctx);
 
@@ -85,7 +93,15 @@ describe('pages', () => {
                     () => mockRawServiceWithDuplicates,
                 ));
 
-                const ctx = getMockContext();
+                const ctx = getMockContext({
+                    session: {
+                        [TXC_SOURCE_ATTRIBUTE]: {
+                            source: 'bods',
+                            hasBods: true,
+                            hasTnds: true,
+                        },
+                    },
+                });
 
                 const result = await getServerSideProps(ctx);
                 expect(result.props.service).toEqual(mockService);

--- a/tests/pages/ticketConfirmation.test.tsx
+++ b/tests/pages/ticketConfirmation.test.tsx
@@ -29,6 +29,7 @@ import {
     SCHOOL_FARE_TYPE_ATTRIBUTE,
     SERVICE_LIST_ATTRIBUTE,
     TICKET_REPRESENTATION_ATTRIBUTE,
+    TXC_SOURCE_ATTRIBUTE,
 } from '../../src/constants/attributes';
 import { ConfirmationElement, MultiOperatorInfo, Operator } from '../../src/interfaces';
 
@@ -60,9 +61,14 @@ describe('pages', () => {
                             userFareStages,
                             matchingFareZones: mockMatchingFaresZones,
                         },
+                        [TXC_SOURCE_ATTRIBUTE]: {
+                            source: 'bods',
+                            hasBods: true,
+                            hasTnds: true,
+                        },
                     },
                 });
-                const expectedConfirmationElementsLength = 2 + Object.entries(mockMatchingFaresZones).length;
+                const expectedConfirmationElementsLength = 3 + Object.entries(mockMatchingFaresZones).length;
                 const confirmationElements = buildSingleTicketConfirmationElements(ctx);
                 expect(confirmationElements).toContainEqual(confirmationElementStructure);
                 expect(confirmationElements).toHaveLength(expectedConfirmationElementsLength);
@@ -91,10 +97,15 @@ describe('pages', () => {
                             amount: '5',
                             typeOfDuration: 'day',
                         },
+                        [TXC_SOURCE_ATTRIBUTE]: {
+                            source: 'bods',
+                            hasBods: true,
+                            hasTnds: true,
+                        },
                     },
                 });
                 const totalNumberOfMatchingFareZones = Object.entries(mockMatchingFaresZones).length * 2;
-                const totalExpectedLength = 2 + totalNumberOfMatchingFareZones;
+                const totalExpectedLength = 3 + totalNumberOfMatchingFareZones;
                 const confirmationElements = buildReturnTicketConfirmationElements(ctx);
                 expect(confirmationElements).toContainEqual(confirmationElementStructure);
                 expect(confirmationElements).toHaveLength(totalExpectedLength);
@@ -110,10 +121,15 @@ describe('pages', () => {
                             matchingFareZones: mockMatchingFaresZones,
                         },
                         [JOURNEY_ATTRIBUTE]: { directionJourneyPattern: '0690WNA02857#0690WNA02856' },
+                        [TXC_SOURCE_ATTRIBUTE]: {
+                            source: 'bods',
+                            hasBods: true,
+                            hasTnds: true,
+                        },
                     },
                 });
                 const totalNumberOfMatchingFareZones = Object.entries(mockMatchingFaresZones).length;
-                const totalExpectedLength = 1 + totalNumberOfMatchingFareZones;
+                const totalExpectedLength = 2 + totalNumberOfMatchingFareZones;
                 const confirmationElements = buildReturnTicketConfirmationElements(ctx);
                 expect(confirmationElements).toContainEqual(confirmationElementStructure);
                 expect(confirmationElements).toHaveLength(totalExpectedLength);


### PR DESCRIPTION
# Description

-   Allows the user to change their TXC data source from TNDS to BODS and back again for the single and return journeys.

# Testing instructions

-   Run locally against most recent master branch of dev, and use single and return journeys.

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
