### PR TITLE
origin and destination added to service displays for bods data source

### DIFF
--- a/src/data/auroradb.ts
+++ b/src/data/auroradb.ts
@@ -116,7 +116,7 @@ export const getServicesByNocCodeAndDataSource = async (nocCode: string, source:
 
     try {
         const queryInput = `
-            SELECT lineName, startDate, serviceDescription AS description, serviceCode
+            SELECT lineName, startDate, serviceDescription AS description, origin, destination, serviceCode
             FROM txcOperatorLine
             WHERE nocCode = ? AND dataSource = ?
             ORDER BY CAST(lineName AS UNSIGNED) = 0, CAST(lineName AS UNSIGNED), LEFT(lineName, 1), MID(lineName, 2), startDate;
@@ -129,6 +129,8 @@ export const getServicesByNocCodeAndDataSource = async (nocCode: string, source:
                 lineName: item.lineName,
                 startDate: convertDateFormat(item.startDate),
                 description: item.description,
+                origin: item.origin,
+                destination: item.destination,
                 serviceCode: item.serviceCode,
             })) || []
         );

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -662,6 +662,8 @@ export interface ServiceType {
     lineName: string;
     startDate: string;
     description: string;
+    origin?: string;
+    destination?: string;
     serviceCode: string;
     dataSource?: string;
 }

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -16,7 +16,7 @@ import CsrfForm from '../components/CsrfForm';
 import { isPassengerType, isServiceAttributeWithErrors } from '../interfaces/typeGuards';
 import { getSessionAttribute } from '../utils/sessions';
 import { redirectTo } from './api/apiUtils';
-// import SwitchDataSource from '../components/SwitchDataSource';
+import SwitchDataSource from '../components/SwitchDataSource';
 
 const title = 'Service - Create Fares Data Service';
 const description = 'Service selection page of the Create Fares Data Service';
@@ -63,7 +63,10 @@ const Service = ({
                                     value={`${service.lineName}#${service.startDate}`}
                                     className="service-option"
                                 >
-                                    {service.lineName} - Start date {service.startDate}
+                                    {dataSourceAttribute.source === 'tnds'
+                                        ? `${service.lineName} - Start date ${service.startDate}`
+                                        : `${service.lineName} ${service.origin || 'N/A'} - ${service.destination ||
+                                              'N/A'} (Start date ${service.startDate})`}
                                 </option>
                             ))}
                         </select>
@@ -82,7 +85,7 @@ const Service = ({
                 <input type="submit" value="Continue" id="continue-button" className="govuk-button" />
             </>
         </CsrfForm>
-        {/* <SwitchDataSource dataSourceAttribute={dataSourceAttribute} pageUrl="/service" csrfToken={csrfToken} /> */}
+        <SwitchDataSource dataSourceAttribute={dataSourceAttribute} pageUrl="/service" csrfToken={csrfToken} />
     </TwoThirdsLayout>
 );
 

--- a/src/pages/serviceList.tsx
+++ b/src/pages/serviceList.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-// import SwitchDataSource from '../components/SwitchDataSource';
+import SwitchDataSource from '../components/SwitchDataSource';
 import ErrorSummary from '../components/ErrorSummary';
 import FormElementWrapper from '../components/FormElementWrapper';
 import { FullColumnLayout } from '../layout/Layout';
@@ -40,7 +40,7 @@ const ServiceList = ({
     dataSourceAttribute,
 }: ServiceListProps): ReactElement => (
     <FullColumnLayout title={pageTitle} description={pageDescription}>
-        {/* <SwitchDataSource dataSourceAttribute={dataSourceAttribute} pageUrl="/serviceList" csrfToken={csrfToken} /> */}
+        <SwitchDataSource dataSourceAttribute={dataSourceAttribute} pageUrl="/serviceList" csrfToken={csrfToken} />
         <CsrfForm action="/api/serviceList" method="post" csrfToken={csrfToken}>
             <>
                 <ErrorSummary errors={errors} />
@@ -82,7 +82,11 @@ const ServiceList = ({
                                 {serviceList.map((service, index) => {
                                     const { lineName, startDate, serviceCode, description, checked } = service;
 
-                                    let checkboxTitles = `${lineName} - ${description} (Start Date ${startDate})`;
+                                    let checkboxTitles =
+                                        dataSourceAttribute.source === 'tnds'
+                                            ? `${lineName} - ${description} (Start Date ${startDate})`
+                                            : `${service.lineName} ${service.origin || 'N/A'} - ${service.destination ||
+                                                  'N/A'} (Start date ${service.startDate})`;
 
                                     if (checkboxTitles.length > 110) {
                                         checkboxTitles = `${checkboxTitles.substr(0, checkboxTitles.length - 10)}...`;

--- a/tests/pages/__snapshots__/service.test.tsx.snap
+++ b/tests/pages/__snapshots__/service.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`pages service should render correctly 1`] = `
+exports[`pages service should render correctly when data source is bods 1`] = `
 <Component
   description="Service selection page of the Create Fares Data Service"
   errors={Array []}
@@ -57,27 +57,135 @@ exports[`pages service should render correctly 1`] = `
             key="123#05/02/2020"
             value="123#05/02/2020"
           >
-            123
-             - Start date 
-            05/02/2020
+            123 Manchester - Leeds (Start date 05/02/2020)
           </option>
           <option
             className="service-option"
             key="X1#06/02/2020"
             value="X1#06/02/2020"
           >
-            X1
-             - Start date 
-            06/02/2020
+            X1 Edinburgh - N/A (Start date 06/02/2020)
           </option>
           <option
             className="service-option"
             key="Infinity Line#07/02/2020"
             value="Infinity Line#07/02/2020"
           >
-            Infinity Line
-             - Start date 
-            07/02/2020
+            Infinity Line N/A - London (Start date 07/02/2020)
+          </option>
+        </select>
+      </FormElementWrapper>
+      <span
+        className="govuk-hint hint-text"
+        id="traveline-hint"
+      >
+        This data is taken from the
+         
+        <b>
+          Bus Open Data Service (BODS)
+        </b>
+        . If the service you are looking for is not listed, contact the BODS help desk for advice
+         
+        <a
+          href="/contact"
+        >
+          here
+        </a>
+      </span>
+    </div>
+    <input
+      className="govuk-button"
+      id="continue-button"
+      type="submit"
+      value="Continue"
+    />
+  </CsrfForm>
+  <SwitchDataSource
+    csrfToken=""
+    dataSourceAttribute={
+      Object {
+        "hasBods": true,
+        "hasTnds": true,
+        "source": "bods",
+      }
+    }
+    pageUrl="/service"
+  />
+</Component>
+`;
+
+exports[`pages service should render correctly when data source is tnds 1`] = `
+<Component
+  description="Service selection page of the Create Fares Data Service"
+  errors={Array []}
+  title="Service - Create Fares Data Service"
+>
+  <CsrfForm
+    action="/api/service"
+    csrfToken=""
+    method="post"
+  >
+    <label
+      htmlFor="service"
+    >
+      <h1
+        className="govuk-heading-l"
+        id="service-page-heading"
+      >
+        Select a service
+      </h1>
+    </label>
+    <span
+      className="govuk-hint"
+      id="service-operator-passenger-type-hint"
+    >
+      Connexions Buses
+       - 
+      Adult
+    </span>
+    <ErrorSummary
+      errors={Array []}
+    />
+    <div
+      className="govuk-form-group "
+    >
+      <FormElementWrapper
+        errorClass="govuk-select--error"
+        errorId="service"
+        errors={Array []}
+      >
+        <select
+          className="govuk-select"
+          defaultValue=""
+          id="service"
+          name="service"
+        >
+          <option
+            disabled={true}
+            value=""
+          >
+            Select One
+          </option>
+          <option
+            className="service-option"
+            key="123#05/02/2020"
+            value="123#05/02/2020"
+          >
+            123 - Start date 05/02/2020
+          </option>
+          <option
+            className="service-option"
+            key="X1#06/02/2020"
+            value="X1#06/02/2020"
+          >
+            X1 - Start date 06/02/2020
+          </option>
+          <option
+            className="service-option"
+            key="Infinity Line#07/02/2020"
+            value="Infinity Line#07/02/2020"
+          >
+            Infinity Line - Start date 07/02/2020
           </option>
         </select>
       </FormElementWrapper>
@@ -106,5 +214,16 @@ exports[`pages service should render correctly 1`] = `
       value="Continue"
     />
   </CsrfForm>
+  <SwitchDataSource
+    csrfToken=""
+    dataSourceAttribute={
+      Object {
+        "hasBods": false,
+        "hasTnds": true,
+        "source": "tnds",
+      }
+    }
+    pageUrl="/service"
+  />
 </Component>
 `;

--- a/tests/pages/__snapshots__/serviceList.test.tsx.snap
+++ b/tests/pages/__snapshots__/serviceList.test.tsx.snap
@@ -5,6 +5,17 @@ exports[`pages serviceList should render an error when the error flag is set to 
   description="Service List selection page of the Create Fares Data Service"
   title="Service List - Create Fares Data Service"
 >
+  <SwitchDataSource
+    csrfToken=""
+    dataSourceAttribute={
+      Object {
+        "hasBods": true,
+        "hasTnds": true,
+        "source": "bods",
+      }
+    }
+    pageUrl="/serviceList"
+  />
   <CsrfForm
     action="/api/serviceList"
     csrfToken=""
@@ -97,11 +108,22 @@ exports[`pages serviceList should render an error when the error flag is set to 
 </Component>
 `;
 
-exports[`pages serviceList should render correctly 1`] = `
+exports[`pages serviceList should render correctly for multiOperator 1`] = `
 <Component
   description="Service List selection page of the Create Fares Data Service"
   title="Service List - Create Fares Data Service"
 >
+  <SwitchDataSource
+    csrfToken=""
+    dataSourceAttribute={
+      Object {
+        "hasBods": false,
+        "hasTnds": true,
+        "source": "tnds",
+      }
+    }
+    pageUrl="/serviceList"
+  />
   <CsrfForm
     action="/api/serviceList"
     csrfToken=""
@@ -121,6 +143,7 @@ exports[`pages serviceList should render correctly 1`] = `
           id="service-list-page-heading"
         >
           Which 
+          of your 
           services is the ticket valid for?
         </h1>
       </legend>
@@ -128,6 +151,7 @@ exports[`pages serviceList should render correctly 1`] = `
         className="govuk-heading-s"
       >
         Select all 
+        of your 
         services that apply
       </span>
       <fieldset
@@ -238,11 +262,22 @@ exports[`pages serviceList should render correctly 1`] = `
 </Component>
 `;
 
-exports[`pages serviceList should render correctly for multiOperator 1`] = `
+exports[`pages serviceList should render correctly with bods data source 1`] = `
 <Component
   description="Service List selection page of the Create Fares Data Service"
   title="Service List - Create Fares Data Service"
 >
+  <SwitchDataSource
+    csrfToken=""
+    dataSourceAttribute={
+      Object {
+        "hasBods": true,
+        "hasTnds": true,
+        "source": "bods",
+      }
+    }
+    pageUrl="/serviceList"
+  />
   <CsrfForm
     action="/api/serviceList"
     csrfToken=""
@@ -262,7 +297,6 @@ exports[`pages serviceList should render correctly for multiOperator 1`] = `
           id="service-list-page-heading"
         >
           Which 
-          of your 
           services is the ticket valid for?
         </h1>
       </legend>
@@ -270,7 +304,158 @@ exports[`pages serviceList should render correctly for multiOperator 1`] = `
         className="govuk-heading-s"
       >
         Select all 
-        of your 
+        services that apply
+      </span>
+      <fieldset
+        className="govuk-fieldset"
+      >
+        <input
+          className="govuk-button govuk-button--secondary"
+          id="select-all-button"
+          name="selectAll"
+          type="submit"
+          value="Select All"
+        />
+        <span
+          className="govuk-hint"
+          id="traveline-hint"
+        >
+          This data is taken from the
+           
+          <b>
+            Bus Open Data Service (BODS)
+          </b>
+          . If the service you are looking for is not listed, contact the BODS help desk for advice
+           
+          <a
+            href="/contact"
+          >
+            here
+          </a>
+          .
+        </span>
+        <FormElementWrapper
+          addFormGroupError={false}
+          errorClass=""
+          errorId="checkbox-0"
+          errors={Array []}
+        >
+          <div
+            className="govuk-checkboxes"
+          >
+            <div
+              className="govuk-checkboxes__item"
+              key="checkbox-item-123"
+            >
+              <input
+                className="govuk-checkboxes__input"
+                defaultChecked={false}
+                id="checkbox-0"
+                name="123#NW_05_BLAC_123_1#05/02/2020"
+                type="checkbox"
+                value="IW Bus Service 123"
+              />
+              <label
+                className="govuk-label govuk-checkboxes__label"
+                htmlFor="checkbox-0"
+              >
+                123 Manchester - Leeds (Start date 05/02/2020)
+              </label>
+            </div>
+            <div
+              className="govuk-checkboxes__item"
+              key="checkbox-item-X1"
+            >
+              <input
+                className="govuk-checkboxes__input"
+                defaultChecked={false}
+                id="checkbox-1"
+                name="X1#NW_05_BLAC_X1_1#06/02/2020"
+                type="checkbox"
+                value="Big Blue Bus Service X1"
+              />
+              <label
+                className="govuk-label govuk-checkboxes__label"
+                htmlFor="checkbox-1"
+              >
+                X1 Edinburgh - N/A (Start date 06/02/2020)
+              </label>
+            </div>
+            <div
+              className="govuk-checkboxes__item"
+              key="checkbox-item-Infinity Line"
+            >
+              <input
+                className="govuk-checkboxes__input"
+                defaultChecked={false}
+                id="checkbox-2"
+                name="Infinity Line#WY_13_IWBT_07_1#07/02/2020"
+                type="checkbox"
+                value="This is some kind of bus service"
+              />
+              <label
+                className="govuk-label govuk-checkboxes__label"
+                htmlFor="checkbox-2"
+              >
+                Infinity Line N/A - London (Start date 07/02/2020)
+              </label>
+            </div>
+          </div>
+        </FormElementWrapper>
+      </fieldset>
+    </div>
+    <input
+      className="govuk-button"
+      id="continue-button"
+      type="submit"
+      value="Continue"
+    />
+  </CsrfForm>
+</Component>
+`;
+
+exports[`pages serviceList should render correctly with tnds data source 1`] = `
+<Component
+  description="Service List selection page of the Create Fares Data Service"
+  title="Service List - Create Fares Data Service"
+>
+  <SwitchDataSource
+    csrfToken=""
+    dataSourceAttribute={
+      Object {
+        "hasBods": false,
+        "hasTnds": true,
+        "source": "tnds",
+      }
+    }
+    pageUrl="/serviceList"
+  />
+  <CsrfForm
+    action="/api/serviceList"
+    csrfToken=""
+    method="post"
+  >
+    <ErrorSummary
+      errors={Array []}
+    />
+    <div
+      className="govuk-form-group "
+    >
+      <legend
+        className="govuk-fieldset__legend govuk-fieldset__legend--s"
+      >
+        <h1
+          className="govuk-heading-l"
+          id="service-list-page-heading"
+        >
+          Which 
+          services is the ticket valid for?
+        </h1>
+      </legend>
+      <span
+        className="govuk-heading-s"
+      >
+        Select all 
         services that apply
       </span>
       <fieldset

--- a/tests/pages/service.test.tsx
+++ b/tests/pages/service.test.tsx
@@ -13,13 +13,22 @@ const mockServices: ServiceType[] = [
         lineName: '123',
         startDate: '05/02/2020',
         description: 'this bus service is 123',
+        origin: 'Manchester',
+        destination: 'Leeds',
         serviceCode: 'NW_05_BLAC_123_1',
     },
-    { lineName: 'X1', startDate: '06/02/2020', description: 'this bus service is X1', serviceCode: 'NW_05_BLAC_X1_1' },
+    {
+        lineName: 'X1',
+        startDate: '06/02/2020',
+        description: 'this bus service is X1',
+        origin: 'Edinburgh',
+        serviceCode: 'NW_05_BLAC_X1_1',
+    },
     {
         lineName: 'Infinity Line',
         startDate: '07/02/2020',
         description: 'this bus service is Infinity Line',
+        destination: 'London',
         serviceCode: 'WY_13_IWBT_07_1',
     },
 ];
@@ -30,7 +39,7 @@ describe('pages', () => {
             (getServicesByNocCodeAndDataSource as jest.Mock).mockImplementation(() => mockServices);
         });
 
-        it('should render correctly', () => {
+        it('should render correctly when data source is tnds', () => {
             const tree = shallow(
                 <Service
                     operator="Connexions Buses"
@@ -41,6 +50,24 @@ describe('pages', () => {
                         source: 'tnds',
                         hasTnds: true,
                         hasBods: false,
+                    }}
+                    csrfToken=""
+                />,
+            );
+            expect(tree).toMatchSnapshot();
+        });
+
+        it('should render correctly when data source is bods', () => {
+            const tree = shallow(
+                <Service
+                    operator="Connexions Buses"
+                    passengerType="Adult"
+                    services={mockServices}
+                    error={[]}
+                    dataSourceAttribute={{
+                        source: 'bods',
+                        hasTnds: true,
+                        hasBods: true,
                     }}
                     csrfToken=""
                 />,
@@ -68,7 +95,7 @@ describe('pages', () => {
             expect(operatorWelcome.text()).toBe('Connexions Buses - Adult');
         });
 
-        it('shows a list of services for the operator in the select box', () => {
+        it('shows a list of services for the operator in the select box with tnds data source', () => {
             const wrapper = shallow(
                 <Service
                     operator="Connexions Buses"
@@ -89,6 +116,29 @@ describe('pages', () => {
             expect(operatorServices.first().text()).toBe('123 - Start date 05/02/2020');
             expect(operatorServices.at(1).text()).toBe('X1 - Start date 06/02/2020');
             expect(operatorServices.at(2).text()).toBe('Infinity Line - Start date 07/02/2020');
+        });
+
+        it('shows a list of services for the operator in the select box with bods data source', () => {
+            const wrapper = shallow(
+                <Service
+                    operator="Connexions Buses"
+                    passengerType="Adult"
+                    services={mockServices}
+                    error={[]}
+                    dataSourceAttribute={{
+                        source: 'bods',
+                        hasTnds: false,
+                        hasBods: true,
+                    }}
+                    csrfToken=""
+                />,
+            );
+            const operatorServices = wrapper.find('.service-option');
+
+            expect(operatorServices).toHaveLength(3);
+            expect(operatorServices.first().text()).toBe('123 Manchester - Leeds (Start date 05/02/2020)');
+            expect(operatorServices.at(1).text()).toBe('X1 Edinburgh - N/A (Start date 06/02/2020)');
+            expect(operatorServices.at(2).text()).toBe('Infinity Line N/A - London (Start date 07/02/2020)');
         });
 
         it('returns operator value and list of services when operator attribute exists with NOCCode', async () => {
@@ -112,18 +162,22 @@ describe('pages', () => {
                             lineName: '123',
                             startDate: '05/02/2020',
                             description: 'this bus service is 123',
+                            origin: 'Manchester',
+                            destination: 'Leeds',
                             serviceCode: 'NW_05_BLAC_123_1',
                         },
                         {
                             lineName: 'X1',
                             startDate: '06/02/2020',
                             description: 'this bus service is X1',
+                            origin: 'Edinburgh',
                             serviceCode: 'NW_05_BLAC_X1_1',
                         },
                         {
                             lineName: 'Infinity Line',
                             startDate: '07/02/2020',
                             description: 'this bus service is Infinity Line',
+                            destination: 'London',
                             serviceCode: 'WY_13_IWBT_07_1',
                         },
                     ],

--- a/tests/pages/serviceList.test.tsx
+++ b/tests/pages/serviceList.test.tsx
@@ -15,6 +15,8 @@ describe('pages', () => {
                 lineName: '123',
                 startDate: '05/02/2020',
                 description: 'IW Bus Service 123',
+                origin: 'Manchester',
+                destination: 'Leeds',
                 serviceCode: 'NW_05_BLAC_123_1',
                 checked: false,
             },
@@ -22,6 +24,7 @@ describe('pages', () => {
                 lineName: 'X1',
                 startDate: '06/02/2020',
                 description: 'Big Blue Bus Service X1',
+                origin: 'Edinburgh',
                 serviceCode: 'NW_05_BLAC_X1_1',
                 checked: false,
             },
@@ -29,6 +32,7 @@ describe('pages', () => {
                 lineName: 'Infinity Line',
                 startDate: '07/02/2020',
                 description: 'This is some kind of bus service',
+                destination: 'London',
                 serviceCode: 'WY_13_IWBT_07_1',
                 checked: false,
             },
@@ -46,18 +50,22 @@ describe('pages', () => {
                 lineName: '123',
                 startDate: '05/02/2020',
                 description: 'IW Bus Service 123',
+                origin: 'Manchester',
+                destination: 'Leeds',
                 serviceCode: 'NW_05_BLAC_123_1',
             },
             {
                 lineName: 'X1',
                 startDate: '06/02/2020',
                 description: 'Big Blue Bus Service X1',
+                origin: 'Edinburgh',
                 serviceCode: 'NW_05_BLAC_X1_1',
             },
             {
                 lineName: 'Infinity Line',
                 startDate: '07/02/2020',
                 description: 'This is some kind of bus service',
+                destination: 'London',
                 serviceCode: 'WY_13_IWBT_07_1',
             },
         ];
@@ -67,7 +75,7 @@ describe('pages', () => {
             (getAllServicesByNocCode as jest.Mock).mockImplementation(() => mockServices);
         });
 
-        it('should render correctly', () => {
+        it('should render correctly with tnds data source', () => {
             const tree = shallow(
                 <ServiceList
                     serviceList={mockServiceList}
@@ -79,6 +87,24 @@ describe('pages', () => {
                         source: 'tnds',
                         hasTnds: true,
                         hasBods: false,
+                    }}
+                />,
+            );
+            expect(tree).toMatchSnapshot();
+        });
+
+        it('should render correctly with bods data source', () => {
+            const tree = shallow(
+                <ServiceList
+                    serviceList={mockServiceList}
+                    buttonText="Select All"
+                    errors={[]}
+                    csrfToken=""
+                    multiOperator={false}
+                    dataSourceAttribute={{
+                        source: 'bods',
+                        hasTnds: true,
+                        hasBods: true,
                     }}
                 />,
             );


### PR DESCRIPTION
# Description

-   Adds origin and destination to the /service and /serviceList displays when BODS data source is chosen.
-   Switches back on the 'switch data source' button on these pages

# Testing instructions

-   Run the site locally. Check that services are displayed correctly on /service and /serviceList pages for BODS and TNDS data source.

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
