### PR TITLE
fix: toggle off switch data source button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17353,9 +17353,9 @@
             "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
         },
         "y18n": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+            "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
         },
         "yallist": {
             "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         }
     },
     "lint-staged": {
-        "./**/*.{ts,tsx}" : [
+        "./**/*.{ts,tsx}": [
             "prettier --c './**/*.{ts,tsx}'"
         ],
         "./**/*.{ts,tsx},.eslintignore": [

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -16,7 +16,7 @@ import CsrfForm from '../components/CsrfForm';
 import { isPassengerType, isServiceAttributeWithErrors } from '../interfaces/typeGuards';
 import { getSessionAttribute } from '../utils/sessions';
 import { redirectTo } from './api/apiUtils';
-import SwitchDataSource from '../components/SwitchDataSource';
+// import SwitchDataSource from '../components/SwitchDataSource';
 
 const title = 'Service - Create Fares Data Service';
 const description = 'Service selection page of the Create Fares Data Service';
@@ -82,7 +82,7 @@ const Service = ({
                 <input type="submit" value="Continue" id="continue-button" className="govuk-button" />
             </>
         </CsrfForm>
-        <SwitchDataSource dataSourceAttribute={dataSourceAttribute} pageUrl="/service" csrfToken={csrfToken} />
+        {/* <SwitchDataSource dataSourceAttribute={dataSourceAttribute} pageUrl="/service" csrfToken={csrfToken} /> */}
     </TwoThirdsLayout>
 );
 

--- a/src/pages/serviceList.tsx
+++ b/src/pages/serviceList.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import SwitchDataSource from '../components/SwitchDataSource';
+// import SwitchDataSource from '../components/SwitchDataSource';
 import ErrorSummary from '../components/ErrorSummary';
 import FormElementWrapper from '../components/FormElementWrapper';
 import { FullColumnLayout } from '../layout/Layout';
@@ -40,7 +40,7 @@ const ServiceList = ({
     dataSourceAttribute,
 }: ServiceListProps): ReactElement => (
     <FullColumnLayout title={pageTitle} description={pageDescription}>
-        <SwitchDataSource dataSourceAttribute={dataSourceAttribute} pageUrl="/serviceList" csrfToken={csrfToken} />
+        {/* <SwitchDataSource dataSourceAttribute={dataSourceAttribute} pageUrl="/serviceList" csrfToken={csrfToken} /> */}
         <CsrfForm action="/api/serviceList" method="post" csrfToken={csrfToken}>
             <>
                 <ErrorSummary errors={errors} />

--- a/tests/pages/__snapshots__/service.test.tsx.snap
+++ b/tests/pages/__snapshots__/service.test.tsx.snap
@@ -106,16 +106,5 @@ exports[`pages service should render correctly 1`] = `
       value="Continue"
     />
   </CsrfForm>
-  <SwitchDataSource
-    csrfToken=""
-    dataSourceAttribute={
-      Object {
-        "hasBods": false,
-        "hasTnds": true,
-        "source": "tnds",
-      }
-    }
-    pageUrl="/service"
-  />
 </Component>
 `;

--- a/tests/pages/__snapshots__/serviceList.test.tsx.snap
+++ b/tests/pages/__snapshots__/serviceList.test.tsx.snap
@@ -5,17 +5,6 @@ exports[`pages serviceList should render an error when the error flag is set to 
   description="Service List selection page of the Create Fares Data Service"
   title="Service List - Create Fares Data Service"
 >
-  <SwitchDataSource
-    csrfToken=""
-    dataSourceAttribute={
-      Object {
-        "hasBods": true,
-        "hasTnds": true,
-        "source": "bods",
-      }
-    }
-    pageUrl="/serviceList"
-  />
   <CsrfForm
     action="/api/serviceList"
     csrfToken=""
@@ -113,17 +102,6 @@ exports[`pages serviceList should render correctly 1`] = `
   description="Service List selection page of the Create Fares Data Service"
   title="Service List - Create Fares Data Service"
 >
-  <SwitchDataSource
-    csrfToken=""
-    dataSourceAttribute={
-      Object {
-        "hasBods": false,
-        "hasTnds": true,
-        "source": "tnds",
-      }
-    }
-    pageUrl="/serviceList"
-  />
   <CsrfForm
     action="/api/serviceList"
     csrfToken=""
@@ -265,17 +243,6 @@ exports[`pages serviceList should render correctly for multiOperator 1`] = `
   description="Service List selection page of the Create Fares Data Service"
   title="Service List - Create Fares Data Service"
 >
-  <SwitchDataSource
-    csrfToken=""
-    dataSourceAttribute={
-      Object {
-        "hasBods": false,
-        "hasTnds": true,
-        "source": "tnds",
-      }
-    }
-    pageUrl="/serviceList"
-  />
   <CsrfForm
     action="/api/serviceList"
     csrfToken=""


### PR DESCRIPTION
# Description

-   Toggles off the 'switch data source' button on the /service and /serviceList pages

# Testing instructions

-   Check the /service and /serviceList pages display correctly, with no switch data soruce button

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
