### PR TITLE
Feat/cfd 42 saved multioperator lists

### DIFF
--- a/src/components/RadioConditionalInput.tsx
+++ b/src/components/RadioConditionalInput.tsx
@@ -8,7 +8,6 @@ import {
     RadioWithConditionalInputs,
     RadioButton,
     RadioConditionalInputFieldset,
-    PremadeTimeRestriction,
 } from '../interfaces';
 import FormElementWrapper from './FormElementWrapper';
 
@@ -286,7 +285,7 @@ const renderConditionalDateInputs = (radio: RadioWithConditionalInputs): ReactEl
     );
 };
 
-const renderConditionalTimeRestrictionDropdown = (radio: RadioWithConditionalInputs): ReactElement => {
+const renderConditionalDropdown = (radio: RadioWithConditionalInputs): ReactElement => {
     const error = radio.inputErrors.length > 0;
 
     return (
@@ -309,17 +308,18 @@ const renderConditionalTimeRestrictionDropdown = (radio: RadioWithConditionalInp
                         errorId={error ? radio.inputErrors[0].id : ''}
                         errorClass=""
                     >
-                        <select className="govuk-select" id="time-restriction" name="timeRestriction" defaultValue="">
+                        <select
+                            className="govuk-select"
+                            id="conditional-dropdown"
+                            name="conditionalDropdown"
+                            defaultValue=""
+                        >
                             <option value="" disabled>
                                 Select One
                             </option>
-                            {(radio.inputs as PremadeTimeRestriction[]).map(timeRestriction => (
-                                <option
-                                    key={`${timeRestriction.name}`}
-                                    value={`${timeRestriction.name}`}
-                                    className="govuk-select"
-                                >
-                                    {timeRestriction.name}
+                            {(radio.inputs as BaseReactElement[]).map(input => (
+                                <option key={`${input.name}`} value={`${input.name}`} className="govuk-select">
+                                    {input.name}
                                 </option>
                             ))}
                         </select>
@@ -375,7 +375,7 @@ const renderConditionalRadioButton = (
         text: renderConditionalTextInput,
         textWithUnits: renderConditionalTextWithUnitsInput,
         date: renderConditionalDateInputs,
-        dropdown: renderConditionalTimeRestrictionDropdown,
+        dropdown: renderConditionalDropdown,
     };
 
     return (

--- a/src/components/RadioConditionalInput.tsx
+++ b/src/components/RadioConditionalInput.tsx
@@ -310,8 +310,8 @@ const renderConditionalDropdown = (radio: RadioWithConditionalInputs): ReactElem
                     >
                         <select
                             className="govuk-select"
-                            id="conditional-dropdown"
-                            name="conditionalDropdown"
+                            id={radio.selectIdentifier || 'conditional-dropdown'}
+                            name={radio.selectIdentifier || 'conditional-dropdown'}
                             defaultValue=""
                         >
                             <option value="" disabled>
@@ -428,7 +428,7 @@ const RadioConditionalInput = ({ fieldset }: RadioConditionalInputProps): ReactE
     const radioError = fieldset.radioError.length > 0;
 
     return (
-        <div className={`govuk-form-group ${radioError ? 'govuk-form-group--error' : ''}`}>
+        <div className={`govuk-form-group ${radioError ? 'govuk-form-group--error' : ''}`} id="conditional-form-group">
             <fieldset className="govuk-fieldset" aria-describedby={fieldset.heading.id}>
                 <legend className="govuk-fieldset__legend govuk-fieldset__legend--m">
                     <h2

--- a/src/constants/attributes.ts
+++ b/src/constants/attributes.ts
@@ -80,4 +80,6 @@ export const OPERATOR_ATTRIBUTE = 'fdbt-operator';
 
 export const TXC_SOURCE_ATTRIBUTE = 'fdbt-txc-source';
 
+export const REUSE_OPERATOR_GROUP_ATTRIBUTE = 'fdbt-reuse-operator-group';
+
 export const SAVE_OPERATOR_GROUP_ATTRIBUTE = 'fdbt-save-operator-group';

--- a/src/constants/attributes.ts
+++ b/src/constants/attributes.ts
@@ -79,3 +79,5 @@ export const USER_ATTRIBUTE = 'fdbt-user';
 export const OPERATOR_ATTRIBUTE = 'fdbt-operator';
 
 export const TXC_SOURCE_ATTRIBUTE = 'fdbt-txc-source';
+
+export const SAVE_OPERATOR_GROUP_ATTRIBUTE = 'fdbt-save-operator-group';

--- a/src/data/auroradb.ts
+++ b/src/data/auroradb.ts
@@ -1,9 +1,8 @@
 import dateFormat from 'dateformat';
 import { createPool, Pool } from 'mysql2/promise';
 import awsParamStore from 'aws-param-store';
-import logger from '../utils/logger';
-import { INTERNAL_NOC } from '../constants';
 import {
+    OperatorGroup,
     Operator,
     ServiceType,
     RawService,
@@ -11,7 +10,9 @@ import {
     SalesOfferPackage,
     FullTimeRestriction,
     PremadeTimeRestriction,
-} from '../interfaces';
+} from '../interfaces/index';
+import logger from '../utils/logger';
+import { INTERNAL_NOC } from '../constants';
 
 interface QueryData {
     operatorShortName: string;
@@ -51,6 +52,12 @@ interface RawSalesOfferPackage {
 }
 
 interface RawTimeRestriction {
+    nocCode: string;
+    name: string;
+    contents: string;
+}
+
+interface RawOperatorGroup {
     nocCode: string;
     name: string;
     contents: string;
@@ -425,6 +432,54 @@ export const deleteSalesOfferPackageByNocCodeAndName = async (sopId: string, noc
     }
 };
 
+export const insertOperatorGroup = async (nocCode: string, operators: Operator[], name: string): Promise<void> => {
+    logger.info('', {
+        context: 'data.auroradb',
+        message: 'inserting operator group for given name and nocCode',
+        nocCode,
+        name,
+    });
+
+    const contents = JSON.stringify(operators);
+
+    const insertQuery = `INSERT INTO operatorGroup 
+    (nocCode, name, contents) 
+    VALUES (?, ?, ?)`;
+    try {
+        await executeQuery(insertQuery, [nocCode, name, contents]);
+    } catch (error) {
+        throw new Error(`Could not insert operator group into the operatorGroup table. ${error.stack}`);
+    }
+};
+
+export const getOperatorGroupByNameAndNoc = async (name: string, nocCode: string): Promise<OperatorGroup[]> => {
+    logger.info('', {
+        context: 'data.auroradb',
+        message: 'retrieving operator group for given name and nocCode',
+        name,
+        nocCode,
+    });
+
+    try {
+        const queryInput = `
+            SELECT contents
+            FROM operatorGroup
+            WHERE name = ?
+            AND nocCode = ?
+        `;
+
+        const queryResults = await executeQuery<RawOperatorGroup[]>(queryInput, [name, nocCode]);
+
+        return queryResults.map(item => ({
+            name,
+            nocCode,
+            operators: JSON.parse(item.contents),
+        }));
+    } catch (error) {
+        throw new Error(`Could not retrieve operator group by name and nocCode from AuroraDB: ${error.stack}`);
+    }
+};
+
 export const insertTimeRestriction = async (
     nocCode: string,
     timeRestriction: FullTimeRestriction[],
@@ -432,8 +487,9 @@ export const insertTimeRestriction = async (
 ): Promise<void> => {
     logger.info('', {
         context: 'data.auroradb',
-        message: 'inserting time restriction for given noc',
-        noc: nocCode,
+        message: 'inserting time restriction for given noc and name',
+        nocCode,
+        name,
     });
 
     const contents = JSON.stringify(timeRestriction);
@@ -452,7 +508,7 @@ export const getTimeRestrictionByNocCode = async (nocCode: string): Promise<Prem
     logger.info('', {
         context: 'data.auroradb',
         message: 'retrieving time restrictions for given noc',
-        noc: nocCode,
+        nocCode,
     });
 
     try {
@@ -481,8 +537,9 @@ export const getTimeRestrictionByNameAndNoc = async (
 ): Promise<PremadeTimeRestriction[]> => {
     logger.info('', {
         context: 'data.auroradb',
-        message: 'retrieving time restriction for given name',
+        message: 'retrieving time restriction for given name and nocCode',
         name,
+        nocCode,
     });
 
     try {

--- a/src/data/auroradb.ts
+++ b/src/data/auroradb.ts
@@ -452,10 +452,35 @@ export const insertOperatorGroup = async (nocCode: string, operators: Operator[]
     }
 };
 
-export const getOperatorGroupByNameAndNoc = async (name: string, nocCode: string): Promise<OperatorGroup[]> => {
+export const getOperatorGroupsByNoc = async (noc: string): Promise<OperatorGroup[]> => {
     logger.info('', {
         context: 'data.auroradb',
-        message: 'retrieving operator group for given name and nocCode',
+        message: 'retrieving operator groups for given noc',
+        noc,
+    });
+
+    try {
+        const queryInput = `
+            SELECT contents, name
+            FROM operatorGroup
+            WHERE nocCode = ?
+        `;
+
+        const queryResults = await executeQuery<RawOperatorGroup[]>(queryInput, [noc]);
+
+        return queryResults.map(item => ({
+            name: item.name,
+            operators: JSON.parse(item.contents),
+        }));
+    } catch (error) {
+        throw new Error(`Could not retrieve operator group by noc from AuroraDB: ${error.stack}`);
+    }
+};
+
+export const getOperatorGroupsByNameAndNoc = async (name: string, nocCode: string): Promise<OperatorGroup[]> => {
+    logger.info('', {
+        context: 'data.auroradb',
+        message: 'retrieving operator groups for given name and nocCode',
         name,
         nocCode,
     });

--- a/src/data/auroradb.ts
+++ b/src/data/auroradb.ts
@@ -452,11 +452,11 @@ export const insertOperatorGroup = async (nocCode: string, operators: Operator[]
     }
 };
 
-export const getOperatorGroupsByNoc = async (noc: string): Promise<OperatorGroup[]> => {
+export const getOperatorGroupsByNoc = async (nocCode: string): Promise<OperatorGroup[]> => {
     logger.info('', {
         context: 'data.auroradb',
-        message: 'retrieving operator groups for given noc',
-        noc,
+        message: 'retrieving operator groups for given nocCode',
+        nocCode,
     });
 
     try {
@@ -466,14 +466,14 @@ export const getOperatorGroupsByNoc = async (noc: string): Promise<OperatorGroup
             WHERE nocCode = ?
         `;
 
-        const queryResults = await executeQuery<RawOperatorGroup[]>(queryInput, [noc]);
+        const queryResults = await executeQuery<RawOperatorGroup[]>(queryInput, [nocCode]);
 
         return queryResults.map(item => ({
             name: item.name,
             operators: JSON.parse(item.contents),
         }));
     } catch (error) {
-        throw new Error(`Could not retrieve operator group by noc from AuroraDB: ${error.stack}`);
+        throw new Error(`Could not retrieve operator group by nocCode from AuroraDB: ${error.stack}`);
     }
 };
 

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -68,6 +68,11 @@ export interface Operator {
     nocCode: string;
 }
 
+export interface OperatorGroup {
+    name: string;
+    operators: Operator[];
+}
+
 export interface MultiOperatorInfo {
     nocCode: string;
     services: string[];

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -741,6 +741,7 @@ export interface RadioWithConditionalInputs extends RadioWithoutConditionals {
     inputType: 'text' | 'checkbox' | 'date' | 'textWithUnits' | 'dropdown';
     inputs: BaseReactElement[] | PremadeTimeRestriction[];
     inputErrors: ErrorInfo[];
+    selectIdentifier?: string;
 }
 
 export type RadioButton = RadioWithoutConditionals | RadioWithConditionalInputs;

--- a/src/pages/api/chooseTimeRestrictions.ts
+++ b/src/pages/api/chooseTimeRestrictions.ts
@@ -3,7 +3,7 @@ import { NextApiResponse } from 'next';
 import { getTimeRestrictionByNameAndNoc, insertTimeRestriction } from '../../data/auroradb';
 import { removeAllWhiteSpace, removeExcessWhiteSpace } from './apiUtils/validator';
 import { NextApiRequestWithSession, TimeRestriction, ErrorInfo, FullTimeRestriction, TimeBand } from '../../interfaces';
-import { redirectToError, redirectTo, getNocFromIdToken } from './apiUtils';
+import { redirectToError, redirectTo, getAndValidateNoc } from './apiUtils';
 import { getSessionAttribute, updateSessionAttribute } from '../../utils/sessions';
 import { TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE, FULL_TIME_RESTRICTIONS_ATTRIBUTE } from '../../constants/attributes';
 
@@ -149,10 +149,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
         const errors: ErrorInfo[] = collectErrors(sanitisedInputs);
         let createdANewTimeRestriction = false;
         if (errors.length === 0 && refinedName) {
-            const noc = getNocFromIdToken(req, res);
-            if (!noc) {
-                throw new Error('Could not find users NOC code.');
-            }
+            const noc = getAndValidateNoc(req, res);
 
             const results = await getTimeRestrictionByNameAndNoc(refinedName, noc);
 

--- a/src/pages/api/csvZoneUpload.ts
+++ b/src/pages/api/csvZoneUpload.ts
@@ -182,7 +182,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             const { fareType } = getSessionAttribute(req, FARE_TYPE_ATTRIBUTE) as FareType;
 
             if (fareType === 'multiOperator') {
-                redirectTo(res, '/searchOperators');
+                redirectTo(res, '/reuseOperatorGroup');
                 return;
             }
 

--- a/src/pages/api/reuseOperatorGroup.ts
+++ b/src/pages/api/reuseOperatorGroup.ts
@@ -21,6 +21,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
         }
 
         if (reuseGroupChoice === 'No') {
+            updateSessionAttribute(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, []);
             redirectTo(res, '/searchOperators');
             return;
         }

--- a/src/pages/api/reuseOperatorGroup.ts
+++ b/src/pages/api/reuseOperatorGroup.ts
@@ -1,0 +1,42 @@
+import { NextApiResponse } from 'next';
+import { getAndValidateNoc, redirectTo, redirectToError } from './apiUtils/index';
+import { getOperatorGroupsByNameAndNoc } from '../../data/auroradb';
+import { MULTIPLE_OPERATOR_ATTRIBUTE, REUSE_OPERATOR_GROUP_ATTRIBUTE } from '../../constants/attributes';
+import { NextApiRequestWithSession } from '../../interfaces';
+import { updateSessionAttribute } from '../../utils/sessions';
+
+export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
+    try {
+        const { reuseGroupChoice, premadeOperatorGroup } = req.body;
+        if (!reuseGroupChoice) {
+            updateSessionAttribute(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, [
+                { errorMessage: 'Choose one of the options below', id: 'conditional-form-group' },
+            ]);
+            redirectTo(res, '/reuseOperatorGroup');
+            return;
+        }
+
+        if (reuseGroupChoice === 'No') {
+            redirectTo(res, '/searchOperators');
+            return;
+        }
+        if (!premadeOperatorGroup) {
+            updateSessionAttribute(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, [
+                { errorMessage: 'Choose a premade operator group from the options below', id: 'premadeOperatorGroup' },
+            ]);
+            redirectTo(res, '/reuseOperatorGroup');
+            return;
+        }
+        const noc = getAndValidateNoc(req, res);
+        const selectedOperators = (await getOperatorGroupsByNameAndNoc(premadeOperatorGroup, noc))[0].operators;
+
+        updateSessionAttribute(req, MULTIPLE_OPERATOR_ATTRIBUTE, { selectedOperators });
+        updateSessionAttribute(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, []);
+
+        redirectTo(res, '/multipleOperatorsServiceList');
+        return;
+    } catch (error) {
+        const message = 'There was a problem with the user selecting their premade operator group:';
+        redirectToError(res, message, 'api.reuseOperatorGroup', error);
+    }
+};

--- a/src/pages/api/reuseOperatorGroup.ts
+++ b/src/pages/api/reuseOperatorGroup.ts
@@ -1,9 +1,13 @@
 import { NextApiResponse } from 'next';
 import { getAndValidateNoc, redirectTo, redirectToError } from './apiUtils/index';
 import { getOperatorGroupsByNameAndNoc } from '../../data/auroradb';
-import { MULTIPLE_OPERATOR_ATTRIBUTE, REUSE_OPERATOR_GROUP_ATTRIBUTE } from '../../constants/attributes';
-import { NextApiRequestWithSession } from '../../interfaces';
-import { updateSessionAttribute } from '../../utils/sessions';
+import {
+    MULTIPLE_OPERATOR_ATTRIBUTE,
+    REUSE_OPERATOR_GROUP_ATTRIBUTE,
+    TICKET_REPRESENTATION_ATTRIBUTE,
+} from '../../constants/attributes';
+import { NextApiRequestWithSession, TicketRepresentationAttribute } from '../../interfaces';
+import { updateSessionAttribute, getSessionAttribute } from '../../utils/sessions';
 
 export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
     try {
@@ -32,8 +36,14 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
 
         updateSessionAttribute(req, MULTIPLE_OPERATOR_ATTRIBUTE, { selectedOperators });
         updateSessionAttribute(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, []);
-
-        redirectTo(res, '/multipleOperatorsServiceList');
+        const ticketRepresentation = (getSessionAttribute(
+            req,
+            TICKET_REPRESENTATION_ATTRIBUTE,
+        ) as TicketRepresentationAttribute).name;
+        redirectTo(
+            res,
+            ticketRepresentation === 'multipleServices' ? '/multipleOperatorsServiceList' : '/howManyProducts',
+        );
         return;
     } catch (error) {
         const message = 'There was a problem with the user selecting their premade operator group:';

--- a/src/pages/api/reuseOperatorGroup.ts
+++ b/src/pages/api/reuseOperatorGroup.ts
@@ -25,6 +25,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             redirectTo(res, '/searchOperators');
             return;
         }
+
         if (!premadeOperatorGroup) {
             updateSessionAttribute(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, [
                 { errorMessage: 'Choose a premade operator group from the options below', id: 'premadeOperatorGroup' },
@@ -32,11 +33,12 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             redirectTo(res, '/reuseOperatorGroup');
             return;
         }
+
         const noc = getAndValidateNoc(req, res);
         const selectedOperators = (await getOperatorGroupsByNameAndNoc(premadeOperatorGroup, noc))[0].operators;
-
         updateSessionAttribute(req, MULTIPLE_OPERATOR_ATTRIBUTE, { selectedOperators });
         updateSessionAttribute(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, []);
+
         const ticketRepresentation = (getSessionAttribute(
             req,
             TICKET_REPRESENTATION_ATTRIBUTE,

--- a/src/pages/api/saveOperatorGroup.ts
+++ b/src/pages/api/saveOperatorGroup.ts
@@ -11,7 +11,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
         const { reuseGroup } = req.body;
         if (!reuseGroup) {
             updateSessionAttribute(req, SAVE_OPERATOR_GROUP_ATTRIBUTE, [
-                { errorMessage: 'Choose one of the options below', id: 'yes-reuse' },
+                { errorMessage: 'Choose one of the options below', id: 'reuse-operator-group-yes' },
             ]);
             redirectTo(res, '/saveOperatorGroup');
             return;

--- a/src/pages/api/saveOperatorGroup.ts
+++ b/src/pages/api/saveOperatorGroup.ts
@@ -3,7 +3,7 @@ import { getAndValidateNoc, redirectToError, redirectTo } from './apiUtils/index
 import { NextApiRequestWithSession, MultipleOperatorsAttribute } from '../../interfaces';
 import { updateSessionAttribute, getSessionAttribute } from '../../utils/sessions';
 import { SAVE_OPERATOR_GROUP_ATTRIBUTE, MULTIPLE_OPERATOR_ATTRIBUTE } from '../../constants/attributes';
-import { getOperatorGroupByNameAndNoc, insertOperatorGroup } from '../../data/auroradb';
+import { getOperatorGroupsByNameAndNoc, insertOperatorGroup } from '../../data/auroradb';
 import { removeExcessWhiteSpace } from './apiUtils/validator';
 
 export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
@@ -27,7 +27,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                 return;
             }
             const noc = getAndValidateNoc(req, res);
-            const results = await getOperatorGroupByNameAndNoc(refinedGroupName, noc);
+            const results = await getOperatorGroupsByNameAndNoc(refinedGroupName, noc);
             const nameIsNotUnique = results.length >= 1;
             if (nameIsNotUnique) {
                 updateSessionAttribute(req, SAVE_OPERATOR_GROUP_ATTRIBUTE, [
@@ -44,6 +44,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                 .selectedOperators;
             await insertOperatorGroup(noc, operators, refinedGroupName);
         }
+        updateSessionAttribute(req, SAVE_OPERATOR_GROUP_ATTRIBUTE, []);
         redirectTo(res, '/multipleOperatorsServiceList');
     } catch (error) {
         const message = 'There was a problem saving the operator group:';

--- a/src/pages/api/saveOperatorGroup.ts
+++ b/src/pages/api/saveOperatorGroup.ts
@@ -1,0 +1,54 @@
+import { NextApiResponse } from 'next';
+import { getAndValidateNoc, redirectToError, redirectTo } from './apiUtils/index';
+import { NextApiRequestWithSession } from '../../interfaces';
+import { updateSessionAttribute } from '../../utils/sessions';
+import { SAVE_OPERATOR_GROUP_ATTRIBUTE } from '../../constants/attributes';
+import { getOperatorGroupByNameAndNoc } from '../../data/auroradb';
+
+export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
+    try {
+        console.log(req.body);
+        const { reuseGroup } = req.body;
+        if (!reuseGroup) {
+            updateSessionAttribute(req, SAVE_OPERATOR_GROUP_ATTRIBUTE, [
+                { errorMessage: 'Choose one of the options below', id: 'yes-reuse' },
+            ]);
+            redirectTo(res, '/saveOperatorGroup');
+            return;
+        }
+        if (reuseGroup === 'yes') {
+            const { groupName } = req.body;
+            if (!groupName) {
+                updateSessionAttribute(req, SAVE_OPERATOR_GROUP_ATTRIBUTE, [
+                    { errorMessage: 'Provide a name for the operator group', id: 'operator-group-name-input' },
+                ]);
+                redirectTo(res, '/saveOperatorGroup');
+                return;
+            }
+            // DATABASE CALL TO CHECK NAME IS UNIQUE
+            const noc = getAndValidateNoc(req, res);
+            const results = await getOperatorGroupByNameAndNoc(groupName, noc);
+            const nameIsNotUnique = results.length >= 1;
+            if (nameIsNotUnique) {
+                updateSessionAttribute(req, SAVE_OPERATOR_GROUP_ATTRIBUTE, [
+                    {
+                        errorMessage: `A saved operator group with name ${groupName} already exists, provide a unique name`,
+                        id: 'operator-group-name-input',
+                        userInput: groupName,
+                    },
+                ]);
+                redirectTo(res, '/saveOperatorGroup');
+                return;
+            }
+            // DATABASE CALL TO ADD GROUP
+
+
+
+            
+        }
+        redirectTo(res, '/multipleOperatorsServiceList');
+    } catch (error) {
+        const message = 'There was a problem saving the operator group:';
+        redirectToError(res, message, 'api.saveOperatorGroup', error);
+    }
+};

--- a/src/pages/api/saveOperatorGroup.ts
+++ b/src/pages/api/saveOperatorGroup.ts
@@ -12,15 +12,15 @@ import { removeExcessWhiteSpace } from './apiUtils/validator';
 
 export default async (req: NextApiRequestWithSession, res: NextApiResponse): Promise<void> => {
     try {
-        const { reuseGroup } = req.body;
-        if (!reuseGroup) {
+        const { saveGroup } = req.body;
+        if (!saveGroup) {
             updateSessionAttribute(req, SAVE_OPERATOR_GROUP_ATTRIBUTE, [
-                { errorMessage: 'Choose one of the options below', id: 'reuse-operator-group-yes' },
+                { errorMessage: 'Choose one of the options below', id: 'save-operator-group-yes' },
             ]);
             redirectTo(res, '/saveOperatorGroup');
             return;
         }
-        if (reuseGroup === 'yes') {
+        if (saveGroup === 'yes') {
             const { groupName } = req.body;
             const refinedGroupName = removeExcessWhiteSpace(groupName);
             if (!refinedGroupName) {

--- a/src/pages/api/saveOperatorGroup.ts
+++ b/src/pages/api/saveOperatorGroup.ts
@@ -1,8 +1,12 @@
 import { NextApiResponse } from 'next';
 import { getAndValidateNoc, redirectToError, redirectTo } from './apiUtils/index';
-import { NextApiRequestWithSession, MultipleOperatorsAttribute } from '../../interfaces';
+import { NextApiRequestWithSession, MultipleOperatorsAttribute, TicketRepresentationAttribute } from '../../interfaces';
 import { updateSessionAttribute, getSessionAttribute } from '../../utils/sessions';
-import { SAVE_OPERATOR_GROUP_ATTRIBUTE, MULTIPLE_OPERATOR_ATTRIBUTE } from '../../constants/attributes';
+import {
+    SAVE_OPERATOR_GROUP_ATTRIBUTE,
+    MULTIPLE_OPERATOR_ATTRIBUTE,
+    TICKET_REPRESENTATION_ATTRIBUTE,
+} from '../../constants/attributes';
 import { getOperatorGroupsByNameAndNoc, insertOperatorGroup } from '../../data/auroradb';
 import { removeExcessWhiteSpace } from './apiUtils/validator';
 
@@ -45,7 +49,14 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             await insertOperatorGroup(noc, operators, refinedGroupName);
         }
         updateSessionAttribute(req, SAVE_OPERATOR_GROUP_ATTRIBUTE, []);
-        redirectTo(res, '/multipleOperatorsServiceList');
+        const ticketRepresentation = (getSessionAttribute(
+            req,
+            TICKET_REPRESENTATION_ATTRIBUTE,
+        ) as TicketRepresentationAttribute).name;
+        redirectTo(
+            res,
+            ticketRepresentation === 'multipleServices' ? '/multipleOperatorsServiceList' : '/howManyProducts',
+        );
     } catch (error) {
         const message = 'There was a problem saving the operator group:';
         redirectToError(res, message, 'api.saveOperatorGroup', error);

--- a/src/pages/api/searchOperators.ts
+++ b/src/pages/api/searchOperators.ts
@@ -1,7 +1,7 @@
 import { NextApiResponse } from 'next';
 import uniqBy from 'lodash/uniqBy';
-import { ErrorInfo, NextApiRequestWithSession, Operator, TicketRepresentationAttribute } from '../../interfaces';
-import { MULTIPLE_OPERATOR_ATTRIBUTE, TICKET_REPRESENTATION_ATTRIBUTE } from '../../constants/attributes';
+import { ErrorInfo, NextApiRequestWithSession, Operator } from '../../interfaces';
+import { MULTIPLE_OPERATOR_ATTRIBUTE } from '../../constants/attributes';
 import { redirectTo, redirectToError } from './apiUtils';
 import { getSessionAttribute, updateSessionAttribute } from '../../utils/sessions';
 import { removeExcessWhiteSpace } from './apiUtils/validator';
@@ -117,18 +117,8 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
         updateSessionAttribute(req, MULTIPLE_OPERATOR_ATTRIBUTE, { selectedOperators });
 
         if (continueButtonClick) {
-            const ticketType = (getSessionAttribute(
-                req,
-                TICKET_REPRESENTATION_ATTRIBUTE,
-            ) as TicketRepresentationAttribute).name;
-            if (ticketType === 'geoZone') {
-                redirectTo(res, '/saveOperatorGroup');
-                return;
-            }
-            if (ticketType === 'multipleServices') {
-                redirectTo(res, '/saveOperatorGroup');
-                return;
-            }
+            redirectTo(res, '/saveOperatorGroup');
+            return;
         }
 
         redirectTo(res, '/searchOperators');

--- a/src/pages/api/searchOperators.ts
+++ b/src/pages/api/searchOperators.ts
@@ -126,7 +126,7 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
                 return;
             }
             if (ticketType === 'multipleServices') {
-                redirectTo(res, '/multipleOperatorsServiceList');
+                redirectTo(res, '/saveOperatorGroup');
                 return;
             }
         }

--- a/src/pages/api/searchOperators.ts
+++ b/src/pages/api/searchOperators.ts
@@ -122,7 +122,7 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
                 TICKET_REPRESENTATION_ATTRIBUTE,
             ) as TicketRepresentationAttribute).name;
             if (ticketType === 'geoZone') {
-                redirectTo(res, '/howManyProducts');
+                redirectTo(res, '/saveOperatorGroup');
                 return;
             }
             if (ticketType === 'multipleServices') {

--- a/src/pages/api/serviceList.ts
+++ b/src/pages/api/serviceList.ts
@@ -57,7 +57,7 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
             return;
         }
         if (fareType === 'multiOperator') {
-            redirectTo(res, '/searchOperators');
+            redirectTo(res, '/reuseOperatorGroup');
             return;
         }
 

--- a/src/pages/defineTimeRestrictions.tsx
+++ b/src/pages/defineTimeRestrictions.tsx
@@ -8,7 +8,6 @@ import {
     RadioConditionalInputFieldset,
     TimeRestriction,
     TimeRestrictionsDefinitionWithErrors,
-    PremadeTimeRestriction,
 } from '../interfaces';
 import CsrfForm from '../components/CsrfForm';
 import { getSessionAttribute } from '../utils/sessions';
@@ -27,7 +26,7 @@ interface DefineTimeRestrictionsProps {
 
 export const getFieldsets = (
     errors: ErrorInfo[],
-    premadeTimeRestrictions: PremadeTimeRestriction[],
+    timeRestrictionNames: string[],
     timeRestrictionsDefinition?: TimeRestriction | TimeRestrictionsDefinitionWithErrors,
 ): RadioConditionalInputFieldset[] => {
     const validDaysFieldset: RadioConditionalInputFieldset = {
@@ -42,7 +41,7 @@ export const getFieldsets = (
                 name: 'timeRestrictionChoice',
                 value: 'Yes',
                 dataAriaControls: 'valid-days-required-conditional',
-                label: `${premadeTimeRestrictions.length > 0 ? 'Yes - define new time restriction' : 'Yes'}`,
+                label: `${timeRestrictionNames.length > 0 ? 'Yes - define new time restriction' : 'Yes'}`,
                 inputHint: {
                     id: 'define-valid-days-inputHint',
                     content: 'Select the days of the week the ticket is valid for',
@@ -109,7 +108,7 @@ export const getFieldsets = (
         ],
         radioError: getErrorsByIds(['valid-days-required'], errors),
     };
-    if (premadeTimeRestrictions.length > 0) {
+    if (timeRestrictionNames.length > 0) {
         validDaysFieldset.radios.splice(1, 0, {
             id: 'premade-time-restriction-yes',
             name: 'timeRestrictionChoice',
@@ -121,12 +120,13 @@ export const getFieldsets = (
             },
             inputType: 'dropdown',
             dataAriaControls: 'premade-time-restriction',
-            inputs: premadeTimeRestrictions.map((premadeTimeRestriction, index) => ({
+            inputs: timeRestrictionNames.map((timeRestrictionName, index) => ({
                 id: `premade-time-restriction-${index}`,
-                name: premadeTimeRestriction.name,
-                label: premadeTimeRestriction.name,
+                name: timeRestrictionName,
+                label: timeRestrictionName,
             })),
             inputErrors: errors,
+            selectIdentifier: 'timeRestriction',
         });
     }
     return [validDaysFieldset];
@@ -173,10 +173,10 @@ export const getServerSideProps = async (
     if (timeRestrictionsDefinition && isTimeRestrictionsDefinitionWithErrors(timeRestrictionsDefinition)) {
         errors = timeRestrictionsDefinition.errors;
     }
-
+    const timeRestrictionNames = timeRestrictions.map(timeRestriction => timeRestriction.name);
     const fieldsets: RadioConditionalInputFieldset[] = getFieldsets(
         errors,
-        timeRestrictions,
+        timeRestrictionNames,
         timeRestrictionsDefinition,
     );
     return { props: { errors, fieldsets, csrfToken } };

--- a/src/pages/defineTimeRestrictions.tsx
+++ b/src/pages/defineTimeRestrictions.tsx
@@ -121,7 +121,11 @@ export const getFieldsets = (
             },
             inputType: 'dropdown',
             dataAriaControls: 'premade-time-restriction',
-            inputs: premadeTimeRestrictions,
+            inputs: premadeTimeRestrictions.map((premadeTimeRestriction, index) => ({
+                id: `premade-time-restriction-${index}`,
+                name: premadeTimeRestriction.name,
+                label: premadeTimeRestriction.name,
+            })),
             inputErrors: errors,
         });
     }

--- a/src/pages/fareType.tsx
+++ b/src/pages/fareType.tsx
@@ -41,29 +41,29 @@ const radioProps: FareTypeRadioProps = {
     standardFares: [
         {
             fareType: 'single',
-            label: 'Single Ticket - Point to Point',
+            label: 'Single ticket - point to point',
         },
         {
             fareType: 'period',
-            label: 'Period Ticket (Day, Week, Month and Annual)',
+            label: 'Period ticket (day, week, month and annual)',
         },
         {
             fareType: 'return',
-            label: 'Return Ticket - Single Service',
+            label: 'Return ticket - single service',
         },
         {
             fareType: 'flatFare',
-            label: 'Flat Fare Ticket - Single Journey',
+            label: 'Flat fare ticket - single journey',
         },
     ],
     otherFares: [
         {
             fareType: 'multiOperator',
-            label: 'Multi-operator - A ticket that covers more than one operator',
+            label: 'Multi-operator - a ticket that covers more than one operator',
         },
         {
             fareType: 'schoolService',
-            label: 'School Service - A ticket available to pupils in full-time education',
+            label: 'School service - a ticket available to pupils in full-time education',
         },
     ],
 };

--- a/src/pages/reuseOperatorGroup.tsx
+++ b/src/pages/reuseOperatorGroup.tsx
@@ -2,13 +2,7 @@ import React, { ReactElement } from 'react';
 import TwoThirdsLayout from '../layout/Layout';
 import ErrorSummary from '../components/ErrorSummary';
 import RadioConditionalInput from '../components/RadioConditionalInput';
-import {
-    ErrorInfo,
-    NextPageContextWithSession,
-    RadioConditionalInputFieldset,
-    TimeRestriction,
-    TimeRestrictionsDefinitionWithErrors,
-} from '../interfaces';
+import { ErrorInfo, NextPageContextWithSession, RadioConditionalInputFieldset } from '../interfaces';
 import CsrfForm from '../components/CsrfForm';
 import { getSessionAttribute } from '../utils/sessions';
 import { REUSE_OPERATOR_GROUP_ATTRIBUTE } from '../constants/attributes';
@@ -21,11 +15,11 @@ const description = 'Reuse Operator Group page of the Create Fares Data Service'
 
 interface ReuseOperatorGroupProps {
     errors: ErrorInfo[];
-    fieldsets: RadioConditionalInputFieldset[];
+    fieldset: RadioConditionalInputFieldset;
     csrfToken: string;
 }
 
-export const getFieldsets = (errors: ErrorInfo[], operatorGroupNames: string[]): RadioConditionalInputFieldset[] => {
+export const getFieldset = (errors: ErrorInfo[], operatorGroupNames: string[]): RadioConditionalInputFieldset => {
     const validDaysFieldset: RadioConditionalInputFieldset = {
         heading: {
             id: 'reuse-operator-group-heading',
@@ -50,7 +44,7 @@ export const getFieldsets = (errors: ErrorInfo[], operatorGroupNames: string[]):
                     name: operatorGroupName,
                     label: operatorGroupName,
                 })),
-                inputErrors: errors,
+                inputErrors: getErrorsByIds(['premadeOperatorGroup'], errors),
                 selectIdentifier: 'premadeOperatorGroup',
             },
             {
@@ -60,17 +54,12 @@ export const getFieldsets = (errors: ErrorInfo[], operatorGroupNames: string[]):
                 label: 'No',
             },
         ],
-        radioError: getErrorsByIds(['valid-days-required'], errors),
+        radioError: getErrorsByIds(['conditional-form-group'], errors),
     };
-    return [validDaysFieldset];
+    return validDaysFieldset;
 };
 
-export const isTimeRestrictionsDefinitionWithErrors = (
-    timeRestrictionsDefinition: TimeRestriction | TimeRestrictionsDefinitionWithErrors,
-): timeRestrictionsDefinition is TimeRestrictionsDefinitionWithErrors =>
-    (timeRestrictionsDefinition as TimeRestrictionsDefinitionWithErrors).errors !== undefined;
-
-const ReuseOperatorGroup = ({ errors = [], fieldsets, csrfToken }: ReuseOperatorGroupProps): ReactElement => (
+const ReuseOperatorGroup = ({ errors = [], fieldset, csrfToken }: ReuseOperatorGroupProps): ReactElement => (
     <TwoThirdsLayout title={title} description={description} errors={errors}>
         <CsrfForm action="/api/reuseOperatorGroup" method="post" csrfToken={csrfToken}>
             <>
@@ -83,9 +72,7 @@ const ReuseOperatorGroup = ({ errors = [], fieldsets, csrfToken }: ReuseOperator
                         You can reuse a saved operator group to save yourself time searching for each operator
                         individually
                     </span>
-                    {fieldsets.map(fieldset => {
-                        return <RadioConditionalInput key={fieldset.heading.id} fieldset={fieldset} />;
-                    })}
+                    <RadioConditionalInput key={fieldset.heading.id} fieldset={fieldset} />
                 </div>
                 <input type="submit" value="Continue" id="continue-button" className="govuk-button" />
             </>
@@ -110,12 +97,8 @@ export const getServerSideProps = async (
 
     const errors = getSessionAttribute(ctx.req, REUSE_OPERATOR_GROUP_ATTRIBUTE) || [];
     const operatorGroupNames = savedOperatorGroups.map(operatorGroup => operatorGroup.name);
-    const fieldsets: RadioConditionalInputFieldset[] = getFieldsets(errors, operatorGroupNames);
-    console.log(fieldsets);
-    fieldsets[0].radios.forEach(radio => {
-        console.log(radio);
-    });
-    return { props: { errors, fieldsets, csrfToken } };
+    const fieldset: RadioConditionalInputFieldset = getFieldset(errors, operatorGroupNames);
+    return { props: { errors, fieldset, csrfToken } };
 };
 
 export default ReuseOperatorGroup;

--- a/src/pages/reuseOperatorGroup.tsx
+++ b/src/pages/reuseOperatorGroup.tsx
@@ -111,6 +111,10 @@ export const getServerSideProps = async (
     const errors = getSessionAttribute(ctx.req, REUSE_OPERATOR_GROUP_ATTRIBUTE) || [];
     const operatorGroupNames = savedOperatorGroups.map(operatorGroup => operatorGroup.name);
     const fieldsets: RadioConditionalInputFieldset[] = getFieldsets(errors, operatorGroupNames);
+    console.log(fieldsets);
+    fieldsets[0].radios.forEach(radio => {
+        console.log(radio);
+    });
     return { props: { errors, fieldsets, csrfToken } };
 };
 

--- a/src/pages/saveOperatorGroup.tsx
+++ b/src/pages/saveOperatorGroup.tsx
@@ -20,19 +20,19 @@ interface SaveOperatorGroupProps {
 export const getFieldset = (errors: ErrorInfo[]): RadioConditionalInputFieldset => {
     const periodValidityFieldSet: RadioConditionalInputFieldset = {
         heading: {
-            id: 'reuse-operators-hidden-heading',
+            id: 'save-operators-hidden-heading',
             content: 'Do you want to save your group of operators for later use?',
             hidden: true,
         },
         radios: [
             {
-                id: 'yes-reuse',
-                name: 'reuseGroup',
+                id: 'yes-save',
+                name: 'saveGroup',
                 value: 'yes',
-                dataAriaControls: 'reuse-operators-required-conditional',
+                dataAriaControls: 'save-operators-required-conditional',
                 label: 'Yes',
                 inputHint: {
-                    id: 'reuse-group-name-hint',
+                    id: 'save-group-name-hint',
                     content: 'Provide a name to remember your group of operators by',
                     hidden: true,
                 },
@@ -48,13 +48,13 @@ export const getFieldset = (errors: ErrorInfo[]): RadioConditionalInputFieldset 
                 inputErrors: getErrorsByIds(['operator-group-name-input'], errors),
             },
             {
-                id: 'no-reuse',
-                name: 'reuseGroup',
+                id: 'no-save',
+                name: 'saveGroup',
                 value: 'no',
                 label: 'No',
             },
         ],
-        radioError: getErrorsByIds(['yes-reuse'], errors),
+        radioError: getErrorsByIds(['yes-save'], errors),
     };
     return periodValidityFieldSet;
 };

--- a/src/pages/saveOperatorGroup.tsx
+++ b/src/pages/saveOperatorGroup.tsx
@@ -42,6 +42,7 @@ export const getFieldset = (errors: ErrorInfo[]): RadioConditionalInputFieldset 
                         id: 'operator-group-name-input',
                         name: 'groupName',
                         label: 'Operator group name',
+                        defaultValue: errors[0]?.userInput,
                     },
                 ],
                 inputErrors: getErrorsByIds(['operator-group-name-input'], errors),

--- a/src/pages/saveOperatorGroup.tsx
+++ b/src/pages/saveOperatorGroup.tsx
@@ -1,0 +1,94 @@
+import React, { ReactElement } from 'react';
+import TwoThirdsLayout from '../layout/Layout';
+import { ErrorInfo, NextPageContextWithSession, RadioConditionalInputFieldset } from '../interfaces';
+import ErrorSummary from '../components/ErrorSummary';
+import CsrfForm from '../components/CsrfForm';
+import { getSessionAttribute } from '../utils/sessions';
+import { getCsrfToken, getErrorsByIds } from '../utils';
+import RadioConditionalInput from '../components/RadioConditionalInput';
+import { SAVE_OPERATOR_GROUP_ATTRIBUTE } from '../constants/attributes';
+
+const title = 'Save Operator Group - Create Fares Data Service';
+const description = 'Save Operator Group selection page of the Create Fares Data Service';
+
+interface SaveOperatorGroupProps {
+    errors?: ErrorInfo[];
+    fieldset: RadioConditionalInputFieldset;
+    csrfToken: string;
+}
+
+export const getFieldset = (errors: ErrorInfo[]): RadioConditionalInputFieldset => {
+    const periodValidityFieldSet: RadioConditionalInputFieldset = {
+        heading: {
+            id: 'reuse-operators-hidden-heading',
+            content: 'Do you want to save your group of operators for later use?',
+            hidden: true,
+        },
+        radios: [
+            {
+                id: 'yes-reuse',
+                name: 'reuseGroup',
+                value: 'yes',
+                dataAriaControls: 'reuse-operators-required-conditional',
+                label: 'Yes',
+                inputHint: {
+                    id: 'reuse-group-name-hint',
+                    content: 'Provide a name to remember your group of operators by',
+                    hidden: true,
+                },
+                inputType: 'text',
+                inputs: [
+                    {
+                        id: 'operator-group-name-input',
+                        name: 'groupName',
+                        label: 'Operator group name',
+                    },
+                ],
+                inputErrors: getErrorsByIds(['operator-group-name-input'], errors),
+            },
+            {
+                id: 'no-reuse',
+                name: 'reuseGroup',
+                value: 'no',
+                label: 'No',
+            },
+        ],
+        radioError: getErrorsByIds(['yes-reuse'], errors),
+    };
+    return periodValidityFieldSet;
+};
+
+const SaveOperatorGroup = ({ errors = [], fieldset, csrfToken }: SaveOperatorGroupProps): ReactElement => {
+    return (
+        <TwoThirdsLayout title={title} description={description} errors={errors}>
+            <CsrfForm action="/api/saveOperatorGroup" method="post" csrfToken={csrfToken}>
+                <>
+                    <ErrorSummary errors={errors} />
+                    <div className={`govuk-form-group ${errors.length > 0 ? 'govuk-form-group--error' : ''}`}>
+                        <fieldset className="govuk-fieldset" aria-describedby="save-group-operator-page-heading">
+                            <legend className="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                <h1 className="govuk-fieldset__heading" id="save-group-operator-page-heading">
+                                    Do you want to save this group of operators for later use?
+                                </h1>
+                            </legend>
+                            <span className="govuk-hint" id="save-group-operator-page-hint">
+                                If you save the group, you can reuse them rather than searching next time
+                            </span>
+                            <RadioConditionalInput key={fieldset.heading.id} fieldset={fieldset} />
+                        </fieldset>
+                    </div>
+                    <input type="submit" value="Continue" id="continue-button" className="govuk-button" />
+                </>
+            </CsrfForm>
+        </TwoThirdsLayout>
+    );
+};
+
+export const getServerSideProps = (ctx: NextPageContextWithSession): { props: SaveOperatorGroupProps } => {
+    const csrfToken = getCsrfToken(ctx);
+    const errors: ErrorInfo[] = getSessionAttribute(ctx.req, SAVE_OPERATOR_GROUP_ATTRIBUTE) || [];
+    const fieldset: RadioConditionalInputFieldset = getFieldset(errors);
+    return { props: { errors, fieldset, csrfToken } };
+};
+
+export default SaveOperatorGroup;

--- a/src/pages/saveOperatorGroup.tsx
+++ b/src/pages/saveOperatorGroup.tsx
@@ -42,7 +42,7 @@ export const getFieldset = (errors: ErrorInfo[]): RadioConditionalInputFieldset 
                         id: 'operator-group-name-input',
                         name: 'groupName',
                         label: 'Operator group name',
-                        defaultValue: errors[0]?.userInput,
+                        defaultValue: errors[0]?.userInput || '',
                     },
                 ],
                 inputErrors: getErrorsByIds(['operator-group-name-input'], errors),

--- a/src/pages/savedOperators.tsx
+++ b/src/pages/savedOperators.tsx
@@ -1,0 +1,111 @@
+import React, { ReactElement } from 'react';
+import TwoThirdsLayout from '../layout/Layout';
+import ErrorSummary from '../components/ErrorSummary';
+import RadioConditionalInput from '../components/RadioConditionalInput';
+import {
+    ErrorInfo,
+    NextPageContextWithSession,
+    RadioConditionalInputFieldset,
+    TimeRestriction,
+    TimeRestrictionsDefinitionWithErrors,
+    PremadeOperatorList,
+} from '../interfaces';
+import CsrfForm from '../components/CsrfForm';
+import { getSessionAttribute } from '../utils/sessions';
+import { TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE } from '../constants/attributes';
+import { getCsrfToken, getErrorsByIds, getNocFromIdToken } from '../utils';
+import { getTimeRestrictionByNocCode } from '../data/auroradb';
+
+const title = 'Define Time Restrictions - Create Fares Data Service';
+const description = 'Define Time Restrictions page of the Create Fares Data Service';
+
+interface DefineTimeRestrictionsProps {
+    errors: ErrorInfo[];
+    fieldsets: RadioConditionalInputFieldset[];
+    csrfToken: string;
+}
+
+export const getFieldsets = (
+    errors: ErrorInfo[],
+    // premadeOperatorLists: PremadeOperatorList[],
+): RadioConditionalInputFieldset[] => {
+    const validDaysFieldset: RadioConditionalInputFieldset = {
+        heading: {
+            id: 'define-valid-days',
+            content: 'Is this ticket only valid on certain days or times?',
+            hidden: true,
+        },
+        radios: [
+            {
+                id: 'premade-time-restriction-yes',
+                name: 'timeRestrictionChoice',
+                value: 'Premade',
+                label: 'Yes',
+                inputHint: {
+                    id: 'choose-time-restriction-hint',
+                    content: 'Select a saved operator list',
+                },
+                inputType: 'dropdown',
+                dataAriaControls: 'premade-time-restriction',
+                // inputs: premadeTimeRestrictions,
+                // inputs: premadeOperatorLists.map(premadeOperatorList => {{ id: premadeOperatorList.name, name: premadeOperatorList.name, label: 'Operator List 1' }}),
+                inputErrors: errors,
+            },
+            {
+                id: 'valid-days-not-required',
+                name: 'timeRestrictionChoice',
+                value: 'No',
+                label: 'No',
+            },
+        ],
+        radioError: getErrorsByIds(['valid-days-required'], errors),
+    };
+    return [validDaysFieldset];
+};
+
+export const isTimeRestrictionsDefinitionWithErrors = (
+    timeRestrictionsDefinition: TimeRestriction | TimeRestrictionsDefinitionWithErrors,
+): timeRestrictionsDefinition is TimeRestrictionsDefinitionWithErrors =>
+    (timeRestrictionsDefinition as TimeRestrictionsDefinitionWithErrors).errors !== undefined;
+
+const SavedOperators = ({ errors = [], fieldsets, csrfToken }: DefineTimeRestrictionsProps): ReactElement => (
+    <TwoThirdsLayout title={title} description={description} errors={errors}>
+        <CsrfForm action="/api/savedOperators" method="post" csrfToken={csrfToken}>
+            <>
+                <ErrorSummary errors={errors} />
+                <div>
+                    <h1 className="govuk-heading-l" id="define-time-restrictions-page-heading">
+                        Would you like to reuse a saved list of operators that this ticket covers?
+                    </h1>
+                    {fieldsets.map(fieldset => {
+                        return <RadioConditionalInput key={fieldset.heading.id} fieldset={fieldset} />;
+                    })}
+                </div>
+                <input type="submit" value="Continue" id="continue-button" className="govuk-button" />
+            </>
+        </CsrfForm>
+    </TwoThirdsLayout>
+);
+
+export const getServerSideProps = async (
+    ctx: NextPageContextWithSession,
+): Promise<{ props: DefineTimeRestrictionsProps }> => {
+    const csrfToken = getCsrfToken(ctx);
+    const timeRestrictionsDefinition = getSessionAttribute(ctx.req, TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE);
+    const noc = getNocFromIdToken(ctx);
+    const timeRestrictions = await getTimeRestrictionByNocCode(noc || '');
+
+    let errors: ErrorInfo[] = [];
+    if (timeRestrictionsDefinition && isTimeRestrictionsDefinitionWithErrors(timeRestrictionsDefinition)) {
+        errors = timeRestrictionsDefinition.errors;
+    }
+
+    const fieldsets: RadioConditionalInputFieldset[] = getFieldsets(
+        errors,
+        timeRestrictions,
+        // timeRestrictionsDefinition,
+    );
+    return { props: { errors, fieldsets, csrfToken } };
+};
+
+export default SavedOperators;

--- a/src/utils/sessions.ts
+++ b/src/utils/sessions.ts
@@ -104,6 +104,7 @@ import {
     USER_ATTRIBUTE,
     OPERATOR_ATTRIBUTE,
     TXC_SOURCE_ATTRIBUTE,
+    SAVE_OPERATOR_GROUP_ATTRIBUTE,
 } from '../constants/attributes';
 
 import * as attributes from '../constants/attributes';
@@ -155,6 +156,7 @@ interface SessionAttributeTypes {
     [USER_ATTRIBUTE]: UserAttribute | WithErrors<UserAttribute>;
     [OPERATOR_ATTRIBUTE]: OperatorAttribute | WithErrors<OperatorAttribute>;
     [TXC_SOURCE_ATTRIBUTE]: TxcSourceAttribute;
+    [SAVE_OPERATOR_GROUP_ATTRIBUTE]: ErrorInfo[];
 }
 
 export type SessionAttribute<T extends string> = T extends keyof SessionAttributeTypes

--- a/src/utils/sessions.ts
+++ b/src/utils/sessions.ts
@@ -104,6 +104,7 @@ import {
     USER_ATTRIBUTE,
     OPERATOR_ATTRIBUTE,
     TXC_SOURCE_ATTRIBUTE,
+    REUSE_OPERATOR_GROUP_ATTRIBUTE,
     SAVE_OPERATOR_GROUP_ATTRIBUTE,
 } from '../constants/attributes';
 
@@ -156,6 +157,7 @@ interface SessionAttributeTypes {
     [USER_ATTRIBUTE]: UserAttribute | WithErrors<UserAttribute>;
     [OPERATOR_ATTRIBUTE]: OperatorAttribute | WithErrors<OperatorAttribute>;
     [TXC_SOURCE_ATTRIBUTE]: TxcSourceAttribute;
+    [REUSE_OPERATOR_GROUP_ATTRIBUTE]: ErrorInfo[];
     [SAVE_OPERATOR_GROUP_ATTRIBUTE]: ErrorInfo[];
 }
 

--- a/tests/components/__snapshots__/RadioConditionalInput.test.tsx.snap
+++ b/tests/components/__snapshots__/RadioConditionalInput.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`RadioConditionalInput should hide the radio button heading when the fieldset has a hidden flag set 1`] = `
 <div
   className="govuk-form-group "
+  id="conditional-form-group"
 >
   <fieldset
     aria-describedby="define-passenger-age-range"
@@ -74,6 +75,7 @@ exports[`RadioConditionalInput should hide the radio button heading when the fie
 exports[`RadioConditionalInput should render a set of radio buttons with conditional inputs when given a fieldset referencing inputs 1`] = `
 <div
   className="govuk-form-group "
+  id="conditional-form-group"
 >
   <fieldset
     aria-describedby="define-passenger-age-range"
@@ -189,6 +191,7 @@ exports[`RadioConditionalInput should render a set of radio buttons with conditi
 exports[`RadioConditionalInput should render an ordinary set of radio buttons when given a base fieldset 1`] = `
 <div
   className="govuk-form-group "
+  id="conditional-form-group"
 >
   <fieldset
     aria-describedby="define-passenger-age-range"

--- a/tests/pages/__snapshots__/defineTimeRestrictions.test.tsx.snap
+++ b/tests/pages/__snapshots__/defineTimeRestrictions.test.tsx.snap
@@ -111,22 +111,14 @@ exports[`pages defineTimeRestrictions should render correctly when no errors are
                 "inputType": "dropdown",
                 "inputs": Array [
                   Object {
-                    "contents": Array [
-                      Object {
-                        "day": "monday",
-                        "timeBands": Array [
-                          Object {
-                            "endTime": "1000",
-                            "startTime": "0900",
-                          },
-                        ],
-                      },
-                    ],
+                    "id": "premade-time-restriction-0",
+                    "label": "Test Time restriction",
                     "name": "Test Time restriction",
                   },
                 ],
                 "label": "Yes - reuse a saved time restriction",
                 "name": "timeRestrictionChoice",
+                "selectIdentifier": "timeRestriction",
                 "value": "Premade",
               },
               Object {

--- a/tests/pages/__snapshots__/fareType.test.tsx.snap
+++ b/tests/pages/__snapshots__/fareType.test.tsx.snap
@@ -47,11 +47,11 @@ exports[`pages fareType should render correctly 1`] = `
               Array [
                 Object {
                   "fareType": "multiOperator",
-                  "label": "Multi-operator - A ticket that covers more than one operator",
+                  "label": "Multi-operator - a ticket that covers more than one operator",
                 },
                 Object {
                   "fareType": "schoolService",
-                  "label": "School Service - A ticket available to pupils in full-time education",
+                  "label": "School service - a ticket available to pupils in full-time education",
                 },
               ]
             }
@@ -59,19 +59,19 @@ exports[`pages fareType should render correctly 1`] = `
               Array [
                 Object {
                   "fareType": "single",
-                  "label": "Single Ticket - Point to Point",
+                  "label": "Single ticket - point to point",
                 },
                 Object {
                   "fareType": "period",
-                  "label": "Period Ticket (Day, Week, Month and Annual)",
+                  "label": "Period ticket (day, week, month and annual)",
                 },
                 Object {
                   "fareType": "return",
-                  "label": "Return Ticket - Single Service",
+                  "label": "Return ticket - single service",
                 },
                 Object {
                   "fareType": "flatFare",
-                  "label": "Flat Fare Ticket - Single Journey",
+                  "label": "Flat fare ticket - single journey",
                 },
               ]
             }
@@ -157,11 +157,11 @@ exports[`pages fareType should render error messaging when errors are passed to 
               Array [
                 Object {
                   "fareType": "multiOperator",
-                  "label": "Multi-operator - A ticket that covers more than one operator",
+                  "label": "Multi-operator - a ticket that covers more than one operator",
                 },
                 Object {
                   "fareType": "schoolService",
-                  "label": "School Service - A ticket available to pupils in full-time education",
+                  "label": "School service - a ticket available to pupils in full-time education",
                 },
               ]
             }
@@ -169,19 +169,19 @@ exports[`pages fareType should render error messaging when errors are passed to 
               Array [
                 Object {
                   "fareType": "single",
-                  "label": "Single Ticket - Point to Point",
+                  "label": "Single ticket - point to point",
                 },
                 Object {
                   "fareType": "period",
-                  "label": "Period Ticket (Day, Week, Month and Annual)",
+                  "label": "Period ticket (day, week, month and annual)",
                 },
                 Object {
                   "fareType": "return",
-                  "label": "Return Ticket - Single Service",
+                  "label": "Return ticket - single service",
                 },
                 Object {
                   "fareType": "flatFare",
-                  "label": "Flat Fare Ticket - Single Journey",
+                  "label": "Flat fare ticket - single journey",
                 },
               ]
             }

--- a/tests/pages/__snapshots__/reuseOperatorGroup.test.tsx.snap
+++ b/tests/pages/__snapshots__/reuseOperatorGroup.test.tsx.snap
@@ -1,86 +1,75 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`pages saveOperatorGroup should render correctly 1`] = `
+exports[`pages reuseOperatorGroup should render correctly 1`] = `
 <Component
-  description="Save Operator Group selection page of the Create Fares Data Service"
+  description="Reuse Operator Group page of the Create Fares Data Service"
   errors={Array []}
-  title="Save Operator Group - Create Fares Data Service"
+  title="Reuse Operator Group - Create Fares Data Service"
 >
   <CsrfForm
-    action="/api/saveOperatorGroup"
+    action="/api/reuseOperatorGroup"
     csrfToken=""
     method="post"
   >
     <ErrorSummary
       errors={Array []}
     />
-    <div
-      className="govuk-form-group "
-    >
-      <fieldset
-        aria-describedby="save-group-operator-page-heading"
-        className="govuk-fieldset"
+    <div>
+      <h1
+        className="govuk-heading-l"
+        id="reuse-operator-group-page-heading"
       >
-        <legend
-          className="govuk-fieldset__legend govuk-fieldset__legend--l"
-        >
-          <h1
-            className="govuk-fieldset__heading"
-            id="save-group-operator-page-heading"
-          >
-            Do you want to save this group of operators for later use?
-          </h1>
-        </legend>
-        <span
-          className="govuk-hint"
-          id="save-group-operator-page-hint"
-        >
-          If you save the group, you can reuse them rather than searching next time
-        </span>
-        <RadioConditionalInput
-          fieldset={
-            Object {
-              "heading": Object {
-                "content": "Do you want to save your group of operators for later use?",
-                "hidden": true,
-                "id": "save-operators-hidden-heading",
-              },
-              "radioError": Array [],
-              "radios": Array [
-                Object {
-                  "dataAriaControls": "save-operators-required-conditional",
-                  "id": "yes-save",
-                  "inputErrors": Array [],
-                  "inputHint": Object {
-                    "content": "Provide a name to remember your group of operators by",
-                    "hidden": true,
-                    "id": "save-group-name-hint",
+        Would you like to reuse a saved list of operators that this ticket covers?
+      </h1>
+      <span
+        className="govuk-hint"
+        id="reuse-operator-group-hint"
+      >
+        You can reuse a saved operator group to save yourself time searching for each operator individually
+      </span>
+      <RadioConditionalInput
+        fieldset={
+          Object {
+            "heading": Object {
+              "content": "Do you want to reuse a saved operator group?",
+              "hidden": true,
+              "id": "reuse-operator-group-heading",
+            },
+            "radioError": Array [],
+            "radios": Array [
+              Object {
+                "dataAriaControls": "reuse-operator-group",
+                "id": "reuse-operator-group-yes",
+                "inputErrors": Array [],
+                "inputHint": Object {
+                  "content": "Select an operator group from the dropdown",
+                  "hidden": true,
+                  "id": "choose-time-restriction-hint",
+                },
+                "inputType": "dropdown",
+                "inputs": Array [
+                  Object {
+                    "id": "operator-group-0",
+                    "label": "Best Ops",
+                    "name": "Best Ops",
                   },
-                  "inputType": "text",
-                  "inputs": Array [
-                    Object {
-                      "defaultValue": "",
-                      "id": "operator-group-name-input",
-                      "label": "Operator group name",
-                      "name": "groupName",
-                    },
-                  ],
-                  "label": "Yes",
-                  "name": "saveGroup",
-                  "value": "yes",
-                },
-                Object {
-                  "id": "no-save",
-                  "label": "No",
-                  "name": "saveGroup",
-                  "value": "no",
-                },
-              ],
-            }
+                ],
+                "label": "Yes",
+                "name": "reuseGroupChoice",
+                "selectIdentifier": "premadeOperatorGroup",
+                "value": "Yes",
+              },
+              Object {
+                "id": "reuse-operator-group-no",
+                "label": "No",
+                "name": "reuseGroupChoice",
+                "value": "No",
+              },
+            ],
           }
-          key="save-operators-hidden-heading"
-        />
-      </fieldset>
+        }
+        key="reuse-operator-group-heading"
+      />
     </div>
     <input
       className="govuk-button"
@@ -92,9 +81,9 @@ exports[`pages saveOperatorGroup should render correctly 1`] = `
 </Component>
 `;
 
-exports[`pages saveOperatorGroup should render errors when user does not provide a group name 1`] = `
+exports[`pages reuseOperatorGroup should render errors when user does not provide a group name 1`] = `
 <Component
-  description="Save Operator Group selection page of the Create Fares Data Service"
+  description="Reuse Operator Group page of the Create Fares Data Service"
   errors={
     Array [
       Object {
@@ -103,10 +92,10 @@ exports[`pages saveOperatorGroup should render errors when user does not provide
       },
     ]
   }
-  title="Save Operator Group - Create Fares Data Service"
+  title="Reuse Operator Group - Create Fares Data Service"
 >
   <CsrfForm
-    action="/api/saveOperatorGroup"
+    action="/api/reuseOperatorGroup"
     csrfToken=""
     method="post"
   >
@@ -120,78 +109,67 @@ exports[`pages saveOperatorGroup should render errors when user does not provide
         ]
       }
     />
-    <div
-      className="govuk-form-group govuk-form-group--error"
-    >
-      <fieldset
-        aria-describedby="save-group-operator-page-heading"
-        className="govuk-fieldset"
+    <div>
+      <h1
+        className="govuk-heading-l"
+        id="reuse-operator-group-page-heading"
       >
-        <legend
-          className="govuk-fieldset__legend govuk-fieldset__legend--l"
-        >
-          <h1
-            className="govuk-fieldset__heading"
-            id="save-group-operator-page-heading"
-          >
-            Do you want to save this group of operators for later use?
-          </h1>
-        </legend>
-        <span
-          className="govuk-hint"
-          id="save-group-operator-page-hint"
-        >
-          If you save the group, you can reuse them rather than searching next time
-        </span>
-        <RadioConditionalInput
-          fieldset={
-            Object {
-              "heading": Object {
-                "content": "Do you want to save your group of operators for later use?",
-                "hidden": true,
-                "id": "save-operators-hidden-heading",
-              },
-              "radioError": Array [],
-              "radios": Array [
-                Object {
-                  "dataAriaControls": "save-operators-required-conditional",
-                  "id": "yes-save",
-                  "inputErrors": Array [
-                    Object {
-                      "errorMessage": "Provide a name for the operator group",
-                      "id": "operator-group-name-input",
-                    },
-                  ],
-                  "inputHint": Object {
-                    "content": "Provide a name to remember your group of operators by",
-                    "hidden": true,
-                    "id": "save-group-name-hint",
+        Would you like to reuse a saved list of operators that this ticket covers?
+      </h1>
+      <span
+        className="govuk-hint"
+        id="reuse-operator-group-hint"
+      >
+        You can reuse a saved operator group to save yourself time searching for each operator individually
+      </span>
+      <RadioConditionalInput
+        fieldset={
+          Object {
+            "heading": Object {
+              "content": "Do you want to reuse a saved operator group?",
+              "hidden": true,
+              "id": "reuse-operator-group-heading",
+            },
+            "radioError": Array [],
+            "radios": Array [
+              Object {
+                "dataAriaControls": "reuse-operator-group",
+                "id": "reuse-operator-group-yes",
+                "inputErrors": Array [
+                  Object {
+                    "errorMessage": "Choose a premade operator group from the options below",
+                    "id": "premadeOperatorGroup",
                   },
-                  "inputType": "text",
-                  "inputs": Array [
-                    Object {
-                      "defaultValue": "",
-                      "id": "operator-group-name-input",
-                      "label": "Operator group name",
-                      "name": "groupName",
-                    },
-                  ],
-                  "label": "Yes",
-                  "name": "saveGroup",
-                  "value": "yes",
+                ],
+                "inputHint": Object {
+                  "content": "Select an operator group from the dropdown",
+                  "hidden": true,
+                  "id": "choose-time-restriction-hint",
                 },
-                Object {
-                  "id": "no-save",
-                  "label": "No",
-                  "name": "saveGroup",
-                  "value": "no",
-                },
-              ],
-            }
+                "inputType": "dropdown",
+                "inputs": Array [
+                  Object {
+                    "id": "operator-group-0",
+                    "label": "Best Ops",
+                    "name": "Best Ops",
+                  },
+                ],
+                "label": "Yes",
+                "name": "reuseGroupChoice",
+                "selectIdentifier": "premadeOperatorGroup",
+                "value": "Yes",
+              },
+              Object {
+                "id": "reuse-operator-group-no",
+                "label": "No",
+                "name": "reuseGroupChoice",
+                "value": "No",
+              },
+            ],
           }
-          key="save-operators-hidden-heading"
-        />
-      </fieldset>
+        }
+        key="reuse-operator-group-heading"
+      />
     </div>
     <input
       className="govuk-button"
@@ -203,9 +181,9 @@ exports[`pages saveOperatorGroup should render errors when user does not provide
 </Component>
 `;
 
-exports[`pages saveOperatorGroup should render errors when user does not select a radio button 1`] = `
+exports[`pages reuseOperatorGroup should render errors when user does not select a radio button 1`] = `
 <Component
-  description="Save Operator Group selection page of the Create Fares Data Service"
+  description="Reuse Operator Group page of the Create Fares Data Service"
   errors={
     Array [
       Object {
@@ -214,10 +192,10 @@ exports[`pages saveOperatorGroup should render errors when user does not select 
       },
     ]
   }
-  title="Save Operator Group - Create Fares Data Service"
+  title="Reuse Operator Group - Create Fares Data Service"
 >
   <CsrfForm
-    action="/api/saveOperatorGroup"
+    action="/api/reuseOperatorGroup"
     csrfToken=""
     method="post"
   >
@@ -231,78 +209,67 @@ exports[`pages saveOperatorGroup should render errors when user does not select 
         ]
       }
     />
-    <div
-      className="govuk-form-group govuk-form-group--error"
-    >
-      <fieldset
-        aria-describedby="save-group-operator-page-heading"
-        className="govuk-fieldset"
+    <div>
+      <h1
+        className="govuk-heading-l"
+        id="reuse-operator-group-page-heading"
       >
-        <legend
-          className="govuk-fieldset__legend govuk-fieldset__legend--l"
-        >
-          <h1
-            className="govuk-fieldset__heading"
-            id="save-group-operator-page-heading"
-          >
-            Do you want to save this group of operators for later use?
-          </h1>
-        </legend>
-        <span
-          className="govuk-hint"
-          id="save-group-operator-page-hint"
-        >
-          If you save the group, you can reuse them rather than searching next time
-        </span>
-        <RadioConditionalInput
-          fieldset={
-            Object {
-              "heading": Object {
-                "content": "Do you want to save your group of operators for later use?",
-                "hidden": true,
-                "id": "save-operators-hidden-heading",
+        Would you like to reuse a saved list of operators that this ticket covers?
+      </h1>
+      <span
+        className="govuk-hint"
+        id="reuse-operator-group-hint"
+      >
+        You can reuse a saved operator group to save yourself time searching for each operator individually
+      </span>
+      <RadioConditionalInput
+        fieldset={
+          Object {
+            "heading": Object {
+              "content": "Do you want to reuse a saved operator group?",
+              "hidden": true,
+              "id": "reuse-operator-group-heading",
+            },
+            "radioError": Array [
+              Object {
+                "errorMessage": "Choose one of the options below",
+                "id": "conditional-form-group",
               },
-              "radioError": Array [
-                Object {
-                  "errorMessage": "Choose one of the options below",
-                  "id": "yes-save",
+            ],
+            "radios": Array [
+              Object {
+                "dataAriaControls": "reuse-operator-group",
+                "id": "reuse-operator-group-yes",
+                "inputErrors": Array [],
+                "inputHint": Object {
+                  "content": "Select an operator group from the dropdown",
+                  "hidden": true,
+                  "id": "choose-time-restriction-hint",
                 },
-              ],
-              "radios": Array [
-                Object {
-                  "dataAriaControls": "save-operators-required-conditional",
-                  "id": "yes-save",
-                  "inputErrors": Array [],
-                  "inputHint": Object {
-                    "content": "Provide a name to remember your group of operators by",
-                    "hidden": true,
-                    "id": "save-group-name-hint",
+                "inputType": "dropdown",
+                "inputs": Array [
+                  Object {
+                    "id": "operator-group-0",
+                    "label": "Best Ops",
+                    "name": "Best Ops",
                   },
-                  "inputType": "text",
-                  "inputs": Array [
-                    Object {
-                      "defaultValue": "",
-                      "id": "operator-group-name-input",
-                      "label": "Operator group name",
-                      "name": "groupName",
-                    },
-                  ],
-                  "label": "Yes",
-                  "name": "saveGroup",
-                  "value": "yes",
-                },
-                Object {
-                  "id": "no-save",
-                  "label": "No",
-                  "name": "saveGroup",
-                  "value": "no",
-                },
-              ],
-            }
+                ],
+                "label": "Yes",
+                "name": "reuseGroupChoice",
+                "selectIdentifier": "premadeOperatorGroup",
+                "value": "Yes",
+              },
+              Object {
+                "id": "reuse-operator-group-no",
+                "label": "No",
+                "name": "reuseGroupChoice",
+                "value": "No",
+              },
+            ],
           }
-          key="save-operators-hidden-heading"
-        />
-      </fieldset>
+        }
+        key="reuse-operator-group-heading"
+      />
     </div>
     <input
       className="govuk-button"

--- a/tests/pages/__snapshots__/reuseOperatorGroup.test.tsx.snap
+++ b/tests/pages/__snapshots__/reuseOperatorGroup.test.tsx.snap
@@ -98,8 +98,8 @@ exports[`pages saveOperatorGroup should render errors when user does not provide
   errors={
     Array [
       Object {
-        "errorMessage": "Provide a name for the operator group",
-        "id": "operator-group-name-input",
+        "errorMessage": "Choose a premade operator group from the options below",
+        "id": "premadeOperatorGroup",
       },
     ]
   }
@@ -114,8 +114,8 @@ exports[`pages saveOperatorGroup should render errors when user does not provide
       errors={
         Array [
           Object {
-            "errorMessage": "Provide a name for the operator group",
-            "id": "operator-group-name-input",
+            "errorMessage": "Choose a premade operator group from the options below",
+            "id": "premadeOperatorGroup",
           },
         ]
       }
@@ -210,7 +210,7 @@ exports[`pages saveOperatorGroup should render errors when user does not select 
     Array [
       Object {
         "errorMessage": "Choose one of the options below",
-        "id": "yes-save",
+        "id": "conditional-form-group",
       },
     ]
   }
@@ -226,7 +226,7 @@ exports[`pages saveOperatorGroup should render errors when user does not select 
         Array [
           Object {
             "errorMessage": "Choose one of the options below",
-            "id": "yes-save",
+            "id": "conditional-form-group",
           },
         ]
       }

--- a/tests/pages/__snapshots__/saveOperatorGroup.test.tsx.snap
+++ b/tests/pages/__snapshots__/saveOperatorGroup.test.tsx.snap
@@ -1,0 +1,315 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pages saveOperatorGroup should render correctly 1`] = `
+<Component
+  description="Save Operator Group selection page of the Create Fares Data Service"
+  errors={Array []}
+  title="Save Operator Group - Create Fares Data Service"
+>
+  <CsrfForm
+    action="/api/saveOperatorGroup"
+    csrfToken=""
+    method="post"
+  >
+    <ErrorSummary
+      errors={Array []}
+    />
+    <div
+      className="govuk-form-group "
+    >
+      <fieldset
+        aria-describedby="save-group-operator-page-heading"
+        className="govuk-fieldset"
+      >
+        <legend
+          className="govuk-fieldset__legend govuk-fieldset__legend--l"
+        >
+          <h1
+            className="govuk-fieldset__heading"
+            id="save-group-operator-page-heading"
+          >
+            Do you want to save this group of operators for later use?
+          </h1>
+        </legend>
+        <span
+          className="govuk-hint"
+          id="save-group-operator-page-hint"
+        >
+          If you save the group, you can reuse them rather than searching next time
+        </span>
+        <RadioConditionalInput
+          fieldset={
+            Object {
+              "heading": Object {
+                "content": "Do you want to save your group of operators for later use?",
+                "hidden": true,
+                "id": "reuse-operators-hidden-heading",
+              },
+              "radioError": Array [],
+              "radios": Array [
+                Object {
+                  "dataAriaControls": "reuse-operators-required-conditional",
+                  "id": "yes-reuse",
+                  "inputErrors": Array [],
+                  "inputHint": Object {
+                    "content": "Provide a name to remember your group of operators by",
+                    "hidden": true,
+                    "id": "reuse-group-name-hint",
+                  },
+                  "inputType": "text",
+                  "inputs": Array [
+                    Object {
+                      "defaultValue": "",
+                      "id": "operator-group-name-input",
+                      "label": "Operator group name",
+                      "name": "groupName",
+                    },
+                  ],
+                  "label": "Yes",
+                  "name": "reuseGroup",
+                  "value": "yes",
+                },
+                Object {
+                  "id": "no-reuse",
+                  "label": "No",
+                  "name": "reuseGroup",
+                  "value": "no",
+                },
+              ],
+            }
+          }
+          key="reuse-operators-hidden-heading"
+        />
+      </fieldset>
+    </div>
+    <input
+      className="govuk-button"
+      id="continue-button"
+      type="submit"
+      value="Continue"
+    />
+  </CsrfForm>
+</Component>
+`;
+
+exports[`pages saveOperatorGroup should render errors when user does not provide a group name 1`] = `
+<Component
+  description="Save Operator Group selection page of the Create Fares Data Service"
+  errors={
+    Array [
+      Object {
+        "errorMessage": "Provide a name for the operator group",
+        "id": "operator-group-name-input",
+      },
+    ]
+  }
+  title="Save Operator Group - Create Fares Data Service"
+>
+  <CsrfForm
+    action="/api/saveOperatorGroup"
+    csrfToken=""
+    method="post"
+  >
+    <ErrorSummary
+      errors={
+        Array [
+          Object {
+            "errorMessage": "Provide a name for the operator group",
+            "id": "operator-group-name-input",
+          },
+        ]
+      }
+    />
+    <div
+      className="govuk-form-group govuk-form-group--error"
+    >
+      <fieldset
+        aria-describedby="save-group-operator-page-heading"
+        className="govuk-fieldset"
+      >
+        <legend
+          className="govuk-fieldset__legend govuk-fieldset__legend--l"
+        >
+          <h1
+            className="govuk-fieldset__heading"
+            id="save-group-operator-page-heading"
+          >
+            Do you want to save this group of operators for later use?
+          </h1>
+        </legend>
+        <span
+          className="govuk-hint"
+          id="save-group-operator-page-hint"
+        >
+          If you save the group, you can reuse them rather than searching next time
+        </span>
+        <RadioConditionalInput
+          fieldset={
+            Object {
+              "heading": Object {
+                "content": "Do you want to save your group of operators for later use?",
+                "hidden": true,
+                "id": "reuse-operators-hidden-heading",
+              },
+              "radioError": Array [],
+              "radios": Array [
+                Object {
+                  "dataAriaControls": "reuse-operators-required-conditional",
+                  "id": "yes-reuse",
+                  "inputErrors": Array [
+                    Object {
+                      "errorMessage": "Provide a name for the operator group",
+                      "id": "operator-group-name-input",
+                    },
+                  ],
+                  "inputHint": Object {
+                    "content": "Provide a name to remember your group of operators by",
+                    "hidden": true,
+                    "id": "reuse-group-name-hint",
+                  },
+                  "inputType": "text",
+                  "inputs": Array [
+                    Object {
+                      "defaultValue": "",
+                      "id": "operator-group-name-input",
+                      "label": "Operator group name",
+                      "name": "groupName",
+                    },
+                  ],
+                  "label": "Yes",
+                  "name": "reuseGroup",
+                  "value": "yes",
+                },
+                Object {
+                  "id": "no-reuse",
+                  "label": "No",
+                  "name": "reuseGroup",
+                  "value": "no",
+                },
+              ],
+            }
+          }
+          key="reuse-operators-hidden-heading"
+        />
+      </fieldset>
+    </div>
+    <input
+      className="govuk-button"
+      id="continue-button"
+      type="submit"
+      value="Continue"
+    />
+  </CsrfForm>
+</Component>
+`;
+
+exports[`pages saveOperatorGroup should render errors when user does not select a radio button 1`] = `
+<Component
+  description="Save Operator Group selection page of the Create Fares Data Service"
+  errors={
+    Array [
+      Object {
+        "errorMessage": "Choose one of the options below",
+        "id": "yes-reuse",
+      },
+    ]
+  }
+  title="Save Operator Group - Create Fares Data Service"
+>
+  <CsrfForm
+    action="/api/saveOperatorGroup"
+    csrfToken=""
+    method="post"
+  >
+    <ErrorSummary
+      errors={
+        Array [
+          Object {
+            "errorMessage": "Choose one of the options below",
+            "id": "yes-reuse",
+          },
+        ]
+      }
+    />
+    <div
+      className="govuk-form-group govuk-form-group--error"
+    >
+      <fieldset
+        aria-describedby="save-group-operator-page-heading"
+        className="govuk-fieldset"
+      >
+        <legend
+          className="govuk-fieldset__legend govuk-fieldset__legend--l"
+        >
+          <h1
+            className="govuk-fieldset__heading"
+            id="save-group-operator-page-heading"
+          >
+            Do you want to save this group of operators for later use?
+          </h1>
+        </legend>
+        <span
+          className="govuk-hint"
+          id="save-group-operator-page-hint"
+        >
+          If you save the group, you can reuse them rather than searching next time
+        </span>
+        <RadioConditionalInput
+          fieldset={
+            Object {
+              "heading": Object {
+                "content": "Do you want to save your group of operators for later use?",
+                "hidden": true,
+                "id": "reuse-operators-hidden-heading",
+              },
+              "radioError": Array [
+                Object {
+                  "errorMessage": "Choose one of the options below",
+                  "id": "yes-reuse",
+                },
+              ],
+              "radios": Array [
+                Object {
+                  "dataAriaControls": "reuse-operators-required-conditional",
+                  "id": "yes-reuse",
+                  "inputErrors": Array [],
+                  "inputHint": Object {
+                    "content": "Provide a name to remember your group of operators by",
+                    "hidden": true,
+                    "id": "reuse-group-name-hint",
+                  },
+                  "inputType": "text",
+                  "inputs": Array [
+                    Object {
+                      "defaultValue": "",
+                      "id": "operator-group-name-input",
+                      "label": "Operator group name",
+                      "name": "groupName",
+                    },
+                  ],
+                  "label": "Yes",
+                  "name": "reuseGroup",
+                  "value": "yes",
+                },
+                Object {
+                  "id": "no-reuse",
+                  "label": "No",
+                  "name": "reuseGroup",
+                  "value": "no",
+                },
+              ],
+            }
+          }
+          key="reuse-operators-hidden-heading"
+        />
+      </fieldset>
+    </div>
+    <input
+      className="govuk-button"
+      id="continue-button"
+      type="submit"
+      value="Continue"
+    />
+  </CsrfForm>
+</Component>
+`;

--- a/tests/pages/api/csvZoneUpload.test.ts
+++ b/tests/pages/api/csvZoneUpload.test.ts
@@ -151,7 +151,7 @@ describe('csvZoneUpload', () => {
         await csvZoneUpload.default(multiOperatorReq, res);
 
         expect(writeHeadMock).toBeCalledWith(302, {
-            Location: '/searchOperators',
+            Location: '/reuseOperatorGroup',
         });
         expect(updateSessionAttributeSpy).toBeCalledWith(multiOperatorReq, FARE_ZONE_ATTRIBUTE, 'Town Centre');
     });

--- a/tests/pages/api/reuseOperatorGroup.test.ts
+++ b/tests/pages/api/reuseOperatorGroup.test.ts
@@ -1,0 +1,88 @@
+import { MULTIPLE_OPERATOR_ATTRIBUTE, REUSE_OPERATOR_GROUP_ATTRIBUTE } from '../../../src/constants/attributes';
+import { getMockRequestAndResponse } from '../../testData/mockData';
+import * as sessions from '../../../src/utils/sessions';
+import reuseOperatorGroup from '../../../src/pages/api/reuseOperatorGroup';
+import * as auroradb from '../../../src/data/auroradb';
+
+describe('reuseOperatorGroup', () => {
+    const updateSessionAttributeSpy = jest.spyOn(sessions, 'updateSessionAttribute');
+    const writeHeadMock = jest.fn();
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('should redirect back to reuseOperatorGroup with errors if the user does not select a radio button', async () => {
+        const { req, res } = getMockRequestAndResponse({
+            body: {},
+            mockWriteHeadFn: writeHeadMock,
+        });
+        await reuseOperatorGroup(req, res);
+
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, [
+            { errorMessage: 'Choose one of the options below', id: 'conditional-form-group' },
+        ]);
+        expect(writeHeadMock).toBeCalledWith(302, { Location: '/reuseOperatorGroup' });
+    });
+
+    it('should redirect back to reuseOperatorGroup with errors if the user selects yes but does not select an operator group name', async () => {
+        const { req, res } = getMockRequestAndResponse({
+            body: { reuseGroupChoice: 'Yes' },
+            mockWriteHeadFn: writeHeadMock,
+        });
+        await reuseOperatorGroup(req, res);
+
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, [
+            { errorMessage: 'Choose a premade operator group from the options below', id: 'premadeOperatorGroup' },
+        ]);
+        expect(writeHeadMock).toBeCalledWith(302, { Location: '/reuseOperatorGroup' });
+    });
+
+    it('should update the MULTIPLE_OPERATOR_ATTRIBUTE with the selected operator group operators if chosen in dropdown', async () => {
+        const getOperatorGroupsByNameAndNocSpy = jest.spyOn(auroradb, 'getOperatorGroupsByNameAndNoc');
+        const testOperators = [
+            {
+                name: 'Best Op 1',
+                nocCode: 'BO1',
+            },
+            {
+                name: 'Best Op 2',
+                nocCode: 'BO3',
+            },
+            {
+                name: 'Best Op Supreme',
+                nocCode: 'BOS',
+            },
+        ];
+        getOperatorGroupsByNameAndNocSpy.mockImplementation().mockResolvedValue([
+            {
+                name: 'Best Ops',
+                operators: testOperators,
+            },
+        ]);
+        const { req, res } = getMockRequestAndResponse({
+            body: { reuseGroupChoice: 'Yes', premadeOperatorGroup: 'Best Ops' },
+            mockWriteHeadFn: writeHeadMock,
+        });
+        await reuseOperatorGroup(req, res);
+
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, []);
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, MULTIPLE_OPERATOR_ATTRIBUTE, {
+            selectedOperators: testOperators,
+        });
+        expect(updateSessionAttributeSpy).toBeCalledTimes(2);
+        expect(writeHeadMock).toBeCalledWith(302, { Location: '/howManyProducts' });
+        expect(getOperatorGroupsByNameAndNocSpy).toBeCalledWith('Best Ops', 'TEST');
+    });
+
+    it('should do nothing but redirect on to searchOperators if no is selected', async () => {
+        const { req, res } = getMockRequestAndResponse({
+            body: { reuseGroupChoice: 'No' },
+            mockWriteHeadFn: writeHeadMock,
+        });
+        await reuseOperatorGroup(req, res);
+
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, []);
+        expect(writeHeadMock).toBeCalledWith(302, { Location: '/searchOperators' });
+    });
+});

--- a/tests/pages/api/reuseOperatorGroup.test.ts
+++ b/tests/pages/api/reuseOperatorGroup.test.ts
@@ -66,13 +66,12 @@ describe('reuseOperatorGroup', () => {
         });
         await reuseOperatorGroup(req, res);
 
+        expect(getOperatorGroupsByNameAndNocSpy).toBeCalledWith('Best Ops', 'TEST');
         expect(updateSessionAttributeSpy).toBeCalledWith(req, REUSE_OPERATOR_GROUP_ATTRIBUTE, []);
         expect(updateSessionAttributeSpy).toBeCalledWith(req, MULTIPLE_OPERATOR_ATTRIBUTE, {
             selectedOperators: testOperators,
         });
-        expect(updateSessionAttributeSpy).toBeCalledTimes(2);
         expect(writeHeadMock).toBeCalledWith(302, { Location: '/howManyProducts' });
-        expect(getOperatorGroupsByNameAndNocSpy).toBeCalledWith('Best Ops', 'TEST');
     });
 
     it('should do nothing but redirect on to searchOperators if no is selected', async () => {

--- a/tests/pages/api/saveOperatorGroup.test.ts
+++ b/tests/pages/api/saveOperatorGroup.test.ts
@@ -1,0 +1,123 @@
+import { SAVE_OPERATOR_GROUP_ATTRIBUTE, MULTIPLE_OPERATOR_ATTRIBUTE } from '../../../src/constants/attributes';
+import { getMockRequestAndResponse } from '../../testData/mockData';
+import * as sessions from '../../../src/utils/sessions';
+import saveOperatorGroup from '../../../src/pages/api/saveOperatorGroup';
+import * as auroradb from '../../../src/data/auroradb';
+
+describe('saveOperatorGroup', () => {
+    const updateSessionAttributeSpy = jest.spyOn(sessions, 'updateSessionAttribute');
+    const writeHeadMock = jest.fn();
+    const insertOperatorGroupSpy = jest.spyOn(auroradb, 'insertOperatorGroup');
+    insertOperatorGroupSpy.mockImplementation().mockResolvedValue();
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('should redirect back to saveOperatorGroup with errors if the user does not select a radio button', async () => {
+        const { req, res } = getMockRequestAndResponse({
+            body: {},
+            mockWriteHeadFn: writeHeadMock,
+        });
+        await saveOperatorGroup(req, res);
+
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, SAVE_OPERATOR_GROUP_ATTRIBUTE, [
+            { errorMessage: 'Choose one of the options below', id: 'yes-reuse' },
+        ]);
+        expect(writeHeadMock).toBeCalledWith(302, { Location: '/saveOperatorGroup' });
+        expect(insertOperatorGroupSpy).toBeCalledTimes(0);
+    });
+
+    it('should redirect back to saveOperatorGroup with errors if the user selects yes but does not provide an operator group name', async () => {
+        const { req, res } = getMockRequestAndResponse({
+            body: { reuseGroup: 'yes' },
+            mockWriteHeadFn: writeHeadMock,
+        });
+        await saveOperatorGroup(req, res);
+
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, SAVE_OPERATOR_GROUP_ATTRIBUTE, [
+            { errorMessage: 'Provide a name for the operator group', id: 'operator-group-name-input' },
+        ]);
+        expect(writeHeadMock).toBeCalledWith(302, { Location: '/saveOperatorGroup' });
+        expect(insertOperatorGroupSpy).toBeCalledTimes(0);
+    });
+
+    it('should redirect back to saveOperatorGroup with errors if the user selects yes but their given operator group name already exists, and should NOT make an insert query to the DB', async () => {
+        const getOperatorGroupByNameAndNocSpy = jest.spyOn(auroradb, 'getOperatorGroupByNameAndNoc');
+        getOperatorGroupByNameAndNocSpy.mockImplementation().mockResolvedValue([
+            {
+                name: 'Best test group',
+                operators: [
+                    {
+                        name: 'Operator one',
+                        nocCode: 'OO',
+                    },
+                ],
+            },
+        ]);
+        const groupNameWithSpaces = '     Best test    group      ';
+        const groupName = 'Best test group';
+        const { req, res } = getMockRequestAndResponse({
+            body: { reuseGroup: 'yes', groupName: groupNameWithSpaces },
+            mockWriteHeadFn: writeHeadMock,
+        });
+        await saveOperatorGroup(req, res);
+
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, SAVE_OPERATOR_GROUP_ATTRIBUTE, [
+            {
+                errorMessage: `A saved operator group with name ${groupName} already exists, provide a unique name`,
+                id: 'operator-group-name-input',
+                userInput: groupName,
+            },
+        ]);
+        expect(writeHeadMock).toBeCalledWith(302, { Location: '/saveOperatorGroup' });
+        expect(getOperatorGroupByNameAndNocSpy).toBeCalledWith('Best test group', 'TEST');
+        expect(insertOperatorGroupSpy).toBeCalledTimes(0);
+    });
+
+    it('should insert the users operator group name with the operator list stored in the session and redirect on to multipleOperatorsServiceList', async () => {
+        const getOperatorGroupByNameAndNocSpy = jest.spyOn(auroradb, 'getOperatorGroupByNameAndNoc');
+        getOperatorGroupByNameAndNocSpy.mockImplementation().mockResolvedValue([]);
+        const groupNameWithSpaces = '     Best test    group      ';
+        const groupName = 'Best test group';
+        const { req, res } = getMockRequestAndResponse({
+            body: { reuseGroup: 'yes', groupName: groupNameWithSpaces },
+            session: {
+                [MULTIPLE_OPERATOR_ATTRIBUTE]: {
+                    selectedOperators: [
+                        { name: 'Operator one', nocCode: 'OO' },
+                        { name: 'Operator two', nocCode: 'OT' },
+                        { name: 'Operator supreme', nocCode: 'OS' },
+                    ],
+                },
+            },
+            mockWriteHeadFn: writeHeadMock,
+        });
+        await saveOperatorGroup(req, res);
+
+        expect(updateSessionAttributeSpy).toBeCalledTimes(0);
+        expect(writeHeadMock).toBeCalledWith(302, { Location: '/multipleOperatorsServiceList' });
+        expect(getOperatorGroupByNameAndNocSpy).toBeCalledWith('Best test group', 'TEST');
+        expect(insertOperatorGroupSpy).toBeCalledWith(
+            'TEST',
+            [
+                { name: 'Operator one', nocCode: 'OO' },
+                { name: 'Operator two', nocCode: 'OT' },
+                { name: 'Operator supreme', nocCode: 'OS' },
+            ],
+            groupName,
+        );
+    });
+
+    it('should do nothing but redirect on to multipleOperatorsServiceList if no is selected', async () => {
+        const { req, res } = getMockRequestAndResponse({
+            body: { reuseGroup: 'no' },
+            mockWriteHeadFn: writeHeadMock,
+        });
+        await saveOperatorGroup(req, res);
+
+        expect(updateSessionAttributeSpy).toBeCalledTimes(0);
+        expect(writeHeadMock).toBeCalledWith(302, { Location: '/multipleOperatorsServiceList' });
+        expect(insertOperatorGroupSpy).toBeCalledTimes(0);
+    });
+});

--- a/tests/pages/api/saveOperatorGroup.test.ts
+++ b/tests/pages/api/saveOperatorGroup.test.ts
@@ -43,8 +43,8 @@ describe('saveOperatorGroup', () => {
     });
 
     it('should redirect back to saveOperatorGroup with errors if the user selects yes but their given operator group name already exists, and should NOT make an insert query to the DB', async () => {
-        const getOperatorGroupByNameAndNocSpy = jest.spyOn(auroradb, 'getOperatorGroupByNameAndNoc');
-        getOperatorGroupByNameAndNocSpy.mockImplementation().mockResolvedValue([
+        const getOperatorGroupsByNameAndNocSpy = jest.spyOn(auroradb, 'getOperatorGroupsByNameAndNoc');
+        getOperatorGroupsByNameAndNocSpy.mockImplementation().mockResolvedValue([
             {
                 name: 'Best test group',
                 operators: [
@@ -71,13 +71,13 @@ describe('saveOperatorGroup', () => {
             },
         ]);
         expect(writeHeadMock).toBeCalledWith(302, { Location: '/saveOperatorGroup' });
-        expect(getOperatorGroupByNameAndNocSpy).toBeCalledWith('Best test group', 'TEST');
+        expect(getOperatorGroupsByNameAndNocSpy).toBeCalledWith('Best test group', 'TEST');
         expect(insertOperatorGroupSpy).toBeCalledTimes(0);
     });
 
     it('should insert the users operator group name with the operator list stored in the session and redirect on to multipleOperatorsServiceList', async () => {
-        const getOperatorGroupByNameAndNocSpy = jest.spyOn(auroradb, 'getOperatorGroupByNameAndNoc');
-        getOperatorGroupByNameAndNocSpy.mockImplementation().mockResolvedValue([]);
+        const getOperatorGroupsByNameAndNocSpy = jest.spyOn(auroradb, 'getOperatorGroupsByNameAndNoc');
+        getOperatorGroupsByNameAndNocSpy.mockImplementation().mockResolvedValue([]);
         const groupNameWithSpaces = '     Best test    group      ';
         const groupName = 'Best test group';
         const { req, res } = getMockRequestAndResponse({
@@ -95,9 +95,9 @@ describe('saveOperatorGroup', () => {
         });
         await saveOperatorGroup(req, res);
 
-        expect(updateSessionAttributeSpy).toBeCalledTimes(0);
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, SAVE_OPERATOR_GROUP_ATTRIBUTE, []);
         expect(writeHeadMock).toBeCalledWith(302, { Location: '/multipleOperatorsServiceList' });
-        expect(getOperatorGroupByNameAndNocSpy).toBeCalledWith('Best test group', 'TEST');
+        expect(getOperatorGroupsByNameAndNocSpy).toBeCalledWith('Best test group', 'TEST');
         expect(insertOperatorGroupSpy).toBeCalledWith(
             'TEST',
             [
@@ -116,7 +116,7 @@ describe('saveOperatorGroup', () => {
         });
         await saveOperatorGroup(req, res);
 
-        expect(updateSessionAttributeSpy).toBeCalledTimes(0);
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, SAVE_OPERATOR_GROUP_ATTRIBUTE, []);
         expect(writeHeadMock).toBeCalledWith(302, { Location: '/multipleOperatorsServiceList' });
         expect(insertOperatorGroupSpy).toBeCalledTimes(0);
     });

--- a/tests/pages/api/saveOperatorGroup.test.ts
+++ b/tests/pages/api/saveOperatorGroup.test.ts
@@ -79,7 +79,7 @@ describe('saveOperatorGroup', () => {
         expect(insertOperatorGroupSpy).toBeCalledTimes(0);
     });
 
-    it('should insert the users operator group name with the operator list stored in the session and redirect on to multipleOperatorsServiceList if geoZone', async () => {
+    it('should insert the users operator group name with the operator list stored in the session and redirect on to howManyProducts if geoZone', async () => {
         const getOperatorGroupsByNameAndNocSpy = jest.spyOn(auroradb, 'getOperatorGroupsByNameAndNoc');
         getOperatorGroupsByNameAndNocSpy.mockImplementation().mockResolvedValue([]);
         const groupNameWithSpaces = '     Best test    group      ';
@@ -99,8 +99,6 @@ describe('saveOperatorGroup', () => {
         });
         await saveOperatorGroup(req, res);
 
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, SAVE_OPERATOR_GROUP_ATTRIBUTE, []);
-        expect(writeHeadMock).toBeCalledWith(302, { Location: '/howManyProducts' });
         expect(getOperatorGroupsByNameAndNocSpy).toBeCalledWith('Best test group', 'TEST');
         expect(insertOperatorGroupSpy).toBeCalledWith(
             'TEST',
@@ -111,7 +109,10 @@ describe('saveOperatorGroup', () => {
             ],
             groupName,
         );
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, SAVE_OPERATOR_GROUP_ATTRIBUTE, []);
+        expect(writeHeadMock).toBeCalledWith(302, { Location: '/howManyProducts' });
     });
+
     it('should insert the users operator group name with the operator list stored in the session and redirect on to multipleOperatorsServiceList if multipleServices', async () => {
         const getOperatorGroupsByNameAndNocSpy = jest.spyOn(auroradb, 'getOperatorGroupsByNameAndNoc');
         getOperatorGroupsByNameAndNocSpy.mockImplementation().mockResolvedValue([]);
@@ -135,8 +136,6 @@ describe('saveOperatorGroup', () => {
         });
         await saveOperatorGroup(req, res);
 
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, SAVE_OPERATOR_GROUP_ATTRIBUTE, []);
-        expect(writeHeadMock).toBeCalledWith(302, { Location: '/multipleOperatorsServiceList' });
         expect(getOperatorGroupsByNameAndNocSpy).toBeCalledWith('Best test group', 'TEST');
         expect(insertOperatorGroupSpy).toBeCalledWith(
             'TEST',
@@ -147,17 +146,36 @@ describe('saveOperatorGroup', () => {
             ],
             groupName,
         );
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, SAVE_OPERATOR_GROUP_ATTRIBUTE, []);
+        expect(writeHeadMock).toBeCalledWith(302, { Location: '/multipleOperatorsServiceList' });
     });
 
-    it('should do nothing but redirect on to howManyProducts if no is selected', async () => {
+    it('should do nothing but redirect on to howManyProducts if no is selected if geoZone', async () => {
         const { req, res } = getMockRequestAndResponse({
             body: { saveGroup: 'no' },
             mockWriteHeadFn: writeHeadMock,
         });
         await saveOperatorGroup(req, res);
 
+        expect(insertOperatorGroupSpy).toBeCalledTimes(0);
         expect(updateSessionAttributeSpy).toBeCalledWith(req, SAVE_OPERATOR_GROUP_ATTRIBUTE, []);
         expect(writeHeadMock).toBeCalledWith(302, { Location: '/howManyProducts' });
+    });
+
+    it('should do nothing but redirect on to multipleOperatorsServiceList if no is selected if multipleServices', async () => {
+        const { req, res } = getMockRequestAndResponse({
+            body: { saveGroup: 'no' },
+            session: {
+                [TICKET_REPRESENTATION_ATTRIBUTE]: {
+                    name: 'multipleServices',
+                },
+            },
+            mockWriteHeadFn: writeHeadMock,
+        });
+        await saveOperatorGroup(req, res);
+
         expect(insertOperatorGroupSpy).toBeCalledTimes(0);
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, SAVE_OPERATOR_GROUP_ATTRIBUTE, []);
+        expect(writeHeadMock).toBeCalledWith(302, { Location: '/multipleOperatorsServiceList' });
     });
 });

--- a/tests/pages/api/searchOperators.test.ts
+++ b/tests/pages/api/searchOperators.test.ts
@@ -314,55 +314,95 @@ describe('searchOperators', () => {
         });
     });
 
-    it.each([
-        ['/howManyProducts', 'geoZone'],
-        ['/saveOperatorGroup', 'multipleServices'],
-    ])(
-        'should redirect to %s when the user has successfully selected operators for a %s multi op ticket',
-        (redirect, ticketType) => {
-            const mockSelectedOperators: Operator[] = [
-                {
-                    nocCode: 'MCTR',
-                    name: 'Manchester Community Transport',
+    it('should redirect to /saveOperatorGroup when the user has successfully selected operators for a geoZone multi op ticket', () => {
+        const mockSelectedOperators: Operator[] = [
+            {
+                nocCode: 'MCTR',
+                name: 'Manchester Community Transport',
+            },
+            {
+                nocCode: 'MCTR2',
+                name: 'Manchester Community Transport 2',
+            },
+            {
+                nocCode: 'MCTR3',
+                name: 'Manchester Community Transport 3',
+            },
+        ];
+        const { req, res } = getMockRequestAndResponse({
+            body: {
+                continueButtonClick: 'Continue',
+                searchText: '',
+            },
+            session: {
+                [MULTIPLE_OPERATOR_ATTRIBUTE]: {
+                    selectedOperators: mockSelectedOperators,
                 },
-                {
-                    nocCode: 'MCTR2',
-                    name: 'Manchester Community Transport 2',
+                [TICKET_REPRESENTATION_ATTRIBUTE]: {
+                    name: 'geoZone',
                 },
-                {
-                    nocCode: 'MCTR3',
-                    name: 'Manchester Community Transport 3',
-                },
-            ];
-            const { req, res } = getMockRequestAndResponse({
-                body: {
-                    continueButtonClick: 'Continue',
-                    searchText: '',
-                },
-                session: {
-                    [MULTIPLE_OPERATOR_ATTRIBUTE]: {
-                        selectedOperators: mockSelectedOperators,
-                    },
-                    [TICKET_REPRESENTATION_ATTRIBUTE]: {
-                        name: ticketType,
-                    },
-                },
-            });
+            },
+        });
 
-            const expectedSessionAttributeCall: MultipleOperatorsAttribute = {
-                selectedOperators: mockSelectedOperators,
-            };
+        const expectedSessionAttributeCall: MultipleOperatorsAttribute = {
+            selectedOperators: mockSelectedOperators,
+        };
 
-            searchOperators(req, res);
+        searchOperators(req, res);
 
-            expect(updateSessionAttributeSpy).toHaveBeenCalledWith(
-                req,
-                MULTIPLE_OPERATOR_ATTRIBUTE,
-                expectedSessionAttributeCall,
-            );
-            expect(res.writeHead).toBeCalledWith(302, {
-                Location: redirect,
-            });
-        },
-    );
+        expect(updateSessionAttributeSpy).toHaveBeenCalledWith(
+            req,
+            MULTIPLE_OPERATOR_ATTRIBUTE,
+            expectedSessionAttributeCall,
+        );
+        expect(res.writeHead).toBeCalledWith(302, {
+            Location: '/saveOperatorGroup',
+        });
+    });
+
+    it('should redirect to /saveOperatorGroup when the user has successfully selected operators for a multipleServices multi op ticket', () => {
+        const mockSelectedOperators: Operator[] = [
+            {
+                nocCode: 'MCTR',
+                name: 'Manchester Community Transport',
+            },
+            {
+                nocCode: 'MCTR2',
+                name: 'Manchester Community Transport 2',
+            },
+            {
+                nocCode: 'MCTR3',
+                name: 'Manchester Community Transport 3',
+            },
+        ];
+        const { req, res } = getMockRequestAndResponse({
+            body: {
+                continueButtonClick: 'Continue',
+                searchText: '',
+            },
+            session: {
+                [MULTIPLE_OPERATOR_ATTRIBUTE]: {
+                    selectedOperators: mockSelectedOperators,
+                },
+                [TICKET_REPRESENTATION_ATTRIBUTE]: {
+                    name: 'multipleServices',
+                },
+            },
+        });
+
+        const expectedSessionAttributeCall: MultipleOperatorsAttribute = {
+            selectedOperators: mockSelectedOperators,
+        };
+
+        searchOperators(req, res);
+
+        expect(updateSessionAttributeSpy).toHaveBeenCalledWith(
+            req,
+            MULTIPLE_OPERATOR_ATTRIBUTE,
+            expectedSessionAttributeCall,
+        );
+        expect(res.writeHead).toBeCalledWith(302, {
+            Location: '/saveOperatorGroup',
+        });
+    });
 });

--- a/tests/pages/api/searchOperators.test.ts
+++ b/tests/pages/api/searchOperators.test.ts
@@ -316,7 +316,7 @@ describe('searchOperators', () => {
 
     it.each([
         ['/howManyProducts', 'geoZone'],
-        ['/multipleOperatorsServiceList', 'multipleServices'],
+        ['/saveOperatorGroup', 'multipleServices'],
     ])(
         'should redirect to %s when the user has successfully selected operators for a %s multi op ticket',
         (redirect, ticketType) => {

--- a/tests/pages/api/serviceList.test.ts
+++ b/tests/pages/api/serviceList.test.ts
@@ -95,7 +95,7 @@ describe('serviceList', () => {
         serviceList(req, res);
 
         expect(writeHeadMock).toBeCalledWith(302, {
-            Location: '/searchOperators',
+            Location: '/reuseOperatorGroup',
         });
     });
 

--- a/tests/pages/defineTimeRestrictions.test.tsx
+++ b/tests/pages/defineTimeRestrictions.test.tsx
@@ -75,22 +75,7 @@ describe('pages', () => {
 
             it('should return fieldsets with time restrictions when some are found', () => {
                 const emptyErrors: ErrorInfo[] = [];
-                const fieldsets = getFieldsets(emptyErrors, [
-                    {
-                        name: 'Test Time restriction',
-                        contents: [
-                            {
-                                day: 'monday',
-                                timeBands: [
-                                    {
-                                        startTime: '0900',
-                                        endTime: '1000',
-                                    },
-                                ],
-                            },
-                        ],
-                    },
-                ]);
+                const fieldsets = getFieldsets(emptyErrors, ['Test Time restriction']);
                 expect(fieldsets).toEqual(mockDefineTimeRestrictionsFieldsets);
             });
         });

--- a/tests/pages/reuseOperatorGroup.test.tsx
+++ b/tests/pages/reuseOperatorGroup.test.tsx
@@ -1,28 +1,28 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import {
-    mockFieldSetForSaveOperatorGroup,
-    mockFieldSetForSaveOperatorGroupWithErrorsIfRadioNotSelected,
-    mockFieldSetForSaveOperatorGroupWithErrorsIfNameMissing,
+    mockFieldSetForReuseOperatorGroup,
+    mockFieldSetForReuseOperatorGroupWithErrorsIfRadioNotSelected,
+    mockFieldSetForReuseOperatorGroupWithErrorsIfOptionNotSelected,
 } from '../testData/mockData';
 import { ErrorInfo } from '../../src/interfaces';
-import SaveOperatorGroup, { getFieldset } from '../../src/pages/saveOperatorGroup';
+import ReuseOperatorGroup, { getFieldsets } from '../../src/pages/reuseOperatorGroup';
 
 describe('pages', () => {
-    describe('saveOperatorGroup', () => {
+    describe('reuseOperatorGroup', () => {
         it('should render correctly', () => {
             const tree = shallow(
-                <SaveOperatorGroup errors={[]} csrfToken="" fieldset={mockFieldSetForSaveOperatorGroup} />,
+                <ReuseOperatorGroup errors={[]} csrfToken="" fieldset={mockFieldSetForReuseOperatorGroup} />,
             );
             expect(tree).toMatchSnapshot();
         });
 
         it('should render errors when user does not select a radio button', () => {
             const tree = shallow(
-                <SaveOperatorGroup
-                    errors={[{ errorMessage: 'Choose one of the options below', id: 'yes-reuse' }]}
+                <ReuseOperatorGroup
+                    errors={[{ errorMessage: 'Choose one of the options below', id: 'conditional-form-group' }]}
                     csrfToken=""
-                    fieldset={mockFieldSetForSaveOperatorGroupWithErrorsIfRadioNotSelected}
+                    fieldset={mockFieldSetForReuseOperatorGroupWithErrorsIfRadioNotSelected}
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -30,12 +30,15 @@ describe('pages', () => {
 
         it('should render errors when user does not provide a group name', () => {
             const tree = shallow(
-                <SaveOperatorGroup
+                <ReuseOperatorGroup
                     errors={[
-                        { errorMessage: 'Provide a name for the operator group', id: 'operator-group-name-input' },
+                        {
+                            errorMessage: 'Choose a premade operator group from the options below',
+                            id: 'premadeOperatorGroup',
+                        },
                     ]}
                     csrfToken=""
-                    fieldset={mockFieldSetForSaveOperatorGroupWithErrorsIfNameMissing}
+                    fieldset={mockFieldSetForReuseOperatorGroupWithErrorsIfNameMissing}
                 />,
             );
             expect(tree).toMatchSnapshot();
@@ -45,21 +48,26 @@ describe('pages', () => {
             it('should return fieldsets with no errors when no errors are passed', () => {
                 const emptyErrors: ErrorInfo[] = [];
                 const fieldsets = getFieldset(emptyErrors);
-                expect(fieldsets).toEqual(mockFieldSetForSaveOperatorGroup);
+                expect(fieldsets).toEqual(mockFieldSetForReuseOperatorGroup);
             });
 
             it('should return fieldsets with radio errors when radio errors are passed', () => {
-                const radioErrors: ErrorInfo[] = [{ errorMessage: 'Choose one of the options below', id: 'yes-reuse' }];
+                const radioErrors: ErrorInfo[] = [
+                    { errorMessage: 'Choose one of the options below', id: 'conditional-form-group' },
+                ];
                 const fieldsets = getFieldset(radioErrors);
-                expect(fieldsets).toEqual(mockFieldSetForSaveOperatorGroupWithErrorsIfRadioNotSelected);
+                expect(fieldsets).toEqual(mockFieldSetForReuseOperatorGroupWithErrorsIfRadioNotSelected);
             });
 
             it('should return fieldsets with input errors when input errors are passed', () => {
                 const inputErrors: ErrorInfo[] = [
-                    { errorMessage: 'Provide a name for the operator group', id: 'operator-group-name-input' },
+                    {
+                        errorMessage: 'Choose a premade operator group from the options below',
+                        id: 'premadeOperatorGroup',
+                    },
                 ];
                 const fieldsets = getFieldset(inputErrors);
-                expect(fieldsets).toEqual(mockFieldSetForSaveOperatorGroupWithErrorsIfNameMissing);
+                expect(fieldsets).toEqual(mockFieldSetForReuseOperatorGroupWithErrorsIfNameMissing);
             });
         });
     });

--- a/tests/pages/reuseOperatorGroup.test.tsx
+++ b/tests/pages/reuseOperatorGroup.test.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import {
+    mockFieldSetForSaveOperatorGroup,
+    mockFieldSetForSaveOperatorGroupWithErrorsIfRadioNotSelected,
+    mockFieldSetForSaveOperatorGroupWithErrorsIfNameMissing,
+} from '../testData/mockData';
+import { ErrorInfo } from '../../src/interfaces';
+import SaveOperatorGroup, { getFieldset } from '../../src/pages/saveOperatorGroup';
+
+describe('pages', () => {
+    describe('saveOperatorGroup', () => {
+        it('should render correctly', () => {
+            const tree = shallow(
+                <SaveOperatorGroup errors={[]} csrfToken="" fieldset={mockFieldSetForSaveOperatorGroup} />,
+            );
+            expect(tree).toMatchSnapshot();
+        });
+
+        it('should render errors when user does not select a radio button', () => {
+            const tree = shallow(
+                <SaveOperatorGroup
+                    errors={[{ errorMessage: 'Choose one of the options below', id: 'yes-reuse' }]}
+                    csrfToken=""
+                    fieldset={mockFieldSetForSaveOperatorGroupWithErrorsIfRadioNotSelected}
+                />,
+            );
+            expect(tree).toMatchSnapshot();
+        });
+
+        it('should render errors when user does not provide a group name', () => {
+            const tree = shallow(
+                <SaveOperatorGroup
+                    errors={[
+                        { errorMessage: 'Provide a name for the operator group', id: 'operator-group-name-input' },
+                    ]}
+                    csrfToken=""
+                    fieldset={mockFieldSetForSaveOperatorGroupWithErrorsIfNameMissing}
+                />,
+            );
+            expect(tree).toMatchSnapshot();
+        });
+
+        describe('getFieldset', () => {
+            it('should return fieldsets with no errors when no errors are passed', () => {
+                const emptyErrors: ErrorInfo[] = [];
+                const fieldsets = getFieldset(emptyErrors);
+                expect(fieldsets).toEqual(mockFieldSetForSaveOperatorGroup);
+            });
+
+            it('should return fieldsets with radio errors when radio errors are passed', () => {
+                const radioErrors: ErrorInfo[] = [{ errorMessage: 'Choose one of the options below', id: 'yes-reuse' }];
+                const fieldsets = getFieldset(radioErrors);
+                expect(fieldsets).toEqual(mockFieldSetForSaveOperatorGroupWithErrorsIfRadioNotSelected);
+            });
+
+            it('should return fieldsets with input errors when input errors are passed', () => {
+                const inputErrors: ErrorInfo[] = [
+                    { errorMessage: 'Provide a name for the operator group', id: 'operator-group-name-input' },
+                ];
+                const fieldsets = getFieldset(inputErrors);
+                expect(fieldsets).toEqual(mockFieldSetForSaveOperatorGroupWithErrorsIfNameMissing);
+            });
+        });
+    });
+});

--- a/tests/pages/saveOperatorGroup.test.tsx
+++ b/tests/pages/saveOperatorGroup.test.tsx
@@ -20,7 +20,7 @@ describe('pages', () => {
         it('should render errors when user does not select a radio button', () => {
             const tree = shallow(
                 <SaveOperatorGroup
-                    errors={[{ errorMessage: 'Choose one of the options below', id: 'yes-reuse' }]}
+                    errors={[{ errorMessage: 'Choose one of the options below', id: 'yes-save' }]}
                     csrfToken=""
                     fieldset={mockFieldSetForSaveOperatorGroupWithErrorsIfRadioNotSelected}
                 />,
@@ -49,7 +49,7 @@ describe('pages', () => {
             });
 
             it('should return fieldsets with radio errors when radio errors are passed', () => {
-                const radioErrors: ErrorInfo[] = [{ errorMessage: 'Choose one of the options below', id: 'yes-reuse' }];
+                const radioErrors: ErrorInfo[] = [{ errorMessage: 'Choose one of the options below', id: 'yes-save' }];
                 const fieldsets = getFieldset(radioErrors);
                 expect(fieldsets).toEqual(mockFieldSetForSaveOperatorGroupWithErrorsIfRadioNotSelected);
             });

--- a/tests/pages/saveOperatorGroup.test.tsx
+++ b/tests/pages/saveOperatorGroup.test.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import {
+    mockFieldSetForSaveOperatorGroup,
+    mockFieldSetForSaveOperatorGroupWithErrorsIfRadioNotSelected,
+    mockFieldSetForSaveOperatorGroupWithErrorsIfNameMissing,
+} from '../testData/mockData';
+import { ErrorInfo } from '../../src/interfaces';
+import SaveOperatorGroup, { getFieldset } from '../../src/pages/saveOperatorGroup';
+
+describe('pages', () => {
+    describe('saveOperatorGroup', () => {
+        it('should render correctly', () => {
+            const tree = shallow(
+                <SaveOperatorGroup errors={[]} csrfToken="" fieldset={mockFieldSetForSaveOperatorGroup} />,
+            );
+            expect(tree).toMatchSnapshot();
+        });
+
+        it('should render errors when user does not select a radio button', () => {
+            const tree = shallow(
+                <SaveOperatorGroup
+                    errors={[{ errorMessage: 'Choose one of the options below', id: 'yes-reuse' }]}
+                    csrfToken=""
+                    fieldset={mockFieldSetForSaveOperatorGroupWithErrorsIfRadioNotSelected}
+                />,
+            );
+            expect(tree).toMatchSnapshot();
+        });
+
+        it('should render errors when user does not provide a group name', () => {
+            const tree = shallow(
+                <SaveOperatorGroup
+                    errors={[
+                        { errorMessage: 'Provide a name for the operator group', id: 'operator-group-name-input' },
+                    ]}
+                    csrfToken=""
+                    fieldset={mockFieldSetForSaveOperatorGroupWithErrorsIfNameMissing}
+                />,
+            );
+            expect(tree).toMatchSnapshot();
+        });
+
+        describe('getFieldset', () => {
+            it('should return fieldsets with no errors when no errors are passed', () => {
+                const emptyErrors: ErrorInfo[] = [];
+                const fieldsets = getFieldset(emptyErrors);
+                expect(fieldsets).toEqual(mockFieldSetForSaveOperatorGroup);
+            });
+
+            it('should return fieldsets with radio errors when radio errors are passed', () => {
+                const radioErrors: ErrorInfo[] = [{ errorMessage: 'Choose one of the options below', id: 'yes-reuse' }];
+                const fieldsets = getFieldset(radioErrors);
+                expect(fieldsets).toEqual(mockFieldSetForSaveOperatorGroupWithErrorsIfRadioNotSelected);
+            });
+
+            it('should return fieldsets with input errors when input errors are passed', () => {
+                const inputErrors: ErrorInfo[] = [
+                    { errorMessage: 'Provide a name for the operator group', id: 'operator-group-name-input' },
+                ];
+                const fieldsets = getFieldset(inputErrors);
+                expect(fieldsets).toEqual(mockFieldSetForSaveOperatorGroupWithErrorsIfNameMissing);
+            });
+        });
+    });
+});

--- a/tests/pages/saveOperatorGroup.test.tsx
+++ b/tests/pages/saveOperatorGroup.test.tsx
@@ -43,8 +43,7 @@ describe('pages', () => {
 
         describe('getFieldset', () => {
             it('should return fieldsets with no errors when no errors are passed', () => {
-                const emptyErrors: ErrorInfo[] = [];
-                const fieldsets = getFieldset(emptyErrors);
+                const fieldsets = getFieldset([]);
                 expect(fieldsets).toEqual(mockFieldSetForSaveOperatorGroup);
             });
 

--- a/tests/testData/mockData.ts
+++ b/tests/testData/mockData.ts
@@ -2,7 +2,6 @@
 import React from 'react';
 import { mockRequest } from 'mock-req-res';
 import MockRes from 'mock-res';
-import { ID_TOKEN_COOKIE, COOKIES_POLICY_COOKIE } from '../../src/constants';
 import {
     SALES_OFFER_PACKAGES_ATTRIBUTE,
     STAGE_NAMES_ATTRIBUTE,
@@ -20,6 +19,8 @@ import {
     DEFINE_PASSENGER_TYPE_ERRORS_ATTRIBUTE,
     FARE_STAGES_ATTRIBUTE,
 } from '../../src/constants/attributes';
+import { ID_TOKEN_COOKIE, COOKIES_POLICY_COOKIE } from '../../src/constants';
+
 import { MatchingFareZones } from '../../src/interfaces/matchingInterface';
 import { TextInputFieldset } from '../../src/pages/definePassengerType';
 import {
@@ -3901,4 +3902,116 @@ export const mockFullTimeRestrictions: FullTimeRestrictionAttribute = {
         },
     ],
     errors: [],
+};
+
+export const mockFieldSetForSaveOperatorGroup: RadioConditionalInputFieldset = {
+    heading: {
+        id: 'reuse-operators-hidden-heading',
+        content: 'Do you want to save your group of operators for later use?',
+        hidden: true,
+    },
+    radios: [
+        {
+            id: 'yes-reuse',
+            name: 'reuseGroup',
+            value: 'yes',
+            dataAriaControls: 'reuse-operators-required-conditional',
+            label: 'Yes',
+            inputHint: {
+                id: 'reuse-group-name-hint',
+                content: 'Provide a name to remember your group of operators by',
+                hidden: true,
+            },
+            inputType: 'text',
+            inputs: [
+                {
+                    id: 'operator-group-name-input',
+                    name: 'groupName',
+                    label: 'Operator group name',
+                    defaultValue: '',
+                },
+            ],
+            inputErrors: [],
+        },
+        { id: 'no-reuse', name: 'reuseGroup', value: 'no', label: 'No' },
+    ],
+    radioError: [],
+};
+
+export const mockFieldSetForSaveOperatorGroupWithErrorsIfRadioNotSelected: RadioConditionalInputFieldset = {
+    heading: {
+        id: 'reuse-operators-hidden-heading',
+        content: 'Do you want to save your group of operators for later use?',
+        hidden: true,
+    },
+    radios: [
+        {
+            id: 'yes-reuse',
+            name: 'reuseGroup',
+            value: 'yes',
+            dataAriaControls: 'reuse-operators-required-conditional',
+            label: 'Yes',
+            inputHint: {
+                id: 'reuse-group-name-hint',
+                content: 'Provide a name to remember your group of operators by',
+                hidden: true,
+            },
+            inputType: 'text',
+            inputs: [
+                {
+                    id: 'operator-group-name-input',
+                    name: 'groupName',
+                    label: 'Operator group name',
+                    defaultValue: '',
+                },
+            ],
+            inputErrors: [],
+        },
+        { id: 'no-reuse', name: 'reuseGroup', value: 'no', label: 'No' },
+    ],
+    radioError: [
+        {
+            errorMessage: 'Choose one of the options below',
+            id: 'yes-reuse',
+        },
+    ],
+};
+
+export const mockFieldSetForSaveOperatorGroupWithErrorsIfNameMissing: RadioConditionalInputFieldset = {
+    heading: {
+        id: 'reuse-operators-hidden-heading',
+        content: 'Do you want to save your group of operators for later use?',
+        hidden: true,
+    },
+    radios: [
+        {
+            id: 'yes-reuse',
+            name: 'reuseGroup',
+            value: 'yes',
+            dataAriaControls: 'reuse-operators-required-conditional',
+            label: 'Yes',
+            inputHint: {
+                id: 'reuse-group-name-hint',
+                content: 'Provide a name to remember your group of operators by',
+                hidden: true,
+            },
+            inputType: 'text',
+            inputs: [
+                {
+                    id: 'operator-group-name-input',
+                    name: 'groupName',
+                    label: 'Operator group name',
+                    defaultValue: '',
+                },
+            ],
+            inputErrors: [
+                {
+                    errorMessage: 'Provide a name for the operator group',
+                    id: 'operator-group-name-input',
+                },
+            ],
+        },
+        { id: 'no-reuse', name: 'reuseGroup', value: 'no', label: 'No' },
+    ],
+    radioError: [],
 };

--- a/tests/testData/mockData.ts
+++ b/tests/testData/mockData.ts
@@ -4055,5 +4055,110 @@ export const mockFieldSetForSaveOperatorGroupWithErrorsIfNameMissing: RadioCondi
 };
 
 export const mockFieldSetForReuseOperatorGroup: RadioConditionalInputFieldset = {
-    
+    heading: {
+        id: 'reuse-operator-group-heading',
+        content: 'Do you want to reuse a saved operator group?',
+        hidden: true,
+    },
+    radios: [
+        {
+            id: 'reuse-operator-group-yes',
+            name: 'reuseGroupChoice',
+            value: 'Yes',
+            label: 'Yes',
+            inputHint: {
+                id: 'choose-time-restriction-hint',
+                content: 'Select an operator group from the dropdown',
+                hidden: true,
+            },
+            inputType: 'dropdown',
+            dataAriaControls: 'reuse-operator-group',
+            inputs: [{ id: 'operator-group-0', name: 'Best Ops', label: 'Best Ops' }],
+            inputErrors: [],
+            selectIdentifier: 'premadeOperatorGroup',
+        },
+        {
+            id: 'reuse-operator-group-no',
+            name: 'reuseGroupChoice',
+            value: 'No',
+            label: 'No',
+        },
+    ],
+    radioError: [],
+};
+
+export const mockFieldSetForReuseOperatorGroupWithErrorsIfRadioNotSelected: RadioConditionalInputFieldset = {
+    heading: {
+        id: 'reuse-operator-group-heading',
+        content: 'Do you want to reuse a saved operator group?',
+        hidden: true,
+    },
+    radios: [
+        {
+            id: 'reuse-operator-group-yes',
+            name: 'reuseGroupChoice',
+            value: 'Yes',
+            label: 'Yes',
+            inputHint: {
+                id: 'choose-time-restriction-hint',
+                content: 'Select an operator group from the dropdown',
+                hidden: true,
+            },
+            inputType: 'dropdown',
+            dataAriaControls: 'reuse-operator-group',
+            inputs: [{ id: 'operator-group-0', name: 'Best Ops', label: 'Best Ops' }],
+            inputErrors: [],
+            selectIdentifier: 'premadeOperatorGroup',
+        },
+        {
+            id: 'reuse-operator-group-no',
+            name: 'reuseGroupChoice',
+            value: 'No',
+            label: 'No',
+        },
+    ],
+    radioError: [
+        {
+            errorMessage: 'Choose one of the options below',
+            id: 'conditional-form-group',
+        },
+    ],
+};
+
+export const mockFieldSetForReuseOperatorGroupWithErrorsIfOptionNotSelected: RadioConditionalInputFieldset = {
+    heading: {
+        id: 'reuse-operator-group-heading',
+        content: 'Do you want to reuse a saved operator group?',
+        hidden: true,
+    },
+    radios: [
+        {
+            id: 'reuse-operator-group-yes',
+            name: 'reuseGroupChoice',
+            value: 'Yes',
+            label: 'Yes',
+            inputHint: {
+                id: 'choose-time-restriction-hint',
+                content: 'Select an operator group from the dropdown',
+                hidden: true,
+            },
+            inputType: 'dropdown',
+            dataAriaControls: 'reuse-operator-group',
+            inputs: [{ id: 'operator-group-0', name: 'Best Ops', label: 'Best Ops' }],
+            inputErrors: [
+                {
+                    errorMessage: 'Choose a premade operator group from the options below',
+                    id: 'premadeOperatorGroup',
+                },
+            ],
+            selectIdentifier: 'premadeOperatorGroup',
+        },
+        {
+            id: 'reuse-operator-group-no',
+            name: 'reuseGroupChoice',
+            value: 'No',
+            label: 'No',
+        },
+    ],
+    radioError: [],
 };

--- a/tests/testData/mockData.ts
+++ b/tests/testData/mockData.ts
@@ -3394,58 +3394,96 @@ export const mockDefineTimeRestrictionsFieldsets: RadioConditionalInputFieldset[
         radioError: [],
         radios: [
             {
-                dataAriaControls: 'valid-days-required-conditional',
-                inputHint: {
-                    content: 'Select the days of the week the ticket is valid for',
-                    id: 'define-valid-days-inputHint',
-                },
                 id: 'valid-days-required',
-                inputErrors: [],
-                inputType: 'checkbox',
-                inputs: [
-                    { id: 'monday', label: 'Monday', name: 'validDays', defaultChecked: false },
-                    { id: 'tuesday', label: 'Tuesday', name: 'validDays', defaultChecked: false },
-                    { id: 'wednesday', label: 'Wednesday', name: 'validDays', defaultChecked: false },
-                    { id: 'thursday', label: 'Thursday', name: 'validDays', defaultChecked: false },
-                    { id: 'friday', label: 'Friday', name: 'validDays', defaultChecked: false },
-                    { id: 'saturday', label: 'Saturday', name: 'validDays', defaultChecked: false },
-                    { id: 'sunday', label: 'Sunday', name: 'validDays', defaultChecked: false },
-                    { id: 'bankHoliday', label: 'Bank holiday', name: 'validDays', defaultChecked: false },
-                ],
-                label: 'Yes - define new time restriction',
                 name: 'timeRestrictionChoice',
                 value: 'Yes',
-            },
-            {
-                dataAriaControls: 'premade-time-restriction',
-                id: 'premade-time-restriction-yes',
-                inputErrors: [],
+                dataAriaControls: 'valid-days-required-conditional',
+                label: 'Yes - define new time restriction',
                 inputHint: {
-                    content: 'Select a saved time restriction to use',
-                    id: 'choose-time-restriction-hint',
+                    id: 'define-valid-days-inputHint',
+                    content: 'Select the days of the week the ticket is valid for',
                 },
-                inputType: 'dropdown',
+                inputType: 'checkbox',
                 inputs: [
                     {
-                        contents: [
-                            {
-                                day: 'monday',
-                                timeBands: [
-                                    {
-                                        endTime: '1000',
-                                        startTime: '0900',
-                                    },
-                                ],
-                            },
-                        ],
-                        name: 'Test Time restriction',
+                        id: 'monday',
+                        name: 'validDays',
+                        label: 'Monday',
+                        defaultChecked: false,
+                    },
+                    {
+                        id: 'tuesday',
+                        name: 'validDays',
+                        label: 'Tuesday',
+                        defaultChecked: false,
+                    },
+                    {
+                        id: 'wednesday',
+                        name: 'validDays',
+                        label: 'Wednesday',
+                        defaultChecked: false,
+                    },
+                    {
+                        id: 'thursday',
+                        name: 'validDays',
+                        label: 'Thursday',
+                        defaultChecked: false,
+                    },
+                    {
+                        id: 'friday',
+                        name: 'validDays',
+                        label: 'Friday',
+                        defaultChecked: false,
+                    },
+                    {
+                        id: 'saturday',
+                        name: 'validDays',
+                        label: 'Saturday',
+                        defaultChecked: false,
+                    },
+                    {
+                        id: 'sunday',
+                        name: 'validDays',
+                        label: 'Sunday',
+                        defaultChecked: false,
+                    },
+                    {
+                        id: 'bankHoliday',
+                        name: 'validDays',
+                        label: 'Bank holiday',
+                        defaultChecked: false,
                     },
                 ],
-                label: 'Yes - reuse a saved time restriction',
+                inputErrors: [],
+            },
+
+            {
+                id: 'premade-time-restriction-yes',
                 name: 'timeRestrictionChoice',
                 value: 'Premade',
+                label: 'Yes - reuse a saved time restriction',
+                inputHint: {
+                    id: 'choose-time-restriction-hint',
+                    content: 'Select a saved time restriction to use',
+                },
+                inputType: 'dropdown',
+                dataAriaControls: 'premade-time-restriction',
+                inputs: [
+                    {
+                        id: 'premade-time-restriction-0',
+                        name: 'Test Time restriction',
+                        label: 'Test Time restriction',
+                    },
+                ],
+                inputErrors: [],
+                selectIdentifier: 'timeRestriction',
             },
-            { id: 'valid-days-not-required', label: 'No', name: 'timeRestrictionChoice', value: 'No' },
+            {
+                id: 'valid-days-not-required',
+                name: 'timeRestrictionChoice',
+                value: 'No',
+                label: 'No',
+            },
         ],
     },
 ];
@@ -3906,19 +3944,19 @@ export const mockFullTimeRestrictions: FullTimeRestrictionAttribute = {
 
 export const mockFieldSetForSaveOperatorGroup: RadioConditionalInputFieldset = {
     heading: {
-        id: 'reuse-operators-hidden-heading',
+        id: 'save-operators-hidden-heading',
         content: 'Do you want to save your group of operators for later use?',
         hidden: true,
     },
     radios: [
         {
-            id: 'yes-reuse',
-            name: 'reuseGroup',
+            id: 'yes-save',
+            name: 'saveGroup',
             value: 'yes',
-            dataAriaControls: 'reuse-operators-required-conditional',
+            dataAriaControls: 'save-operators-required-conditional',
             label: 'Yes',
             inputHint: {
-                id: 'reuse-group-name-hint',
+                id: 'save-group-name-hint',
                 content: 'Provide a name to remember your group of operators by',
                 hidden: true,
             },
@@ -3933,26 +3971,26 @@ export const mockFieldSetForSaveOperatorGroup: RadioConditionalInputFieldset = {
             ],
             inputErrors: [],
         },
-        { id: 'no-reuse', name: 'reuseGroup', value: 'no', label: 'No' },
+        { id: 'no-save', name: 'saveGroup', value: 'no', label: 'No' },
     ],
     radioError: [],
 };
 
 export const mockFieldSetForSaveOperatorGroupWithErrorsIfRadioNotSelected: RadioConditionalInputFieldset = {
     heading: {
-        id: 'reuse-operators-hidden-heading',
+        id: 'save-operators-hidden-heading',
         content: 'Do you want to save your group of operators for later use?',
         hidden: true,
     },
     radios: [
         {
-            id: 'yes-reuse',
-            name: 'reuseGroup',
+            id: 'yes-save',
+            name: 'saveGroup',
             value: 'yes',
-            dataAriaControls: 'reuse-operators-required-conditional',
+            dataAriaControls: 'save-operators-required-conditional',
             label: 'Yes',
             inputHint: {
-                id: 'reuse-group-name-hint',
+                id: 'save-group-name-hint',
                 content: 'Provide a name to remember your group of operators by',
                 hidden: true,
             },
@@ -3967,31 +4005,31 @@ export const mockFieldSetForSaveOperatorGroupWithErrorsIfRadioNotSelected: Radio
             ],
             inputErrors: [],
         },
-        { id: 'no-reuse', name: 'reuseGroup', value: 'no', label: 'No' },
+        { id: 'no-save', name: 'saveGroup', value: 'no', label: 'No' },
     ],
     radioError: [
         {
             errorMessage: 'Choose one of the options below',
-            id: 'yes-reuse',
+            id: 'yes-save',
         },
     ],
 };
 
 export const mockFieldSetForSaveOperatorGroupWithErrorsIfNameMissing: RadioConditionalInputFieldset = {
     heading: {
-        id: 'reuse-operators-hidden-heading',
+        id: 'save-operators-hidden-heading',
         content: 'Do you want to save your group of operators for later use?',
         hidden: true,
     },
     radios: [
         {
-            id: 'yes-reuse',
-            name: 'reuseGroup',
+            id: 'yes-save',
+            name: 'saveGroup',
             value: 'yes',
-            dataAriaControls: 'reuse-operators-required-conditional',
+            dataAriaControls: 'save-operators-required-conditional',
             label: 'Yes',
             inputHint: {
-                id: 'reuse-group-name-hint',
+                id: 'save-group-name-hint',
                 content: 'Provide a name to remember your group of operators by',
                 hidden: true,
             },
@@ -4011,7 +4049,11 @@ export const mockFieldSetForSaveOperatorGroupWithErrorsIfNameMissing: RadioCondi
                 },
             ],
         },
-        { id: 'no-reuse', name: 'reuseGroup', value: 'no', label: 'No' },
+        { id: 'no-save', name: 'saveGroup', value: 'no', label: 'No' },
     ],
     radioError: [],
+};
+
+export const mockFieldSetForReuseOperatorGroup: RadioConditionalInputFieldset = {
+    
 };


### PR DESCRIPTION
# Description

-   Adds the option to save and reuse operator groups in the multi-op journey.

# Testing instructions

-   Run through the multi-op journey for both geozone and multi-service products, and test the functionality for saving and reusing operator groups.

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
