### PR TITLE
fix: data source spelling mistake and anybody treated as adult

### DIFF
--- a/src/components/SwitchDataSource.tsx
+++ b/src/components/SwitchDataSource.tsx
@@ -29,7 +29,7 @@ const SwitchDataSource = ({
                     className="govuk-button govuk-button--secondary"
                     disabled={buttonDisabled}
                 >
-                    Change TransXChange datasource to {source === 'bods' ? 'TNDS' : 'BODS'}
+                    Change TransXChange data source to {source === 'bods' ? 'TNDS' : 'BODS'}
                 </button>
             </>
         </CsrfForm>

--- a/src/pages/api/definePassengerType.ts
+++ b/src/pages/api/definePassengerType.ts
@@ -106,7 +106,7 @@ export const passengerTypeDetailsSchema = yup
             .oneOf(['Yes', 'No'])
             .required(radioButtonError),
         proof: yup.string().when('passengerType', {
-            is: passengerTypeValue => passengerTypeValue !== 'adult',
+            is: passengerTypeValue => !(passengerTypeValue === 'adult' || passengerTypeValue === 'anyone'),
             then: yup
                 .string()
                 .oneOf(['Yes', 'No'])

--- a/src/pages/api/definePassengerType.ts
+++ b/src/pages/api/definePassengerType.ts
@@ -101,10 +101,13 @@ export const passengerTypeDetailsSchema = yup
                     then: maxNumberOfPassengersSchema.min(0, numberOfPassengersError).required(numberOfPassengersError),
                 }),
         }),
-        ageRange: yup
-            .string()
-            .oneOf(['Yes', 'No'])
-            .required(radioButtonError),
+        ageRange: yup.string().when('passengerType', {
+            is: passengerTypeValue => passengerTypeValue !== 'anyone',
+            then: yup
+                .string()
+                .oneOf(['Yes', 'No'])
+                .required(radioButtonError),
+        }),
         proof: yup.string().when('passengerType', {
             is: passengerTypeValue => !(passengerTypeValue === 'adult' || passengerTypeValue === 'anyone'),
             then: yup

--- a/src/pages/api/switchDataSource.ts
+++ b/src/pages/api/switchDataSource.ts
@@ -19,7 +19,7 @@ export default (req: NextApiRequestWithSession, res: NextApiResponse): void => {
         updateSessionAttribute(req, attributeToUse, { ...dataSource, source: newDataSource });
         redirectTo(res, referer);
     } catch (error) {
-        const message = 'There was a problem switching the TXC datasource:';
+        const message = 'There was a problem switching the TXC data source:';
         redirectToError(res, message, 'api.switchDataSource', error);
     }
 };

--- a/src/pages/definePassengerType.tsx
+++ b/src/pages/definePassengerType.tsx
@@ -145,7 +145,7 @@ export const getFieldsets = (
 
     fieldsets.push(ageRangeFieldset);
 
-    if (!passengerType || (passengerType && passengerType !== 'adult')) {
+    if (!passengerType || (passengerType && passengerType !== 'adult' && passengerType !== 'anyone')) {
         fieldsets.push(proofRequiredFieldset);
     }
 

--- a/src/pages/definePassengerType.tsx
+++ b/src/pages/definePassengerType.tsx
@@ -143,7 +143,9 @@ export const getFieldsets = (
         radioError: getErrorsByIds(['proof-required'], errors),
     };
 
-    fieldsets.push(ageRangeFieldset);
+    if (passengerType !== 'anyone') {
+        fieldsets.push(ageRangeFieldset);
+    }
 
     if (!passengerType || (passengerType && passengerType !== 'adult' && passengerType !== 'anyone')) {
         fieldsets.push(proofRequiredFieldset);
@@ -159,7 +161,9 @@ export const getNumberOfPassengerTypeFieldset = (
 ): TextInputFieldset => ({
     heading: {
         id: 'number-of-passenger-type-heading',
-        content: `How many ${lowerCase(passengerType)} passengers can be in the group?`,
+        content: `How many ${
+            passengerType === 'anyone' ? `'anyone'` : lowerCase(passengerType)
+        } passengers can be in the group?`,
     },
     inputs: [
         {

--- a/tests/components/__snapshots__/SwitchDataSource.test.tsx.snap
+++ b/tests/components/__snapshots__/SwitchDataSource.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`SwitchDataSource should render the button disabled 1`] = `
     id="change-data-source"
     type="submit"
   >
-    Change TransXChange datasource to 
+    Change TransXChange data source to 
     TNDS
   </button>
 </CsrfForm>
@@ -50,7 +50,7 @@ exports[`SwitchDataSource should render the button not disabled 1`] = `
     id="change-data-source"
     type="submit"
   >
-    Change TransXChange datasource to 
+    Change TransXChange data source to 
     TNDS
   </button>
 </CsrfForm>


### PR DESCRIPTION
# Description

-   Correcting a spelling mistake and making it so group passenger Anybody's cannot select a proof.

# Testing instructions

-   Run locally and test the group Anybody proof selection.

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [ ] Able to run pr locally
-   [ ] Followed acceptance criteria
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
