### PR TITLE
feat: CFD-245 Reusing groups

### DIFF
--- a/cypress_tests/browserstack.json
+++ b/cypress_tests/browserstack.json
@@ -2,27 +2,7 @@
     "browsers": [
         {
             "browser": "chrome",
-            "os": "Windows 10",
-            "versions": ["latest"]
-        },
-        {
-            "browser": "firefox",
-            "os": "Windows 10",
-            "versions": ["latest"]
-        },
-        {
-            "browser": "chrome",
             "os": "OS X Catalina",
-            "versions": ["latest"]
-        },
-        {
-            "browser": "firefox",
-            "os": "OS X Catalina",
-            "versions": ["latest"]
-        },
-        {
-            "browser": "edge",
-            "os": "Windows 10",
             "versions": ["latest"]
         }
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -11125,9 +11125,6 @@
             "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.1.0.tgz",
             "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q=="
         },
-        "node-fetch": {
-            "version": "^2.6.1"
-        },
         "node-html-parser": {
             "version": "1.4.9",
             "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-1.4.9.tgz",

--- a/src/constants/attributes.ts
+++ b/src/constants/attributes.ts
@@ -87,3 +87,5 @@ export const MULTI_OP_TXC_SOURCE_ATTRIBUTE = 'fdbt-multi-op-txc-source';
 export const REUSE_OPERATOR_GROUP_ATTRIBUTE = 'fdbt-reuse-operator-group';
 
 export const SAVE_OPERATOR_GROUP_ATTRIBUTE = 'fdbt-save-operator-group';
+
+export const SAVED_PASSENGER_GROUPS = 'fdbt-saved-passenger-groups';

--- a/src/constants/attributes.ts
+++ b/src/constants/attributes.ts
@@ -88,4 +88,4 @@ export const REUSE_OPERATOR_GROUP_ATTRIBUTE = 'fdbt-reuse-operator-group';
 
 export const SAVE_OPERATOR_GROUP_ATTRIBUTE = 'fdbt-save-operator-group';
 
-export const SAVED_PASSENGER_GROUPS = 'fdbt-saved-passenger-groups';
+export const SAVED_PASSENGER_GROUPS_ATTRIBUTE = 'fdbt-saved-passenger-groups';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -67,9 +67,12 @@ export const solveFeedbackQuestion = 'Did we solve your problem?';
 export const hearAboutUsFeedbackQuestion = 'How did you hear about our service?';
 export const generalFeedbackQuestion = 'Please let us know any feedback or suggestions for improvements you may have';
 
+export const GROUP_PASSENGER_TYPE = 'group';
+export const GROUP_REUSE_PASSENGER_TYPE = 'group-reuse';
 export const PASSENGER_TYPES_WITH_GROUP: PassengerAttributes[] = [
-    { passengerTypeDisplay: 'Group (more than one passenger)', passengerTypeValue: 'group' },
     ...PASSENGER_TYPES_LIST,
+    { passengerTypeDisplay: 'Group - define new group', passengerTypeValue: GROUP_PASSENGER_TYPE },
+    { passengerTypeDisplay: 'Group - reuse saved group', passengerTypeValue: GROUP_REUSE_PASSENGER_TYPE },
 ];
 
 export const INTERNAL_NOC = 'IWBusCo';

--- a/src/data/auroradb.ts
+++ b/src/data/auroradb.ts
@@ -693,7 +693,11 @@ export const getPassengerTypeByNameAndNocCode = async (
     }
 };
 
-type SavedPassengerType = { group: GroupPassengerType[]; single: PassengerType[] };
+interface SavedPassengerType {
+    group: GroupPassengerType[];
+    single: PassengerType[];
+}
+
 export const getPassengerTypesByNocCode = async <T extends keyof SavedPassengerType>(
     nocCode: string,
     type: T,

--- a/src/data/auroradb.ts
+++ b/src/data/auroradb.ts
@@ -6,6 +6,7 @@ import { INTERNAL_NOC } from '../constants';
 import {
     CompanionInfo,
     FullTimeRestriction,
+    GroupPassengerType,
     Operator,
     OperatorGroup,
     PassengerType,
@@ -687,6 +688,42 @@ export const getPassengerTypeByNameAndNocCode = async (
         }
 
         return queryResults[0] ? JSON.parse(queryResults[0].contents) : undefined;
+    } catch (error) {
+        throw new Error(`Could not retrieve passenger type by nocCode from AuroraDB: ${error}`);
+    }
+};
+
+type SavedPassengerType = { group: GroupPassengerType[]; single: PassengerType[] };
+export const getPassengerTypesByNocCode = async <T extends keyof SavedPassengerType>(
+    nocCode: string,
+    type: T,
+): Promise<SavedPassengerType[T]> => {
+    logger.info('', {
+        context: 'data.auroradb',
+        message: 'retrieving passenger types for given noc',
+        nocCode,
+    });
+
+    try {
+        const queryInput = `
+            SELECT contents
+            FROM passengerType
+            WHERE nocCode = ?
+            AND isGroup = ?
+        `;
+
+        const queryResults = await executeQuery<{ contents: string; name: string }[]>(queryInput, [
+            nocCode,
+            type === 'group',
+        ]);
+        return queryResults.map(row =>
+            type === 'group'
+                ? {
+                      companions: JSON.parse(row.contents),
+                      name: row.name,
+                  }
+                : JSON.parse(row.contents),
+        );
     } catch (error) {
         throw new Error(`Could not retrieve passenger type by nocCode from AuroraDB: ${error}`);
     }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -104,10 +104,6 @@ export interface UserDataUploadsProps {
     csrfToken: string;
 }
 
-export interface GroupDefinitionWithErrors extends GroupDefinition {
-    errors: ErrorInfo[];
-}
-
 export interface NumberOfStagesAttributeWithError {
     errors: ErrorInfo[];
 }
@@ -364,14 +360,6 @@ export interface FlatFareTicket extends BaseTicket {
     termTime: boolean;
 }
 
-export interface BaseGroupTicket {
-    nocCode: string;
-    type: string;
-    groupDefinition: GroupDefinition;
-    email: string;
-    uuid: string;
-}
-
 export interface SchemeOperatorTicket {
     schemeOperatorName: string;
     schemeOperatorRegionCode: string;
@@ -431,8 +419,8 @@ export interface CompanionInfo {
     proofDocuments?: string[];
 }
 
-export interface GroupDefinition {
-    maxGroupSize: number;
+export interface GroupPassengerType {
+    name: string;
     companions: CompanionInfo[];
 }
 

--- a/src/pages/api/apiUtils/index.ts
+++ b/src/pages/api/apiUtils/index.ts
@@ -65,7 +65,7 @@ export const redirectToError = (
     context: string,
     error: Error,
 ): void => {
-    logger.error(error.toString(), { context, message });
+    logger.error(error.toString(), { context, message, error: error.stack });
     redirectTo(res, '/error');
 };
 

--- a/src/pages/api/definePassengerType.ts
+++ b/src/pages/api/definePassengerType.ts
@@ -8,7 +8,7 @@ import {
     GROUP_PASSENGER_TYPES_ATTRIBUTE,
     GROUP_SIZE_ATTRIBUTE,
     PASSENGER_TYPE_ATTRIBUTE,
-    SAVED_PASSENGER_GROUPS,
+    SAVED_PASSENGER_GROUPS_ATTRIBUTE,
 } from '../../constants/attributes';
 import { getPassengerTypeByNameAndNocCode, insertPassengerType, upsertPassengerType } from '../../data/auroradb';
 import {
@@ -320,9 +320,9 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                         });
                     } else {
                         await insertPassengerType(noc, companions, trimmedName, true);
-                        const savedGroups = getSessionAttribute(req, SAVED_PASSENGER_GROUPS) ?? [];
+                        const savedGroups = getSessionAttribute(req, SAVED_PASSENGER_GROUPS_ATTRIBUTE) ?? [];
                         savedGroups.push({ companions, name: trimmedName });
-                        updateSessionAttribute(req, SAVED_PASSENGER_GROUPS, savedGroups);
+                        updateSessionAttribute(req, SAVED_PASSENGER_GROUPS_ATTRIBUTE, savedGroups);
                     }
                 }
 

--- a/src/pages/api/definePassengerType.ts
+++ b/src/pages/api/definePassengerType.ts
@@ -8,6 +8,7 @@ import {
     GROUP_PASSENGER_TYPES_ATTRIBUTE,
     GROUP_SIZE_ATTRIBUTE,
     PASSENGER_TYPE_ATTRIBUTE,
+    SAVED_PASSENGER_GROUPS,
 } from '../../constants/attributes';
 import { getPassengerTypeByNameAndNocCode, insertPassengerType, upsertPassengerType } from '../../data/auroradb';
 import {
@@ -319,6 +320,9 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                         });
                     } else {
                         await insertPassengerType(noc, companions, trimmedName, true);
+                        const savedGroups = getSessionAttribute(req, SAVED_PASSENGER_GROUPS) ?? [];
+                        savedGroups.push({ companions, name: trimmedName });
+                        updateSessionAttribute(req, SAVED_PASSENGER_GROUPS, savedGroups);
                     }
                 }
 

--- a/src/pages/api/passengerType.ts
+++ b/src/pages/api/passengerType.ts
@@ -2,7 +2,7 @@ import { NextApiResponse } from 'next';
 import {
     GROUP_PASSENGER_INFO_ATTRIBUTE,
     PASSENGER_TYPE_ATTRIBUTE,
-    SAVED_PASSENGER_GROUPS,
+    SAVED_PASSENGER_GROUPS_ATTRIBUTE,
 } from '../../constants/attributes';
 import { GROUP_PASSENGER_TYPE, GROUP_REUSE_PASSENGER_TYPE, PASSENGER_TYPES_WITH_GROUP } from '../../constants/index';
 import { getPassengerTypeByNameAndNocCode } from '../../data/auroradb';
@@ -19,7 +19,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
             const { passengerType } = req.body;
 
             if (passengerType === GROUP_REUSE_PASSENGER_TYPE) {
-                const savedGroups = getSessionAttribute(req, SAVED_PASSENGER_GROUPS);
+                const savedGroups = getSessionAttribute(req, SAVED_PASSENGER_GROUPS_ATTRIBUTE);
                 if (!savedGroups) {
                     throw new Error("Didn't have any saved groups but they should have been loaded on render");
                 }
@@ -27,7 +27,9 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                 const { reuseGroup } = req.body;
                 const reusedGroup = savedGroups.find(group => group.name === reuseGroup);
                 if (!reusedGroup || !reuseGroup) {
-                    const errors = [{ errorMessage: 'Please select a group to reuse', id: 'group-reuse' }];
+                    const errors = [
+                        { errorMessage: 'Select a group to reuse', id: `passenger-type-${GROUP_PASSENGER_TYPE}` },
+                    ];
                     updateSessionAttribute(req, PASSENGER_TYPE_ATTRIBUTE, {
                         errors,
                     });

--- a/src/pages/api/passengerType.ts
+++ b/src/pages/api/passengerType.ts
@@ -1,9 +1,13 @@
 import { NextApiResponse } from 'next';
-import { PASSENGER_TYPE_ATTRIBUTE } from '../../constants/attributes';
-import { PASSENGER_TYPES_WITH_GROUP } from '../../constants/index';
+import {
+    GROUP_PASSENGER_INFO_ATTRIBUTE,
+    PASSENGER_TYPE_ATTRIBUTE,
+    SAVED_PASSENGER_GROUPS,
+} from '../../constants/attributes';
+import { GROUP_PASSENGER_TYPE, GROUP_REUSE_PASSENGER_TYPE, PASSENGER_TYPES_WITH_GROUP } from '../../constants/index';
 import { getPassengerTypeByNameAndNocCode } from '../../data/auroradb';
 import { ErrorInfo, NextApiRequestWithSession } from '../../interfaces';
-import { updateSessionAttribute } from '../../utils/sessions';
+import { getSessionAttribute, updateSessionAttribute } from '../../utils/sessions';
 import { getAndValidateNoc, redirectTo, redirectToError } from './apiUtils/index';
 import { getPassengerTypeRedirectLocation } from './definePassengerType';
 
@@ -14,6 +18,36 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
         if (req.body.passengerType && passengerTypeValues.includes(req.body.passengerType)) {
             const { passengerType } = req.body;
 
+            if (passengerType === GROUP_REUSE_PASSENGER_TYPE) {
+                const savedGroups = getSessionAttribute(req, SAVED_PASSENGER_GROUPS);
+                if (!savedGroups) {
+                    throw new Error("Didn't have any saved groups but they should have been loaded on render");
+                }
+
+                const { reuseGroup } = req.body;
+                const reusedGroup = savedGroups.find(group => group.name === reuseGroup);
+                if (!reusedGroup || !reuseGroup) {
+                    const errors = [{ errorMessage: 'Please select a group to reuse', id: 'group-reuse' }];
+                    updateSessionAttribute(req, PASSENGER_TYPE_ATTRIBUTE, {
+                        errors,
+                    });
+                    redirectTo(res, '/passengerType');
+                    return;
+                }
+
+                updateSessionAttribute(req, PASSENGER_TYPE_ATTRIBUTE, { passengerType: GROUP_PASSENGER_TYPE });
+                updateSessionAttribute(req, GROUP_PASSENGER_INFO_ATTRIBUTE, reusedGroup.companions);
+                redirectTo(res, '/defineTimeRestrictions');
+                return;
+            }
+
+            updateSessionAttribute(req, PASSENGER_TYPE_ATTRIBUTE, { passengerType });
+
+            if (passengerType === GROUP_PASSENGER_TYPE) {
+                redirectTo(res, '/groupSize');
+                return;
+            }
+
             const noc = getAndValidateNoc(req, res);
             const storedPassengerType = await getPassengerTypeByNameAndNocCode(noc, passengerType, false);
             if (storedPassengerType) {
@@ -22,15 +56,8 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
                 return;
             }
 
-            updateSessionAttribute(req, PASSENGER_TYPE_ATTRIBUTE, { passengerType });
-
             if (passengerType === 'anyone') {
                 redirectTo(res, '/defineTimeRestrictions');
-                return;
-            }
-
-            if (passengerType === 'group') {
-                redirectTo(res, '/groupSize');
                 return;
             }
 
@@ -40,7 +67,7 @@ export default async (req: NextApiRequestWithSession, res: NextApiResponse): Pro
 
         const errors: ErrorInfo[] = [
             {
-                id: `passenger-type-${PASSENGER_TYPES_WITH_GROUP[0].passengerTypeValue}`,
+                id: `passenger-type-${GROUP_PASSENGER_TYPE}`,
                 errorMessage: 'Choose a passenger type from the options',
             },
         ];

--- a/src/pages/passengerType.tsx
+++ b/src/pages/passengerType.tsx
@@ -1,15 +1,22 @@
 import React, { ReactElement } from 'react';
-import TwoThirdsLayout from '../layout/Layout';
-import { PASSENGER_TYPES_WITH_GROUP } from '../constants';
-import { PASSENGER_TYPE_ATTRIBUTE } from '../constants/attributes';
-import { ErrorInfo, NextPageContextWithSession } from '../interfaces';
+import CsrfForm from '../components/CsrfForm';
 import ErrorSummary from '../components/ErrorSummary';
 import FormElementWrapper from '../components/FormElementWrapper';
-import CsrfForm from '../components/CsrfForm';
 import InsetText from '../components/InsetText';
-import { getSessionAttribute } from '../utils/sessions';
+import RadioConditionalInput from '../components/RadioConditionalInput';
+import { GROUP_PASSENGER_TYPE, GROUP_REUSE_PASSENGER_TYPE, PASSENGER_TYPES_WITH_GROUP } from '../constants';
+import { PASSENGER_TYPE_ATTRIBUTE, SAVED_PASSENGER_GROUPS } from '../constants/attributes';
+import { getPassengerTypesByNocCode } from '../data/auroradb';
+import {
+    ErrorInfo,
+    GroupPassengerType,
+    NextPageContextWithSession,
+    RadioConditionalInputFieldset,
+} from '../interfaces';
 import { isPassengerTypeAttributeWithErrors } from '../interfaces/typeGuards';
-import { getCsrfToken } from '../utils';
+import TwoThirdsLayout from '../layout/Layout';
+import { getAndValidateNoc, getCsrfToken } from '../utils';
+import { getSessionAttribute, updateSessionAttribute } from '../utils/sessions';
 
 const title = 'Passenger Type - Create Fares Data Service';
 const description = 'Passenger Type selection page of the Create Fares Data Service';
@@ -19,9 +26,47 @@ const insetText = 'More passenger types will become available soon';
 interface PassengerTypeProps {
     errors?: ErrorInfo[];
     csrfToken: string;
+    savedGroups: GroupPassengerType[];
 }
 
-const PassengerType = ({ errors = [], csrfToken }: PassengerTypeProps): ReactElement => (
+export const getFieldsets = (
+    errors: ErrorInfo[],
+    savedGroups: GroupPassengerType[],
+): RadioConditionalInputFieldset => ({
+    radioError: errors,
+    heading: {
+        id: 'passenger-types-fieldset',
+        content: '',
+        hidden: true,
+    },
+    radios: PASSENGER_TYPES_WITH_GROUP.map(({ passengerTypeValue: value, passengerTypeDisplay: display }) => ({
+        id: `passenger-type-${value}`,
+        key: value,
+        name: 'passengerType',
+        value,
+        dataAriaControls: 'passenger-type-required-conditional',
+        label: display,
+        type: 'radio',
+        inputType: 'dropdown',
+        ...(value !== GROUP_REUSE_PASSENGER_TYPE
+            ? {}
+            : {
+                  inputHint: {
+                      id: 'choose-time-restriction-hint',
+                      content: 'Select a saved group to use',
+                  },
+                  selectIdentifier: 'reuseGroup',
+                  inputErrors: errors,
+                  inputs: savedGroups.map((group, index) => ({
+                      id: `group-passenger-type-${index}`,
+                      name: group.name,
+                      label: group.name,
+                  })),
+              }),
+    })),
+});
+
+const PassengerType = ({ errors = [], csrfToken, savedGroups }: PassengerTypeProps): ReactElement => (
     <TwoThirdsLayout title={title} description={description} errors={errors}>
         <CsrfForm action="/api/passengerType" method="post" csrfToken={csrfToken}>
             <>
@@ -38,29 +83,14 @@ const PassengerType = ({ errors = [], csrfToken }: PassengerTypeProps): ReactEle
                         </span>
                         <FormElementWrapper
                             errors={errors}
-                            errorId={`passenger-type-${PASSENGER_TYPES_WITH_GROUP[0].passengerTypeValue}`}
+                            errorId={`passenger-type-${GROUP_PASSENGER_TYPE}`}
                             errorClass="govuk-radios--error"
                         >
                             <div className="govuk-radios">
-                                {PASSENGER_TYPES_WITH_GROUP.map(
-                                    (passenger): ReactElement => (
-                                        <div className="govuk-radios__item" key={passenger.passengerTypeValue}>
-                                            <input
-                                                className="govuk-radios__input"
-                                                id={`passenger-type-${passenger.passengerTypeValue}`}
-                                                name="passengerType"
-                                                type="radio"
-                                                value={passenger.passengerTypeValue}
-                                            />
-                                            <label
-                                                className="govuk-label govuk-radios__label"
-                                                htmlFor={`passenger-type-${passenger.passengerTypeValue}`}
-                                            >
-                                                {`${passenger.passengerTypeDisplay}`}
-                                            </label>
-                                        </div>
-                                    ),
-                                )}
+                                <RadioConditionalInput
+                                    key="passenger-types-fieldset"
+                                    fieldset={getFieldsets(errors, savedGroups)}
+                                />
                             </div>
                         </FormElementWrapper>
                     </fieldset>
@@ -72,16 +102,23 @@ const PassengerType = ({ errors = [], csrfToken }: PassengerTypeProps): ReactEle
     </TwoThirdsLayout>
 );
 
-export const getServerSideProps = (ctx: NextPageContextWithSession): { props: PassengerTypeProps } => {
+export const getServerSideProps = async (ctx: NextPageContextWithSession): Promise<{ props: PassengerTypeProps }> => {
     const csrfToken = getCsrfToken(ctx);
     const passengerTypeAttribute = getSessionAttribute(ctx.req, PASSENGER_TYPE_ATTRIBUTE);
+
+    let savedGroups = getSessionAttribute(ctx.req, SAVED_PASSENGER_GROUPS);
+    if (savedGroups === undefined) {
+        const noc = getAndValidateNoc(ctx);
+        savedGroups = await getPassengerTypesByNocCode(noc, 'group');
+        updateSessionAttribute(ctx.req, SAVED_PASSENGER_GROUPS, savedGroups);
+    }
 
     const errors: ErrorInfo[] =
         passengerTypeAttribute && isPassengerTypeAttributeWithErrors(passengerTypeAttribute)
             ? passengerTypeAttribute.errors
             : [];
 
-    return { props: { errors, csrfToken } };
+    return { props: { errors, csrfToken, savedGroups } };
 };
 
 export default PassengerType;

--- a/src/utils/sessions.ts
+++ b/src/utils/sessions.ts
@@ -6,8 +6,6 @@ import {
     ProductInfo,
     ProductData,
     ProductInfoWithErrors,
-    GroupDefinition,
-    GroupDefinitionWithErrors,
     TimeRestriction,
     CompanionInfo,
     DurationValidInfo,
@@ -61,6 +59,7 @@ import {
     OperatorAttribute,
     ForgotPasswordAttribute,
     TxcSourceAttribute,
+    GroupPassengerType,
 } from '../interfaces';
 
 import {
@@ -75,7 +74,6 @@ import {
     PRODUCT_DETAILS_ATTRIBUTE,
     GROUP_SIZE_ATTRIBUTE,
     GROUP_PASSENGER_TYPES_ATTRIBUTE,
-    GROUP_DEFINITION_ATTRIBUTE,
     GROUP_PASSENGER_INFO_ATTRIBUTE,
     TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE,
     INPUT_METHOD_ATTRIBUTE,
@@ -108,6 +106,7 @@ import {
     SAVE_OPERATOR_GROUP_ATTRIBUTE,
     MULTI_OP_TXC_SOURCE_ATTRIBUTE,
     CARNET_FARE_TYPE_ATTRIBUTE,
+    SAVED_PASSENGER_GROUPS,
 } from '../constants/attributes';
 
 import * as attributes from '../constants/attributes';
@@ -133,7 +132,6 @@ interface SessionAttributeTypes {
     [GROUP_SIZE_ATTRIBUTE]: GroupTicketAttribute | GroupTicketAttributeWithErrors;
     [GROUP_PASSENGER_TYPES_ATTRIBUTE]: GroupPassengerTypesCollection | GroupPassengerTypesCollectionWithErrors;
     [GROUP_PASSENGER_INFO_ATTRIBUTE]: CompanionInfo[];
-    [GROUP_DEFINITION_ATTRIBUTE]: GroupDefinition | GroupDefinitionWithErrors;
     [TIME_RESTRICTIONS_DEFINITION_ATTRIBUTE]: TimeRestriction | TimeRestrictionsDefinitionWithErrors;
     [FARE_ZONE_ATTRIBUTE]: string | FareZoneWithErrors;
     [CSV_UPLOAD_ATTRIBUTE]: CsvUploadAttributeWithErrors;
@@ -163,6 +161,7 @@ interface SessionAttributeTypes {
     [REUSE_OPERATOR_GROUP_ATTRIBUTE]: ErrorInfo[];
     [SAVE_OPERATOR_GROUP_ATTRIBUTE]: ErrorInfo[];
     [CARNET_FARE_TYPE_ATTRIBUTE]: boolean;
+    [SAVED_PASSENGER_GROUPS]: GroupPassengerType[];
 }
 
 export type SessionAttribute<T extends string> = T extends keyof SessionAttributeTypes

--- a/src/utils/sessions.ts
+++ b/src/utils/sessions.ts
@@ -106,7 +106,7 @@ import {
     SAVE_OPERATOR_GROUP_ATTRIBUTE,
     MULTI_OP_TXC_SOURCE_ATTRIBUTE,
     CARNET_FARE_TYPE_ATTRIBUTE,
-    SAVED_PASSENGER_GROUPS,
+    SAVED_PASSENGER_GROUPS_ATTRIBUTE,
 } from '../constants/attributes';
 
 import * as attributes from '../constants/attributes';
@@ -161,7 +161,7 @@ interface SessionAttributeTypes {
     [REUSE_OPERATOR_GROUP_ATTRIBUTE]: ErrorInfo[];
     [SAVE_OPERATOR_GROUP_ATTRIBUTE]: ErrorInfo[];
     [CARNET_FARE_TYPE_ATTRIBUTE]: boolean;
-    [SAVED_PASSENGER_GROUPS]: GroupPassengerType[];
+    [SAVED_PASSENGER_GROUPS_ATTRIBUTE]: GroupPassengerType[];
 }
 
 export type SessionAttribute<T extends string> = T extends keyof SessionAttributeTypes

--- a/tests/pages/__snapshots__/passengerType.test.tsx.snap
+++ b/tests/pages/__snapshots__/passengerType.test.tsx.snap
@@ -45,150 +45,118 @@ exports[`pages operator should render correctly 1`] = `
           <div
             className="govuk-radios"
           >
-            <div
-              className="govuk-radios__item"
-              key="group"
-            >
-              <input
-                className="govuk-radios__input"
-                id="passenger-type-group"
-                name="passengerType"
-                type="radio"
-                value="group"
-              />
-              <label
-                className="govuk-label govuk-radios__label"
-                htmlFor="passenger-type-group"
-              >
-                Group (more than one passenger)
-              </label>
-            </div>
-            <div
-              className="govuk-radios__item"
-              key="adult"
-            >
-              <input
-                className="govuk-radios__input"
-                id="passenger-type-adult"
-                name="passengerType"
-                type="radio"
-                value="adult"
-              />
-              <label
-                className="govuk-label govuk-radios__label"
-                htmlFor="passenger-type-adult"
-              >
-                Adult
-              </label>
-            </div>
-            <div
-              className="govuk-radios__item"
-              key="child"
-            >
-              <input
-                className="govuk-radios__input"
-                id="passenger-type-child"
-                name="passengerType"
-                type="radio"
-                value="child"
-              />
-              <label
-                className="govuk-label govuk-radios__label"
-                htmlFor="passenger-type-child"
-              >
-                Child
-              </label>
-            </div>
-            <div
-              className="govuk-radios__item"
-              key="infant"
-            >
-              <input
-                className="govuk-radios__input"
-                id="passenger-type-infant"
-                name="passengerType"
-                type="radio"
-                value="infant"
-              />
-              <label
-                className="govuk-label govuk-radios__label"
-                htmlFor="passenger-type-infant"
-              >
-                Infant
-              </label>
-            </div>
-            <div
-              className="govuk-radios__item"
-              key="senior"
-            >
-              <input
-                className="govuk-radios__input"
-                id="passenger-type-senior"
-                name="passengerType"
-                type="radio"
-                value="senior"
-              />
-              <label
-                className="govuk-label govuk-radios__label"
-                htmlFor="passenger-type-senior"
-              >
-                Senior
-              </label>
-            </div>
-            <div
-              className="govuk-radios__item"
-              key="student"
-            >
-              <input
-                className="govuk-radios__input"
-                id="passenger-type-student"
-                name="passengerType"
-                type="radio"
-                value="student"
-              />
-              <label
-                className="govuk-label govuk-radios__label"
-                htmlFor="passenger-type-student"
-              >
-                Student
-              </label>
-            </div>
-            <div
-              className="govuk-radios__item"
-              key="youngPerson"
-            >
-              <input
-                className="govuk-radios__input"
-                id="passenger-type-youngPerson"
-                name="passengerType"
-                type="radio"
-                value="youngPerson"
-              />
-              <label
-                className="govuk-label govuk-radios__label"
-                htmlFor="passenger-type-youngPerson"
-              >
-                Young Person
-              </label>
-            </div>
-            <div
-              className="govuk-radios__item"
-              key="anyone"
-            >
-              <input
-                className="govuk-radios__input"
-                id="passenger-type-anyone"
-                name="passengerType"
-                type="radio"
-                value="anyone"
-              />
-              <label
-                className="govuk-label govuk-radios__label"
-                htmlFor="passenger-type-anyone"
-              >
-                Anyone
-              </label>
-            </div>
+            <RadioConditionalInput
+              fieldset={
+                Object {
+                  "heading": Object {
+                    "content": "",
+                    "hidden": true,
+                    "id": "passenger-types-fieldset",
+                  },
+                  "radioError": Array [],
+                  "radios": Array [
+                    Object {
+                      "dataAriaControls": "passenger-type-required-conditional",
+                      "id": "passenger-type-adult",
+                      "inputType": "dropdown",
+                      "key": "adult",
+                      "label": "Adult",
+                      "name": "passengerType",
+                      "type": "radio",
+                      "value": "adult",
+                    },
+                    Object {
+                      "dataAriaControls": "passenger-type-required-conditional",
+                      "id": "passenger-type-child",
+                      "inputType": "dropdown",
+                      "key": "child",
+                      "label": "Child",
+                      "name": "passengerType",
+                      "type": "radio",
+                      "value": "child",
+                    },
+                    Object {
+                      "dataAriaControls": "passenger-type-required-conditional",
+                      "id": "passenger-type-infant",
+                      "inputType": "dropdown",
+                      "key": "infant",
+                      "label": "Infant",
+                      "name": "passengerType",
+                      "type": "radio",
+                      "value": "infant",
+                    },
+                    Object {
+                      "dataAriaControls": "passenger-type-required-conditional",
+                      "id": "passenger-type-senior",
+                      "inputType": "dropdown",
+                      "key": "senior",
+                      "label": "Senior",
+                      "name": "passengerType",
+                      "type": "radio",
+                      "value": "senior",
+                    },
+                    Object {
+                      "dataAriaControls": "passenger-type-required-conditional",
+                      "id": "passenger-type-student",
+                      "inputType": "dropdown",
+                      "key": "student",
+                      "label": "Student",
+                      "name": "passengerType",
+                      "type": "radio",
+                      "value": "student",
+                    },
+                    Object {
+                      "dataAriaControls": "passenger-type-required-conditional",
+                      "id": "passenger-type-youngPerson",
+                      "inputType": "dropdown",
+                      "key": "youngPerson",
+                      "label": "Young Person",
+                      "name": "passengerType",
+                      "type": "radio",
+                      "value": "youngPerson",
+                    },
+                    Object {
+                      "dataAriaControls": "passenger-type-required-conditional",
+                      "id": "passenger-type-anyone",
+                      "inputType": "dropdown",
+                      "key": "anyone",
+                      "label": "Anyone",
+                      "name": "passengerType",
+                      "type": "radio",
+                      "value": "anyone",
+                    },
+                    Object {
+                      "dataAriaControls": "passenger-type-required-conditional",
+                      "id": "passenger-type-group",
+                      "inputType": "dropdown",
+                      "key": "group",
+                      "label": "Group - define new group",
+                      "name": "passengerType",
+                      "type": "radio",
+                      "value": "group",
+                    },
+                    Object {
+                      "dataAriaControls": "passenger-type-required-conditional",
+                      "id": "passenger-type-group-reuse",
+                      "inputErrors": Array [],
+                      "inputHint": Object {
+                        "content": "Select a saved group to use",
+                        "id": "choose-time-restriction-hint",
+                      },
+                      "inputType": "dropdown",
+                      "inputs": Array [],
+                      "key": "group-reuse",
+                      "label": "Group - reuse saved group",
+                      "name": "passengerType",
+                      "selectIdentifier": "reuseGroup",
+                      "type": "radio",
+                      "value": "group-reuse",
+                    },
+                  ],
+                }
+              }
+              key="passenger-types-fieldset"
+            />
           </div>
         </FormElementWrapper>
       </fieldset>

--- a/tests/pages/__snapshots__/passengerType.test.tsx.snap
+++ b/tests/pages/__snapshots__/passengerType.test.tsx.snap
@@ -135,23 +135,6 @@ exports[`pages operator should render correctly 1`] = `
                       "type": "radio",
                       "value": "group",
                     },
-                    Object {
-                      "dataAriaControls": "passenger-type-required-conditional",
-                      "id": "passenger-type-group-reuse",
-                      "inputErrors": Array [],
-                      "inputHint": Object {
-                        "content": "Select a saved group to use",
-                        "id": "choose-time-restriction-hint",
-                      },
-                      "inputType": "dropdown",
-                      "inputs": Array [],
-                      "key": "group-reuse",
-                      "label": "Group - reuse saved group",
-                      "name": "passengerType",
-                      "selectIdentifier": "reuseGroup",
-                      "type": "radio",
-                      "value": "group-reuse",
-                    },
                   ],
                 }
               }

--- a/tests/pages/api/definePassengerType.test.ts
+++ b/tests/pages/api/definePassengerType.test.ts
@@ -5,7 +5,7 @@ import {
     GROUP_PASSENGER_TYPES_ATTRIBUTE,
     GROUP_SIZE_ATTRIBUTE,
     PASSENGER_TYPE_ATTRIBUTE,
-    SAVED_PASSENGER_GROUPS,
+    SAVED_PASSENGER_GROUPS_ATTRIBUTE,
 } from '../../../src/constants/attributes';
 import * as auroradb from '../../../src/data/auroradb';
 import { CompanionInfo, GroupPassengerTypesCollection, GroupTicketAttribute } from '../../../src/interfaces';
@@ -549,7 +549,7 @@ describe('definePassengerType', () => {
         expect(getPassengerTypeSpy).toBeCalledWith('TEST', 'A Name', true);
         expect(insertPassengerTypeSpy).toBeCalledWith('TEST', savedGroupInfo, 'A Name', true);
         expect(updateSessionAttributeSpy).toBeCalledWith(req, GROUP_PASSENGER_INFO_ATTRIBUTE, savedGroupInfo);
-        expect(updateSessionAttributeSpy).toBeCalledWith(req, SAVED_PASSENGER_GROUPS, [
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, SAVED_PASSENGER_GROUPS_ATTRIBUTE, [
             { companions: savedGroupInfo, name: 'A Name' },
         ]);
     });

--- a/tests/pages/api/definePassengerType.test.ts
+++ b/tests/pages/api/definePassengerType.test.ts
@@ -5,6 +5,7 @@ import {
     GROUP_PASSENGER_TYPES_ATTRIBUTE,
     GROUP_SIZE_ATTRIBUTE,
     PASSENGER_TYPE_ATTRIBUTE,
+    SAVED_PASSENGER_GROUPS,
 } from '../../../src/constants/attributes';
 import * as auroradb from '../../../src/data/auroradb';
 import { CompanionInfo, GroupPassengerTypesCollection, GroupTicketAttribute } from '../../../src/interfaces';
@@ -16,14 +17,13 @@ import definePassengerType, {
 import * as sessions from '../../../src/utils/sessions';
 import { getMockRequestAndResponse } from '../../testData/mockData';
 
+jest.mock('../../../src/data/auroradb');
+
 describe('definePassengerType', () => {
     const writeHeadMock = jest.fn();
     const updateSessionAttributeSpy = jest.spyOn(sessions, 'updateSessionAttribute');
 
     afterEach(jest.resetAllMocks);
-
-    beforeEach(() => jest.spyOn(auroradb, 'upsertPassengerType'));
-    beforeEach(() => jest.spyOn(auroradb, 'getPassengerTypeByNameAndNocCode'));
 
     describe('passengerTypeDetailsSchema', () => {
         it.each([
@@ -549,6 +549,9 @@ describe('definePassengerType', () => {
         expect(getPassengerTypeSpy).toBeCalledWith('TEST', 'A Name', true);
         expect(insertPassengerTypeSpy).toBeCalledWith('TEST', savedGroupInfo, 'A Name', true);
         expect(updateSessionAttributeSpy).toBeCalledWith(req, GROUP_PASSENGER_INFO_ATTRIBUTE, savedGroupInfo);
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, SAVED_PASSENGER_GROUPS, [
+            { companions: savedGroupInfo, name: 'A Name' },
+        ]);
     });
 
     it('should show an error for groups if a name is provided that already exists', async () => {

--- a/tests/pages/api/passengerType.test.ts
+++ b/tests/pages/api/passengerType.test.ts
@@ -1,7 +1,13 @@
-import passengerType from '../../../src/pages/api/passengerType';
+import { GROUP_PASSENGER_TYPE, GROUP_REUSE_PASSENGER_TYPE } from '../../../src/constants';
+import {
+    GROUP_PASSENGER_INFO_ATTRIBUTE,
+    PASSENGER_TYPE_ATTRIBUTE,
+    SAVED_PASSENGER_GROUPS,
+} from '../../../src/constants/attributes';
 import * as aurora from '../../../src/data/auroradb';
+import passengerType from '../../../src/pages/api/passengerType';
+import * as sessions from '../../../src/utils/sessions';
 import { getMockRequestAndResponse } from '../../testData/mockData';
-import { PASSENGER_TYPE_ATTRIBUTE } from '../../../src/constants/attributes';
 
 describe('passengerType', () => {
     const writeHeadMock = jest.fn();
@@ -72,6 +78,61 @@ describe('passengerType', () => {
 
         expect(writeHeadMock).toBeCalledWith(302, {
             Location: '/groupSize',
+        });
+    });
+
+    it('should select the appropriate group config when user is reusing a group', async () => {
+        const updateSessionAttributeSpy = jest.spyOn(sessions, 'updateSessionAttribute');
+
+        const { req, res } = getMockRequestAndResponse({
+            cookieValues: {},
+            body: { passengerType: GROUP_REUSE_PASSENGER_TYPE, reuseGroup: 'Hi Name' },
+            uuid: {},
+            mockWriteHeadFn: writeHeadMock,
+            session: {
+                [PASSENGER_TYPE_ATTRIBUTE]: { passengerType: 'group' },
+                [SAVED_PASSENGER_GROUPS]: [
+                    { name: 'Hello Name', companions: [{ passengerType: 'child' }] },
+                    { name: 'Hi Name', companions: [{ passengerType: 'adult' }] },
+                ],
+            },
+        });
+
+        await passengerType(req, res);
+
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, PASSENGER_TYPE_ATTRIBUTE, {
+            passengerType: GROUP_PASSENGER_TYPE,
+        });
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, GROUP_PASSENGER_INFO_ATTRIBUTE, [
+            { passengerType: 'adult' },
+        ]);
+
+        expect(writeHeadMock).toBeCalledWith(302, {
+            Location: '/defineTimeRestrictions',
+        });
+    });
+
+    it('should return an error when reusing a group with no group selected', async () => {
+        const updateSessionAttributeSpy = jest.spyOn(sessions, 'updateSessionAttribute');
+
+        const { req, res } = getMockRequestAndResponse({
+            cookieValues: {},
+            body: { passengerType: GROUP_REUSE_PASSENGER_TYPE, reuseGroup: '' },
+            uuid: {},
+            mockWriteHeadFn: writeHeadMock,
+            session: {
+                [PASSENGER_TYPE_ATTRIBUTE]: { passengerType: 'group' },
+                [SAVED_PASSENGER_GROUPS]: [{}],
+            },
+        });
+
+        await passengerType(req, res);
+
+        expect(updateSessionAttributeSpy).toBeCalledWith(req, PASSENGER_TYPE_ATTRIBUTE, {
+            errors: [{ errorMessage: 'Please select a group to reuse', id: 'group-reuse' }],
+        });
+        expect(writeHeadMock).toBeCalledWith(302, {
+            Location: '/passengerType',
         });
     });
 

--- a/tests/pages/api/passengerType.test.ts
+++ b/tests/pages/api/passengerType.test.ts
@@ -2,7 +2,7 @@ import { GROUP_PASSENGER_TYPE, GROUP_REUSE_PASSENGER_TYPE } from '../../../src/c
 import {
     GROUP_PASSENGER_INFO_ATTRIBUTE,
     PASSENGER_TYPE_ATTRIBUTE,
-    SAVED_PASSENGER_GROUPS,
+    SAVED_PASSENGER_GROUPS_ATTRIBUTE,
 } from '../../../src/constants/attributes';
 import * as aurora from '../../../src/data/auroradb';
 import passengerType from '../../../src/pages/api/passengerType';
@@ -91,7 +91,7 @@ describe('passengerType', () => {
             mockWriteHeadFn: writeHeadMock,
             session: {
                 [PASSENGER_TYPE_ATTRIBUTE]: { passengerType: 'group' },
-                [SAVED_PASSENGER_GROUPS]: [
+                [SAVED_PASSENGER_GROUPS_ATTRIBUTE]: [
                     { name: 'Hello Name', companions: [{ passengerType: 'child' }] },
                     { name: 'Hi Name', companions: [{ passengerType: 'adult' }] },
                 ],
@@ -122,14 +122,14 @@ describe('passengerType', () => {
             mockWriteHeadFn: writeHeadMock,
             session: {
                 [PASSENGER_TYPE_ATTRIBUTE]: { passengerType: 'group' },
-                [SAVED_PASSENGER_GROUPS]: [{}],
+                [SAVED_PASSENGER_GROUPS_ATTRIBUTE]: [{}],
             },
         });
 
         await passengerType(req, res);
 
         expect(updateSessionAttributeSpy).toBeCalledWith(req, PASSENGER_TYPE_ATTRIBUTE, {
-            errors: [{ errorMessage: 'Please select a group to reuse', id: 'group-reuse' }],
+            errors: [{ errorMessage: 'Select a group to reuse', id: `passenger-type-${GROUP_PASSENGER_TYPE}` }],
         });
         expect(writeHeadMock).toBeCalledWith(302, {
             Location: '/passengerType',

--- a/tests/pages/passengerType.test.tsx
+++ b/tests/pages/passengerType.test.tsx
@@ -5,7 +5,7 @@ import PassengerType from '../../src/pages/passengerType';
 describe('pages', () => {
     describe('operator', () => {
         it('should render correctly', () => {
-            const tree = shallow(<PassengerType errors={[]} csrfToken="" />);
+            const tree = shallow(<PassengerType errors={[]} csrfToken="" savedGroups={[]} />);
             expect(tree).toMatchSnapshot();
         });
     });


### PR DESCRIPTION
# Description

-   Reuse saved groups on the passenger types screen

# Testing instructions

-   Go through the single ticket journey, selecting to define a new group
-   Set all the group options and choose to name your new group when given the chance
-   Continue until you end up on the time restrictions page
-   Go back and start a new journey
-   This time select to reuse a saved group
-   Check you are taken direct to the time restrictions page
-   Complete the journey and check that the previous selected group configuration is used

# Type of change

-   [X] feat - A new feature
-   [ ] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [X] Able to run pr locally
-   [X] Followed acceptance criteria
-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [X] I have made corresponding changes to the documentation if applicable
-   [X] I have added tests that prove my fix is effective or that my feature works
