### PR TITLE
feat: Multi operator TXC switch enabled

### DIFF
--- a/src/components/SwitchDataSource.tsx
+++ b/src/components/SwitchDataSource.tsx
@@ -5,10 +5,16 @@ import CsrfForm from './CsrfForm';
 interface SwitchDataSourceProps {
     dataSourceAttribute: TxcSourceAttribute;
     pageUrl: string;
+    attributeVersion: 'baseOperator' | 'multiOperator';
     csrfToken: string;
 }
 
-const SwitchDataSource = ({ dataSourceAttribute, pageUrl, csrfToken }: SwitchDataSourceProps): ReactElement => {
+const SwitchDataSource = ({
+    dataSourceAttribute,
+    pageUrl,
+    attributeVersion,
+    csrfToken,
+}: SwitchDataSourceProps): ReactElement => {
     const { hasBods, hasTnds, source } = dataSourceAttribute;
     const buttonDisabled = (source === 'bods' && !hasTnds) || (source === 'tnds' && !hasBods);
 
@@ -16,6 +22,7 @@ const SwitchDataSource = ({ dataSourceAttribute, pageUrl, csrfToken }: SwitchDat
         <CsrfForm action="/api/switchDataSource" method="post" csrfToken={csrfToken}>
             <>
                 <input type="hidden" name="referer" value={pageUrl} />
+                <input type="hidden" name="attributeVersion" value={attributeVersion} />
                 <button
                     id="change-data-source"
                     type="submit"

--- a/src/constants/attributes.ts
+++ b/src/constants/attributes.ts
@@ -80,6 +80,8 @@ export const OPERATOR_ATTRIBUTE = 'fdbt-operator';
 
 export const TXC_SOURCE_ATTRIBUTE = 'fdbt-txc-source';
 
+export const MULTI_OP_TXC_SOURCE_ATTRIBUTE = 'fdbt-multi-op-txc-source';
+
 export const REUSE_OPERATOR_GROUP_ATTRIBUTE = 'fdbt-reuse-operator-group';
 
 export const SAVE_OPERATOR_GROUP_ATTRIBUTE = 'fdbt-save-operator-group';

--- a/src/data/auroradb.ts
+++ b/src/data/auroradb.ts
@@ -596,18 +596,14 @@ export const getSearchOperatorsByNocRegion = async (searchText: string, nocCode:
         search: searchText,
     });
 
-    const nocCodeParameter = replaceInternalNocCode(nocCode);
-
     const searchQuery = `
         SELECT nocCode, operatorPublicName AS name FROM nocTable WHERE nocCode IN (
-                SELECT DISTINCT nocCode FROM txcOperatorLine WHERE dataSource = 'tnds' AND regionCode IN (
-                    SELECT DISTINCT regionCode FROM txcOperatorLine WHERE nocCode = ? AND dataSource = 'tnds'
-                )
+            SELECT DISTINCT nocCode FROM txcOperatorLine
         ) AND operatorPublicName LIKE ?
     `;
 
     try {
-        return await executeQuery<Operator[]>(searchQuery, [nocCodeParameter, `%${searchText}%`]);
+        return await executeQuery<Operator[]>(searchQuery, [`%${searchText}%`]);
     } catch (error) {
         throw new Error(`Could not retrieve operators from AuroraDB: ${error.stack}`);
     }

--- a/src/data/auroradb.ts
+++ b/src/data/auroradb.ts
@@ -588,11 +588,10 @@ export const getTimeRestrictionByNameAndNoc = async (
     }
 };
 
-export const getSearchOperatorsByNocRegion = async (searchText: string, nocCode: string): Promise<Operator[]> => {
+export const getSearchOperatorsBySearchText = async (searchText: string): Promise<Operator[]> => {
     logger.info('', {
         context: 'data.auroradb',
         message: 'retrieving operators for given search text and noc',
-        nocCode,
         search: searchText,
     });
 
@@ -604,28 +603,6 @@ export const getSearchOperatorsByNocRegion = async (searchText: string, nocCode:
 
     try {
         return await executeQuery<Operator[]>(searchQuery, [`%${searchText}%`]);
-    } catch (error) {
-        throw new Error(`Could not retrieve operators from AuroraDB: ${error.stack}`);
-    }
-};
-
-export const getSearchOperatorsBySchemeOpRegion = async (
-    searchText: string,
-    regionCode: string,
-): Promise<Operator[]> => {
-    logger.info('', {
-        context: 'data.auroradb',
-        message: 'retrieving operators for given search text and noc',
-        regionCode,
-        search: searchText,
-    });
-
-    const searchQuery = `SELECT nocCode, operatorPublicName AS name FROM nocTable WHERE nocCode IN (
-        SELECT DISTINCT nocCode FROM txcOperatorLine WHERE regionCode = ?
-        ) AND operatorPublicName LIKE ? AND dataSource = 'tnds'`;
-
-    try {
-        return await executeQuery<Operator[]>(searchQuery, [regionCode, `%${searchText}%`]);
     } catch (error) {
         throw new Error(`Could not retrieve operators from AuroraDB: ${error.stack}`);
     }

--- a/src/pages/api/multipleOperatorsServiceList.ts
+++ b/src/pages/api/multipleOperatorsServiceList.ts
@@ -1,6 +1,10 @@
 import { NextApiResponse } from 'next';
 import isArray from 'lodash/isArray';
-import { MULTIPLE_OPERATOR_ATTRIBUTE, MULTIPLE_OPERATORS_SERVICES_ATTRIBUTE } from '../../constants/attributes';
+import {
+    MULTI_OP_TXC_SOURCE_ATTRIBUTE,
+    MULTIPLE_OPERATOR_ATTRIBUTE,
+    MULTIPLE_OPERATORS_SERVICES_ATTRIBUTE,
+} from '../../constants/attributes';
 import { redirectTo, redirectToError } from './apiUtils';
 import { getSessionAttribute, updateSessionAttribute } from '../../utils/sessions';
 import { NextApiRequestWithSession, MultiOperatorInfo, MultipleOperatorsAttribute } from '../../interfaces';
@@ -86,6 +90,8 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
         updateSessionAttribute(req, MULTIPLE_OPERATORS_SERVICES_ATTRIBUTE, newListOfMultiOperatorsData);
         const numberOfOperators = (getSessionAttribute(req, MULTIPLE_OPERATOR_ATTRIBUTE) as MultipleOperatorsAttribute)
             .selectedOperators.length;
+        // below update to session attribute is to reset it for the next operator in the list
+        updateSessionAttribute(req, MULTI_OP_TXC_SOURCE_ATTRIBUTE, undefined);
         if (newListOfMultiOperatorsData.length !== numberOfOperators) {
             redirectTo(res, '/multipleOperatorsServiceList');
             return;

--- a/src/pages/api/switchDataSource.ts
+++ b/src/pages/api/switchDataSource.ts
@@ -1,20 +1,22 @@
 import { NextApiResponse } from 'next';
+import { MULTI_OP_TXC_SOURCE_ATTRIBUTE, TXC_SOURCE_ATTRIBUTE } from '../../constants/attributes';
 import { getSessionAttribute, updateSessionAttribute } from '../../utils/sessions';
-import { TXC_SOURCE_ATTRIBUTE } from '../../constants/attributes';
 import { redirectToError, redirectTo } from './apiUtils/index';
 import { NextApiRequestWithSession } from '../../interfaces';
 
 export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
     try {
-        const { referer } = req.body;
-        const dataSource = getSessionAttribute(req, TXC_SOURCE_ATTRIBUTE);
+        const { referer, attributeVersion } = req.body;
+        const attributeToUse =
+            attributeVersion === 'baseOperator' ? TXC_SOURCE_ATTRIBUTE : MULTI_OP_TXC_SOURCE_ATTRIBUTE;
+        const dataSource = getSessionAttribute(req, attributeToUse);
 
         if (!dataSource) {
             throw new Error('Datasource has been incorrectly set and is neither TNDS nor BODS');
         }
 
         const newDataSource = dataSource.source === 'bods' ? 'tnds' : 'bods';
-        updateSessionAttribute(req, TXC_SOURCE_ATTRIBUTE, { ...dataSource, source: newDataSource });
+        updateSessionAttribute(req, attributeToUse, { ...dataSource, source: newDataSource });
         redirectTo(res, referer);
     } catch (error) {
         const message = 'There was a problem switching the TXC datasource:';

--- a/src/pages/multipleOperatorsServiceList.tsx
+++ b/src/pages/multipleOperatorsServiceList.tsx
@@ -159,9 +159,6 @@ export const getServerSideProps = async (
 
     if (!dataSourceAttribute) {
         const services = await getAllServicesByNocCode(operatorToUse.nocCode);
-        const hasBodsServices = services.some(service => service.dataSource && service.dataSource === 'bods');
-        const hasTndsServices = services.some(service => service.dataSource && service.dataSource === 'tnds');
-
         if (services.length === 0) {
             if (ctx.res) {
                 redirectTo(ctx.res, '/noServices');
@@ -169,6 +166,8 @@ export const getServerSideProps = async (
                 throw new Error(`No services found for NOC Code: ${operatorToUse.nocCode}`);
             }
         }
+        const hasBodsServices = services.some(service => service.dataSource && service.dataSource === 'bods');
+        const hasTndsServices = services.some(service => service.dataSource && service.dataSource === 'tnds');
         updateSessionAttribute(ctx.req, MULTI_OP_TXC_SOURCE_ATTRIBUTE, {
             source: hasBodsServices && !hasTndsServices ? 'bods' : 'tnds',
             hasBods: hasBodsServices,

--- a/src/pages/multipleOperatorsServiceList.tsx
+++ b/src/pages/multipleOperatorsServiceList.tsx
@@ -72,8 +72,15 @@ const MultipleOperatorsServiceList = ({
                             id="select-all-button"
                             className="govuk-button govuk-button--secondary"
                         />
-                        <span className="govuk-hint" id="traveline-hint">
-                            This data is taken from the Traveline National Dataset.
+                        <span className="govuk-hint" id="txc-hint">
+                            This data is taken from the{' '}
+                            <b>
+                                {dataSourceAttribute.source === 'tnds'
+                                    ? 'Traveline National Dataset (TNDS)'
+                                    : 'Bus Open Data Service (BODS)'}
+                            </b>
+                            . If the service you are looking for is not listed, contact the BODS help desk for advice{' '}
+                            <a href="/contact">here</a>.
                         </span>
                         <FormElementWrapper
                             errors={errors}

--- a/src/pages/multipleOperatorsServiceList.tsx
+++ b/src/pages/multipleOperatorsServiceList.tsx
@@ -1,20 +1,27 @@
 import React, { ReactElement } from 'react';
 import { getSessionAttribute, updateSessionAttribute } from '../utils/sessions';
-import { MULTIPLE_OPERATOR_ATTRIBUTE, MULTIPLE_OPERATORS_SERVICES_ATTRIBUTE } from '../constants/attributes';
+import {
+    MULTIPLE_OPERATOR_ATTRIBUTE,
+    MULTIPLE_OPERATORS_SERVICES_ATTRIBUTE,
+    MULTI_OP_TXC_SOURCE_ATTRIBUTE,
+} from '../constants/attributes';
 import { isMultiOperatorInfoWithErrors } from '../interfaces/typeGuards';
 import ErrorSummary from '../components/ErrorSummary';
 import FormElementWrapper from '../components/FormElementWrapper';
 import { FullColumnLayout } from '../layout/Layout';
-import { getServicesByNocCodeAndDataSource } from '../data/auroradb';
+import { getServicesByNocCodeAndDataSource, getAllServicesByNocCode } from '../data/auroradb';
 import {
     ErrorInfo,
     NextPageContextWithSession,
     MultiOperatorInfo,
     ServicesInfo,
     MultipleOperatorsAttribute,
+    TxcSourceAttribute,
 } from '../interfaces';
 import CsrfForm from '../components/CsrfForm';
 import { getCsrfToken } from '../utils';
+import { redirectTo } from './api/apiUtils';
+import SwitchDataSource from '../components/SwitchDataSource';
 
 const pageTitle = 'Multiple Operators Service List - Create Fares Data Service';
 const pageDescription = 'Multiple Operators Service List selection page of the Create Fares Data Service';
@@ -25,6 +32,7 @@ interface MultipleOperatorsServiceListProps {
     errors: ErrorInfo[];
     operatorName: string;
     nocCode: string;
+    dataSourceAttribute: TxcSourceAttribute;
     csrfToken: string;
 }
 
@@ -35,8 +43,15 @@ const MultipleOperatorsServiceList = ({
     errors,
     operatorName,
     nocCode,
+    dataSourceAttribute,
 }: MultipleOperatorsServiceListProps): ReactElement => (
     <FullColumnLayout title={pageTitle} description={pageDescription}>
+        <SwitchDataSource
+            dataSourceAttribute={dataSourceAttribute}
+            pageUrl="/multipleOperatorsServiceList"
+            attributeVersion="multiOperator"
+            csrfToken={csrfToken}
+        />
         <CsrfForm action="/api/multipleOperatorsServiceList" method="post" csrfToken={csrfToken}>
             <>
                 <ErrorSummary errors={errors} />
@@ -70,11 +85,7 @@ const MultipleOperatorsServiceList = ({
                                 {serviceList.map((service, index) => {
                                     const { lineName, startDate, serviceCode, description, checked } = service;
 
-                                    let checkboxTitles = `${lineName} - ${description} (Start Date ${startDate})`;
-
-                                    if (checkboxTitles.length > 110) {
-                                        checkboxTitles = `${checkboxTitles.substr(0, checkboxTitles.length - 10)}...`;
-                                    }
+                                    const checkboxTitles = `${lineName} - ${description} (Start Date ${startDate})`;
                                     const checkBoxValues = `${description}`;
 
                                     return (
@@ -144,15 +155,40 @@ export const getServerSideProps = async (
         throw new Error('Necessary operator not found to show multipleOperatorsServiceList page');
     }
 
-    const services = await getServicesByNocCodeAndDataSource(operatorToUse.nocCode, 'tnds');
+    let dataSourceAttribute = getSessionAttribute(ctx.req, MULTI_OP_TXC_SOURCE_ATTRIBUTE);
 
-    if (!services) {
+    if (!dataSourceAttribute) {
+        const services = await getAllServicesByNocCode(operatorToUse.nocCode);
+        const hasBodsServices = services.some(service => service.dataSource && service.dataSource === 'bods');
+        const hasTndsServices = services.some(service => service.dataSource && service.dataSource === 'tnds');
+
+        if (services.length === 0) {
+            if (ctx.res) {
+                redirectTo(ctx.res, '/noServices');
+            } else {
+                throw new Error(`No services found for NOC Code: ${operatorToUse.nocCode}`);
+            }
+        }
+        updateSessionAttribute(ctx.req, MULTI_OP_TXC_SOURCE_ATTRIBUTE, {
+            source: hasBodsServices && !hasTndsServices ? 'bods' : 'tnds',
+            hasBods: hasBodsServices,
+            hasTnds: hasTndsServices,
+        });
+        dataSourceAttribute = getSessionAttribute(ctx.req, MULTI_OP_TXC_SOURCE_ATTRIBUTE) as TxcSourceAttribute;
+    }
+
+    const chosenDataSourceServices = await getServicesByNocCodeAndDataSource(
+        operatorToUse.nocCode,
+        dataSourceAttribute.source,
+    );
+
+    if (!chosenDataSourceServices) {
         throw new Error(`No services found for ${operatorToUse.nocCode}`);
     }
 
     const { selectAll } = ctx.query;
 
-    const serviceList: ServicesInfo[] = services.map(service => {
+    const serviceList: ServicesInfo[] = chosenDataSourceServices.map(service => {
         return {
             ...service,
             checked: !selectAll || (selectAll !== 'true' && selectAll !== 'false') ? false : selectAll !== 'false',
@@ -166,6 +202,7 @@ export const getServerSideProps = async (
             errors: isMultiOperatorInfoWithErrors(completedOperatorInfo) ? completedOperatorInfo.errors : [],
             operatorName: operatorToUse.name,
             nocCode: operatorToUse.nocCode,
+            dataSourceAttribute,
             csrfToken,
         },
     };

--- a/src/pages/service.tsx
+++ b/src/pages/service.tsx
@@ -85,7 +85,12 @@ const Service = ({
                 <input type="submit" value="Continue" id="continue-button" className="govuk-button" />
             </>
         </CsrfForm>
-        <SwitchDataSource dataSourceAttribute={dataSourceAttribute} pageUrl="/service" csrfToken={csrfToken} />
+        <SwitchDataSource
+            dataSourceAttribute={dataSourceAttribute}
+            pageUrl="/service"
+            attributeVersion="baseOperator"
+            csrfToken={csrfToken}
+        />
     </TwoThirdsLayout>
 );
 

--- a/src/pages/serviceList.tsx
+++ b/src/pages/serviceList.tsx
@@ -67,7 +67,7 @@ const ServiceList = ({
                             id="select-all-button"
                             className="govuk-button govuk-button--secondary"
                         />
-                        <span className="govuk-hint" id="traveline-hint">
+                        <span className="govuk-hint" id="txc-hint">
                             This data is taken from the{' '}
                             <b>
                                 {dataSourceAttribute.source === 'tnds'

--- a/src/pages/serviceList.tsx
+++ b/src/pages/serviceList.tsx
@@ -137,9 +137,6 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
 
     if (!dataSourceAttribute) {
         const services = await getAllServicesByNocCode(nocCode);
-        const hasBodsServices = services.some(service => service.dataSource && service.dataSource === 'bods');
-        const hasTndsServices = services.some(service => service.dataSource && service.dataSource === 'tnds');
-
         if (services.length === 0) {
             if (ctx.res) {
                 redirectTo(ctx.res, '/noServices');
@@ -147,6 +144,8 @@ export const getServerSideProps = async (ctx: NextPageContextWithSession): Promi
                 throw new Error(`No services found for NOC Code: ${nocCode}`);
             }
         }
+        const hasBodsServices = services.some(service => service.dataSource && service.dataSource === 'bods');
+        const hasTndsServices = services.some(service => service.dataSource && service.dataSource === 'tnds');
         updateSessionAttribute(ctx.req, TXC_SOURCE_ATTRIBUTE, {
             source: hasBodsServices && !hasTndsServices ? 'bods' : 'tnds',
             hasBods: hasBodsServices,

--- a/src/utils/sessions.ts
+++ b/src/utils/sessions.ts
@@ -106,6 +106,7 @@ import {
     TXC_SOURCE_ATTRIBUTE,
     REUSE_OPERATOR_GROUP_ATTRIBUTE,
     SAVE_OPERATOR_GROUP_ATTRIBUTE,
+    MULTI_OP_TXC_SOURCE_ATTRIBUTE,
 } from '../constants/attributes';
 
 import * as attributes from '../constants/attributes';
@@ -157,6 +158,7 @@ interface SessionAttributeTypes {
     [USER_ATTRIBUTE]: UserAttribute | WithErrors<UserAttribute>;
     [OPERATOR_ATTRIBUTE]: OperatorAttribute | WithErrors<OperatorAttribute>;
     [TXC_SOURCE_ATTRIBUTE]: TxcSourceAttribute;
+    [MULTI_OP_TXC_SOURCE_ATTRIBUTE]: TxcSourceAttribute;
     [REUSE_OPERATOR_GROUP_ATTRIBUTE]: ErrorInfo[];
     [SAVE_OPERATOR_GROUP_ATTRIBUTE]: ErrorInfo[];
 }

--- a/tests/components/SwitchDataSource.test.tsx
+++ b/tests/components/SwitchDataSource.test.tsx
@@ -8,6 +8,7 @@ describe('SwitchDataSource', () => {
             <SwitchDataSource
                 dataSourceAttribute={{ source: 'bods', hasTnds: true, hasBods: true }}
                 pageUrl="/service"
+                attributeVersion="baseOperator"
                 csrfToken="token"
             />,
         );
@@ -20,6 +21,7 @@ describe('SwitchDataSource', () => {
             <SwitchDataSource
                 dataSourceAttribute={{ source: 'bods', hasTnds: false, hasBods: true }}
                 pageUrl="/service"
+                attributeVersion="baseOperator"
                 csrfToken="token"
             />,
         );

--- a/tests/components/__snapshots__/SwitchDataSource.test.tsx.snap
+++ b/tests/components/__snapshots__/SwitchDataSource.test.tsx.snap
@@ -11,6 +11,11 @@ exports[`SwitchDataSource should render the button disabled 1`] = `
     type="hidden"
     value="/service"
   />
+  <input
+    name="attributeVersion"
+    type="hidden"
+    value="baseOperator"
+  />
   <button
     className="govuk-button govuk-button--secondary"
     disabled={true}
@@ -33,6 +38,11 @@ exports[`SwitchDataSource should render the button not disabled 1`] = `
     name="referer"
     type="hidden"
     value="/service"
+  />
+  <input
+    name="attributeVersion"
+    type="hidden"
+    value="baseOperator"
   />
   <button
     className="govuk-button govuk-button--secondary"

--- a/tests/pages/__snapshots__/multipleOperatorsServiceList.test.tsx.snap
+++ b/tests/pages/__snapshots__/multipleOperatorsServiceList.test.tsx.snap
@@ -57,9 +57,21 @@ exports[`pages multipleOperatorsServiceList should render correctly 1`] = `
         />
         <span
           className="govuk-hint"
-          id="traveline-hint"
+          id="txc-hint"
         >
-          This data is taken from the Traveline National Dataset.
+          This data is taken from the
+           
+          <b>
+            Traveline National Dataset (TNDS)
+          </b>
+          . If the service you are looking for is not listed, contact the BODS help desk for advice
+           
+          <a
+            href="/contact"
+          >
+            here
+          </a>
+          .
         </span>
         <FormElementWrapper
           addFormGroupError={false}
@@ -205,9 +217,21 @@ exports[`pages multipleOperatorsServiceList should render correctly with errors 
         />
         <span
           className="govuk-hint"
-          id="traveline-hint"
+          id="txc-hint"
         >
-          This data is taken from the Traveline National Dataset.
+          This data is taken from the
+           
+          <b>
+            Traveline National Dataset (TNDS)
+          </b>
+          . If the service you are looking for is not listed, contact the BODS help desk for advice
+           
+          <a
+            href="/contact"
+          >
+            here
+          </a>
+          .
         </span>
         <FormElementWrapper
           addFormGroupError={false}

--- a/tests/pages/__snapshots__/multipleOperatorsServiceList.test.tsx.snap
+++ b/tests/pages/__snapshots__/multipleOperatorsServiceList.test.tsx.snap
@@ -5,6 +5,18 @@ exports[`pages multipleOperatorsServiceList should render correctly 1`] = `
   description="Multiple Operators Service List selection page of the Create Fares Data Service"
   title="Multiple Operators Service List - Create Fares Data Service"
 >
+  <SwitchDataSource
+    attributeVersion="multiOperator"
+    csrfToken=""
+    dataSourceAttribute={
+      Object {
+        "hasBods": true,
+        "hasTnds": true,
+        "source": "tnds",
+      }
+    }
+    pageUrl="/multipleOperatorsServiceList"
+  />
   <CsrfForm
     action="/api/multipleOperatorsServiceList"
     csrfToken=""
@@ -134,6 +146,18 @@ exports[`pages multipleOperatorsServiceList should render correctly with errors 
   description="Multiple Operators Service List selection page of the Create Fares Data Service"
   title="Multiple Operators Service List - Create Fares Data Service"
 >
+  <SwitchDataSource
+    attributeVersion="multiOperator"
+    csrfToken=""
+    dataSourceAttribute={
+      Object {
+        "hasBods": false,
+        "hasTnds": true,
+        "source": "tnds",
+      }
+    }
+    pageUrl="/multipleOperatorsServiceList"
+  />
   <CsrfForm
     action="/api/multipleOperatorsServiceList"
     csrfToken=""

--- a/tests/pages/__snapshots__/service.test.tsx.snap
+++ b/tests/pages/__snapshots__/service.test.tsx.snap
@@ -101,6 +101,7 @@ exports[`pages service should render correctly when data source is bods 1`] = `
     />
   </CsrfForm>
   <SwitchDataSource
+    attributeVersion="baseOperator"
     csrfToken=""
     dataSourceAttribute={
       Object {
@@ -215,6 +216,7 @@ exports[`pages service should render correctly when data source is tnds 1`] = `
     />
   </CsrfForm>
   <SwitchDataSource
+    attributeVersion="baseOperator"
     csrfToken=""
     dataSourceAttribute={
       Object {

--- a/tests/pages/__snapshots__/serviceList.test.tsx.snap
+++ b/tests/pages/__snapshots__/serviceList.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`pages serviceList should render an error when the error flag is set to 
         />
         <span
           className="govuk-hint"
-          id="traveline-hint"
+          id="txc-hint"
         >
           This data is taken from the
            
@@ -168,7 +168,7 @@ exports[`pages serviceList should render correctly for multiOperator 1`] = `
         />
         <span
           className="govuk-hint"
-          id="traveline-hint"
+          id="txc-hint"
         >
           This data is taken from the
            
@@ -321,7 +321,7 @@ exports[`pages serviceList should render correctly with bods data source 1`] = `
         />
         <span
           className="govuk-hint"
-          id="traveline-hint"
+          id="txc-hint"
         >
           This data is taken from the
            
@@ -474,7 +474,7 @@ exports[`pages serviceList should render correctly with tnds data source 1`] = `
         />
         <span
           className="govuk-hint"
-          id="traveline-hint"
+          id="txc-hint"
         >
           This data is taken from the
            

--- a/tests/pages/__snapshots__/serviceList.test.tsx.snap
+++ b/tests/pages/__snapshots__/serviceList.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`pages serviceList should render an error when the error flag is set to 
   title="Service List - Create Fares Data Service"
 >
   <SwitchDataSource
+    attributeVersion="baseOperator"
     csrfToken=""
     dataSourceAttribute={
       Object {
@@ -114,6 +115,7 @@ exports[`pages serviceList should render correctly for multiOperator 1`] = `
   title="Service List - Create Fares Data Service"
 >
   <SwitchDataSource
+    attributeVersion="baseOperator"
     csrfToken=""
     dataSourceAttribute={
       Object {
@@ -268,6 +270,7 @@ exports[`pages serviceList should render correctly with bods data source 1`] = `
   title="Service List - Create Fares Data Service"
 >
   <SwitchDataSource
+    attributeVersion="baseOperator"
     csrfToken=""
     dataSourceAttribute={
       Object {
@@ -420,6 +423,7 @@ exports[`pages serviceList should render correctly with tnds data source 1`] = `
   title="Service List - Create Fares Data Service"
 >
   <SwitchDataSource
+    attributeVersion="baseOperator"
     csrfToken=""
     dataSourceAttribute={
       Object {

--- a/tests/pages/api/multipleOperatorsServiceList.test.ts
+++ b/tests/pages/api/multipleOperatorsServiceList.test.ts
@@ -1,8 +1,13 @@
+import {
+    MULTI_OP_TXC_SOURCE_ATTRIBUTE,
+    MULTIPLE_OPERATOR_ATTRIBUTE,
+    MULTIPLE_OPERATORS_SERVICES_ATTRIBUTE,
+} from '../../../src/constants/attributes';
 import { getMockRequestAndResponse } from '../../testData/mockData';
 import multipleOperatorsServiceList, {
     getSelectedServicesAndNocCodeFromRequest,
 } from '../../../src/pages/api/multipleOperatorsServiceList';
-import { MULTIPLE_OPERATOR_ATTRIBUTE, MULTIPLE_OPERATORS_SERVICES_ATTRIBUTE } from '../../../src/constants/attributes';
+
 import * as sessions from '../../../src/utils/sessions';
 
 describe('multipleOperatorsServiceList', () => {
@@ -73,7 +78,7 @@ describe('multipleOperatorsServiceList', () => {
         });
     });
 
-    it('redirects to /howManyProducts if input is valid and the user is entering details for a period ticket, and the user has completed all of their multiple operators services', () => {
+    it('redirects to /howManyProducts if input is valid with no errors, and deletes TXC multiOp session attribute', () => {
         const serviceInfo = {
             'MCTR#237#11-237-_-y08-1#07/04/2020': 'Ashton Under Lyne - Glossop',
             'MCTR#391#NW_01_MCT_391_1#23/04/2019': 'Macclesfield - Bollington - Poynton - Stockport',
@@ -126,6 +131,7 @@ describe('multipleOperatorsServiceList', () => {
             { nocCode: 'N1', services: ['service one', 'service two'] },
             { nocCode: 'N2', services: ['service one', 'service two'] },
         ]);
+        expect(updateSessionAttributeSpy).toHaveBeenCalledWith(req, MULTI_OP_TXC_SOURCE_ATTRIBUTE, undefined);
     });
     describe('getSelectedServicesAndNocCodeFromRequest', () => {
         it('returns an object with services and nocCode from a request', () => {

--- a/tests/pages/searchOperators.test.tsx
+++ b/tests/pages/searchOperators.test.tsx
@@ -120,8 +120,7 @@ describe('pages', () => {
         });
 
         describe('getServerSideProps', () => {
-            const searchOperatorByNocRegionSpy = jest.spyOn(aurora, 'getSearchOperatorsByNocRegion');
-            const searchOperatorBySchemeOpRegionSpy = jest.spyOn(aurora, 'getSearchOperatorsBySchemeOpRegion');
+            const getSearchOperatorsBySearchTextSpy = jest.spyOn(aurora, 'getSearchOperatorsBySearchText');
 
             it('should return base props when the page is first visited by the user', async () => {
                 const mockProps: { props: SearchOperatorProps } = {
@@ -162,7 +161,7 @@ describe('pages', () => {
             });
 
             it('should return base props with errors when the url query string contains an invalid search term', async () => {
-                searchOperatorByNocRegionSpy.mockImplementation().mockResolvedValue([]);
+                getSearchOperatorsBySearchTextSpy.mockImplementation().mockResolvedValue([]);
                 const mockErrors: ErrorInfo[] = [
                     {
                         errorMessage: "No operators found for 'asda'. Try another search term.",
@@ -188,7 +187,7 @@ describe('pages', () => {
             });
 
             it('should return props containing search results when the url query string contains a valid search term and the user is not a scheme operator', async () => {
-                searchOperatorByNocRegionSpy.mockImplementation().mockResolvedValue(mockOperators);
+                getSearchOperatorsBySearchTextSpy.mockImplementation().mockResolvedValue(mockOperators);
                 const mockProps: { props: SearchOperatorProps } = {
                     props: {
                         errors: [],
@@ -204,12 +203,12 @@ describe('pages', () => {
                 });
                 const result = await getServerSideProps(ctx);
 
-                expect(searchOperatorByNocRegionSpy).toHaveBeenCalled();
+                expect(getSearchOperatorsBySearchTextSpy).toHaveBeenCalled();
                 expect(result).toEqual(mockProps);
             });
 
             it('should return props containing search results when the url query string contains a valid search term and the user is a scheme operator', async () => {
-                searchOperatorBySchemeOpRegionSpy.mockImplementation().mockResolvedValue(mockOperators);
+                getSearchOperatorsBySearchTextSpy.mockImplementation().mockResolvedValue(mockOperators);
                 const mockProps: { props: SearchOperatorProps } = {
                     props: {
                         errors: [],
@@ -231,7 +230,7 @@ describe('pages', () => {
                 });
                 const result = await getServerSideProps(ctx);
 
-                expect(searchOperatorBySchemeOpRegionSpy).toHaveBeenCalled();
+                expect(getSearchOperatorsBySearchTextSpy).toHaveBeenCalled();
                 expect(result).toEqual(mockProps);
             });
         });

--- a/tests/pages/serviceList.test.tsx
+++ b/tests/pages/serviceList.test.tsx
@@ -53,6 +53,7 @@ describe('pages', () => {
                 origin: 'Manchester',
                 destination: 'Leeds',
                 serviceCode: 'NW_05_BLAC_123_1',
+                dataSource: 'tnds',
             },
             {
                 lineName: 'X1',
@@ -60,6 +61,7 @@ describe('pages', () => {
                 description: 'Big Blue Bus Service X1',
                 origin: 'Edinburgh',
                 serviceCode: 'NW_05_BLAC_X1_1',
+                dataSource: 'tnds',
             },
             {
                 lineName: 'Infinity Line',
@@ -67,6 +69,7 @@ describe('pages', () => {
                 description: 'This is some kind of bus service',
                 destination: 'London',
                 serviceCode: 'WY_13_IWBT_07_1',
+                dataSource: 'tnds',
             },
         ];
 


### PR DESCRIPTION
# Description

-   To enable the user to switch the TXC data source from TNDS to BODS (and back) for the other operators as part of the multiple operator journey.

# Testing instructions

-   Run site locally and use multi operator multi service journey. Also use the serviceList afterwards / before for the flat fare journey to ensure no regressions across that.

# Type of change

-   [x] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [x] Able to run pr locally
-   [x] Followed acceptance criteria
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have made corresponding changes to the documentation if applicable
-   [x] I have added tests that prove my fix is effective or that my feature works
